### PR TITLE
Fix heading layout on small screens

### DIFF
--- a/_sass/cds/_base.scss
+++ b/_sass/cds/_base.scss
@@ -104,7 +104,7 @@ h1, .h1 {
     	line-height : 1.2em;
 
         @include mobile_only {
-          margin: 1.5rem 1.5rem;
+          padding: 1.5rem 1.5rem;
         }
 
         @include tablet {


### PR DESCRIPTION
On small screens the heading (`h1, .h1`) displays better with `padding` instead of `margin` so that the box model does not extend to the right of the viewport. At the moment, some text (on the home page) is truncated on the right side of the viewport on small screens.

### Steps to reproduce

1. Open `digital.canada.ca` in Chrome
2. Open dev tools
3. Toggle device toolbar (cmd + shift + m) (macOS)
4. Set to a small screen size (anything below tablet size)