### PR TITLE
Fix typo on work with us

### DIFF
--- a/_pages/en/work-with-us.html
+++ b/_pages/en/work-with-us.html
@@ -552,7 +552,7 @@ trans_url: '/travaillez-avec-nous/'
 									</div>
 
 									<div class="form-group">
-										<label for="body" class="col-sm-3 control-label">Why do you want<br>to work with us?<br>(150 words)</label>
+										<label for="body" class="col-sm-3 control-label">Why you want<br>to work with us<br>(150 words)</label>
 										<div class="col-sm-9">
 											<textarea class="form-control" id="body" rows="10" required="required"></textarea>
 										</div>

--- a/_pages/en/work-with-us.html
+++ b/_pages/en/work-with-us.html
@@ -552,7 +552,7 @@ trans_url: '/travaillez-avec-nous/'
 									</div>
 
 									<div class="form-group">
-										<label for="body" class="col-sm-3 control-label">Why you want<br>to work with us?<br>(150 words)</label>
+										<label for="body" class="col-sm-3 control-label">Why do you want<br>to work with us?<br>(150 words)</label>
 										<div class="col-sm-9">
 											<textarea class="form-control" id="body" rows="10" required="required"></textarea>
 										</div>


### PR DESCRIPTION
Super tiny thing: “Why you want to work with us?” -> “Why do you want to work with us?”

Alternatively, the fix might be to drop the question mark (the French version lacks the question mark).