### PR TITLE
Print friendly fixes

### DIFF
--- a/_includes/cds/disqus-embed.html
+++ b/_includes/cds/disqus-embed.html
@@ -1,4 +1,4 @@
-<div id="disqus_thread" style="margin-top: 0.8em"></div>
+<div id="disqus_thread" style="margin-top: 0.8em" class="hidden-print"></div>
 <script>
 
 /**

--- a/_pages/en/engagement-report/beginning-the-conversation-full.html
+++ b/_pages/en/engagement-report/beginning-the-conversation-full.html
@@ -22,7 +22,7 @@ trans_url: '/commencement-de-la-conversation/rapport-complet'
     <!--
         Page Navigation
     -->
-    <div id="themenav">
+    <div id="themenav" class="hidden-print">
         <ul class="nav scroll dragscroll secondary" data-spy="affix" data-offset-top="640">
             <li class="hidden-xs">
                 <a class="nav-link section--engagement" href="#engagement" data-target="#engagement">Engagement</a>
@@ -51,10 +51,10 @@ trans_url: '/commencement-de-la-conversation/rapport-complet'
         A Case for Digital Government Section
     -->
     <div class="engagement-report-section" style="margin-top: 1.5em;">
-        <div class="pull-left">
+        <div class="pull-left hidden-print">
             <a href="/beginning-the-conversation" class="btn btn-link"><span class="hidden-xs">Back to</span> Highlights</a>
         </div>
-        <div class="pull-right">
+        <div class="pull-right hidden-print">
             <a href="#comments" class="btn btn-link">Comments</a>
         </div>
         <div class="clearfix"></div>
@@ -383,12 +383,12 @@ trans_url: '/commencement-de-la-conversation/rapport-complet'
         <p>The thoughtfulness, time, and ideas that were contributed to the discussion by all stakeholders are greatly appreciated. The contributions of provincial and community partners who helped facilitate and host meetings across Canada were also very much appreciated. This process is the beginning of an ongoing dialogue and collaboration that will allow us to continually learn from each other&rsquo;s efforts to build better digital services for all Canadians across the country.</p>
     </div>
     <!-- Disqus comments -->
-    <div class="engagement-report-section">
+    <div class="engagement-report-section hidden-print">
         <div class="pull-right">
             <a href="#privacy-notice-modal" aria-controls="privacy-notice-modal" class="overlay-lnk btn btn-link wb-lbx" style="margin-top: -0.2em;">Privacy Notice</a>
             <a href="{{ site.data.trans[page.lang].trans-base-url }}{{ page.trans_url }}#commentaires" lang="{{ site.data.trans[page.lang].trans-abbr-switch }}" class="btn btn-link" style="margin-top: -0.2em;">Fran&ccedil;ais</a>
         </div>
-        <h3 id="comments" style="margin-bottom: 0.5em">
+        <h3 id="comments" style="margin-bottom: 0.5em" class="hidden-print">
             Your Comments
         </h3> 
 

--- a/_pages/en/engagement-report/beginning-the-conversation-full.html
+++ b/_pages/en/engagement-report/beginning-the-conversation-full.html
@@ -13,10 +13,10 @@ trans_url: '/commencement-de-la-conversation/rapport-complet'
     -->
     <div id="top" class="heading-container heading-container-large cover">
         <h1 class="padded-multiline title">
-            <span>Beginning the&nbsp;<br/>&nbsp;Conversation&hellip;</span>
+            <span class="pad">Beginning the<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"> </span>Conversation&hellip;</span>
         </h1>
         <p class="padded-multiline subtitle">
-            <span>A Made-in-Canada Approach&nbsp;<br/>&nbsp;to Digital Government</span>
+            <span class="pad">A Made-in-Canada Approach<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"> </span>to Digital Government</span>
         </p>
     </div>
     <!--
@@ -97,7 +97,7 @@ trans_url: '/commencement-de-la-conversation/rapport-complet'
         <div class="heading-container section--engagement">
             <a href="#top" class="toplink"><span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> <span class="toplinktext">Top</span></a>
             <h2 class="padded-multiline">
-        <span>Starting a Conversation&nbsp;<br/>&nbsp;on a Made-in-Canada&nbsp;<br/>&nbsp;Approach</span>
+        <span class="pad">Starting a Conversation<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"><br/> </span>on a Made-in-Canada<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"> </span>Approach</span>
     </h2>
         </div>
     </div>
@@ -134,7 +134,7 @@ trans_url: '/commencement-de-la-conversation/rapport-complet'
         <div class="heading-container section--organizing">
             <a href="#top" class="toplink"><span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> <span class="toplinktext">Top</span></a>
             <h2 class="padded-multiline">
-        <span>Organizing&nbsp;<br/>&nbsp;to Deliver Digital</span>
+        <span class="pad">Organizing<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"> </span>to Deliver Digital</span>
     </h2>
         </div>
     </div>
@@ -188,7 +188,7 @@ trans_url: '/commencement-de-la-conversation/rapport-complet'
         <div class="heading-container section--talent">
             <a href="#top" class="toplink"><span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> <span class="toplinktext">Top</span></a>
             <h2 class="padded-multiline">
-        <span>Digital Talent</span>
+        <span class="pad">Digital Talent</span>
     </h2>
         </div>
     </div>
@@ -256,7 +256,7 @@ trans_url: '/commencement-de-la-conversation/rapport-complet'
         <div class="heading-container section--design">
             <a href="#top" class="toplink"><span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> <span class="toplinktext">Top</span></a>
             <h2 class="padded-multiline">
-        <span>Digital Service Design&nbsp;<br/>&nbsp;and Delivery</span>
+        <span class="pad">Digital Service Design<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"> </span>and Delivery</span>
     </h2>
         </div>
     </div>
@@ -309,7 +309,7 @@ trans_url: '/commencement-de-la-conversation/rapport-complet'
         <div class="heading-container section--foundations">
             <a href="#top" class="toplink"><span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> <span class="toplinktext">Top</span></a>
             <h2 class="padded-multiline">
-        <span>Putting in Place the&nbsp;<br/>&nbsp;Right Foundations</span>
+        <span class="pad">Putting in Place the<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"> </span>Right Foundations</span>
     </h2>
         </div>
     </div>
@@ -372,7 +372,7 @@ trans_url: '/commencement-de-la-conversation/rapport-complet'
         <div class="heading-container section--yourthoughts">
             <a href="#top" class="toplink"><span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> <span class="toplinktext">Top</span></a>
             <h2 class="padded-multiline">
-        <span>Continuing the&nbsp;<br/>&nbsp;Conversation</span>
+        <span class="pad">Continuing the<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"> </span>Conversation</span>
     </h2>
         </div>
     </div>

--- a/_pages/en/engagement-report/beginning-the-conversation-summary.html
+++ b/_pages/en/engagement-report/beginning-the-conversation-summary.html
@@ -24,28 +24,28 @@ trans_url: '/commencement-de-la-conversation'
         <div class="col-sm-6 col-lg-3">
             <a href="/beginning-the-conversation/full-report#organizing" class="heading-container section--organizing mini-heading-container">
                 <span class="padded-multiline">
-                    <span>Organizing to&nbsp;<br/>&nbsp;Deliver Digital</span>
+                    <span class="pad">Organizing to&nbsp;<br/>&nbsp;Deliver Digital</span>
                 </span>
             </a>
         </div>
         <div class="col-sm-6 col-lg-3">
             <a href="/beginning-the-conversation/full-report#talent" class="heading-container section--talent mini-heading-container">
                 <span class="padded-multiline">
-                    <span>Digital Talent</span>
+                    <span class="pad">Digital Talent</span>
                 </span>
             </a>
         </div>
         <div class="col-sm-6 col-lg-3">
             <a href="/beginning-the-conversation/full-report#design" class="heading-container section--design mini-heading-container">
                 <span class="padded-multiline">
-                    <span>Digital Service Design&nbsp;<br/>&nbsp;and Delivery</span>
+                    <span class="pad">Digital Service Design&nbsp;<br/>&nbsp;and Delivery</span>
                 </span>
             </a>
         </div>
         <div class="col-sm-6 col-lg-3">
             <a href="/beginning-the-conversation/full-report#foundations" class="heading-container section--foundations mini-heading-container">
                 <span class="padded-multiline">
-                    <span>Putting in Place the&nbsp;<br/>&nbsp;Right Foundations</span>
+                    <span class="pad">Putting in Place the&nbsp;<br/>&nbsp;Right Foundations</span>
                 </span>
             </a>
         </div>

--- a/_pages/fr/engagement-report/commencement-de-la-conversation-complet.html
+++ b/_pages/fr/engagement-report/commencement-de-la-conversation-complet.html
@@ -22,7 +22,7 @@ trans_url: '/beginning-the-conversation/full-report'
     <!--
         Page Navigation
     -->
-    <div id="themenav">
+    <div id="themenav" class="hidden-print">
         <ul class="nav scroll dragscroll secondary" data-spy="affix" data-offset-top="640">
             <li class="hidden-xs">
                 <a class="nav-link section--engagement" href="#mobilisation" data-target="#mobilisation">Mobilisation</a>
@@ -51,10 +51,10 @@ trans_url: '/beginning-the-conversation/full-report'
         A Case for Digital Government Section
     -->
     <div class="engagement-report-section" style="margin-top: 1.5em;">
-        <div class="pull-left">
+        <div class="pull-left hidden-print">
             <a href="/commencement-de-la-conversation" class="btn btn-link">Retour aux faits saillants</a>
         </div>
-        <div class="pull-right">
+        <div class="pull-right hidden-print">
             <a href="#commentaires" class="btn btn-link">Commentaires</a>
         </div>
         <div class="clearfix"></div>
@@ -384,12 +384,12 @@ trans_url: '/beginning-the-conversation/full-report'
         <p>&nbsp;</p>
     </div>
     <!-- Disqus comments -->
-    <div class="engagement-report-section">
+    <div class="engagement-report-section hidden-print">
         <div class="pull-right">
             <a href="#privacy-notice-modal" aria-controls="privacy-notice-modal" class="overlay-lnk btn btn-link wb-lbx" role="button" style="margin-top: -0.2em;" aria-label="Énoncé de confidentialité">Confidentialité</a>
             <a href="{{ site.data.trans[page.lang].trans-base-url }}{{ page.trans_url }}#comments" lang="{{ site.data.trans[page.lang].trans-abbr-switch }}" class="btn btn-link" style="margin-top: -0.2em;">English</a>
         </div>
-        <h3 id="commentaires" style="margin-bottom: 0.5em">
+        <h3 id="commentaires" style="margin-bottom: 0.5em" class="hidden-print">
             Vos commentaires
         </h3>
         

--- a/_pages/fr/engagement-report/commencement-de-la-conversation-complet.html
+++ b/_pages/fr/engagement-report/commencement-de-la-conversation-complet.html
@@ -13,10 +13,10 @@ trans_url: '/beginning-the-conversation/full-report'
     -->
     <div id="haut" class="heading-container heading-container-large cover">
         <h1 class="padded-multiline title">
-            <span>Le commencement de&nbsp;<br/>&nbsp;la conversation&hellip;</span>
+            <span class="pad">Le commencement de<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"> </span>la conversation&hellip;</span>
         </h1>
         <p class="padded-multiline subtitle">
-            <span>Une approche canadienne&nbsp;<br/>&nbsp;en matière de gouvernement&nbsp;<br/>&nbsp;numérique</span>
+            <span class="pad">Une approche canadienne<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"> </span>en matière de<span class="visible-print-inline"><br/></span> gouvernement<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"> </span>numérique</span>
         </p>
     </div>
     <!--
@@ -97,7 +97,7 @@ trans_url: '/beginning-the-conversation/full-report'
         <div class="heading-container section--engagement">
             <a href="#haut" class="toplink"><span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> <span class="toplinktext">Haut</span></a>
             <h2 class="padded-multiline">
-                <span>Commencer une&nbsp;<br/>&nbsp;conversation sur une&nbsp;<br/>&nbsp;approche canadienne</span>
+                <span class="pad">Commencer une<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"> </span>conversation<span class="visible-print-inline"><br/></span> sur une<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"> </span>approche canadienne</span>
             </h2>
         </div>
     </div>
@@ -134,7 +134,7 @@ trans_url: '/beginning-the-conversation/full-report'
         <div class="heading-container section--organizing">
             <a href="#haut" class="toplink"><span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> <span class="toplinktext">Haut</span></a>
             <h2 class="padded-multiline">
-                <span>S’organiser pour&nbsp;<br/>&nbsp;offrir le numérique</span>
+                <span class="pad">S’organiser pour<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"> </span>offrir le numérique</span>
             </h2>
         </div>
     </div>
@@ -188,7 +188,7 @@ trans_url: '/beginning-the-conversation/full-report'
         <div class="heading-container section--talent">
             <a href="#haut" class="toplink"><span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> <span class="toplinktext">Haut</span></a>
             <h2 class="padded-multiline">
-                <span>Talent pour le numérique</span>
+                <span class="pad">Talent pour le numérique</span>
             </h2>
         </div>
     </div>
@@ -256,7 +256,7 @@ trans_url: '/beginning-the-conversation/full-report'
         <div class="heading-container section--design">
             <a href="#haut" class="toplink"><span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> <span class="toplinktext">Haut</span></a>
             <h2 class="padded-multiline">
-                <span>Conception et prestation&nbsp;<br/>&nbsp;de services numériques</span>
+                <span class="pad">Conception et prestation<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"><br/> </span>de services numériques</span>
             </h2>
         </div>
     </div>
@@ -309,7 +309,7 @@ trans_url: '/beginning-the-conversation/full-report'
         <div class="heading-container section--foundations">
             <a href="#haut" class="toplink"><span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> <span class="toplinktext">Haut</span></a>
             <h2 class="padded-multiline">
-                <span>Établir les bonnes assises</span>
+                <span class="pad">Établir les bonnes assises</span>
             </h2>
         </div>
     </div>
@@ -372,7 +372,7 @@ trans_url: '/beginning-the-conversation/full-report'
         <div class="heading-container section--yourthoughts">
             <a href="#haut" class="toplink"><span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> <span class="toplinktext">Haut</span></a>
             <h2 class="padded-multiline">
-                <span>Poursuivre la&nbsp;<br/>&nbsp;conversation</span>
+                <span class="pad">Poursuivre la<span class="hidden-print">&nbsp;<br/>&nbsp;</span><span class="visible-print-inline"> </span>conversation</span>
             </h2>
         </div>
     </div>

--- a/_pages/fr/engagement-report/commencement-de-la-conversation-sommaire.html
+++ b/_pages/fr/engagement-report/commencement-de-la-conversation-sommaire.html
@@ -24,28 +24,28 @@ trans_url: '/beginning-the-conversation'
         <div class="col-sm-6 col-lg-3">
             <a href="/commencement-de-la-conversation/rapport-complet#organiser" class="heading-container section--organizing mini-heading-container">
                 <span class="padded-multiline">
-                    <span>S’organiser pour&nbsp;<br/>&nbsp;offrir le numérique</span>
+                    <span class="pad">S’organiser pour&nbsp;<br/>&nbsp;offrir le numérique</span>
                 </span>
             </a>
         </div>
         <div class="col-sm-6 col-lg-3">
             <a href="/commencement-de-la-conversation/rapport-complet#talent" class="heading-container section--talent mini-heading-container">
                 <span class="padded-multiline">
-                    <span>Talent pour le&nbsp;<br/>&nbsp;numérique</span>
+                    <span class="pad">Talent pour le&nbsp;<br/>&nbsp;numérique</span>
                 </span>
             </a>
         </div>
         <div class="col-sm-6 col-lg-3">
             <a href="/commencement-de-la-conversation/rapport-complet#conception" class="heading-container section--design mini-heading-container">
                 <span class="padded-multiline">
-                    <span>Conception et&nbsp;<br/>&nbsp;prestation de&nbsp;<br/>&nbsp;services numériques</span>
+                    <span class="pad">Conception et&nbsp;<br/>&nbsp;prestation de&nbsp;<br/>&nbsp;services numériques</span>
                 </span>
             </a>
         </div>
         <div class="col-sm-6 col-lg-3">
             <a href="/commencement-de-la-conversation/rapport-complet#assises" class="heading-container section--foundations mini-heading-container">
                 <span class="padded-multiline">
-                    <span>Établir les bonnes assises</span>
+                    <span class="pad">Établir les bonnes assises</span>
                 </span>
             </a>
         </div>

--- a/_sass/engagement/_headers.scss
+++ b/_sass/engagement/_headers.scss
@@ -55,14 +55,14 @@
             padding-bottom: 50px;
         }
         h1 { 
-            &.title span {
+            &.title span.pad {
                 @media screen and (max-width: 650px) {
                     padding: 0.6rem !important;
                 }
             }
         }
 
-        .subtitle span {
+        .subtitle span.pad {
             @media screen and (max-width: 650px) {
                 padding: 0.5rem !important;
             }
@@ -94,7 +94,7 @@
 
         //@media screen and (min-width: 992px) { bottom: 40px; line-height: 1.65; }
 
-        span {
+        span.pad {
             background-color     : #3a3a3a;
             box-decoration-break : clone;
             color                : #fff;
@@ -112,7 +112,7 @@
 
             @media screen and (min-width: 500px) { font-size: 38px; }
             @media screen and (min-width: 650px) { font-size: 46px; }
-            span { 
+            span.pad { 
                 padding  : 0.7em; 
 
                 @media screen and (min-width: 500px) { padding: 0.9rem }
@@ -132,7 +132,7 @@
             @media screen and (min-width: 500px) { font-size: 30px; }
             @media screen and (min-width: 650px) { font-size: 36px; }
 
-            span { 
+            span.pad { 
                 padding: 0.7rem; 
 
                 @media screen and (min-width: 500px) { padding: 0.9rem; }
@@ -163,11 +163,11 @@
         margin-top: 0;
         margin-bottom: 0;
 
-        .padded-multiline span, .toplink { 
+        .padded-multiline span.pad, .toplink { 
             background-color: $primary-color; //rgba($primary-color, 0.9); 
         }
         
-        .padded-multiline span {
+        .padded-multiline span.pad {
             background-color: $primary-color; //rgba($primary-color, 0.9); 
             margin-bottom: 1rem;
         }
@@ -176,7 +176,7 @@
     &.section--engagement {
         @include image-header("img/v2/pei-startupzone-v2a.jpg", $engagement-color);
 
-        .padded-multiline span, .toplink { 
+        .padded-multiline span.pad, .toplink { 
             background-color: $engagement-color; //rgba($engagement-color, 0.9); 
         }
     }
@@ -184,7 +184,7 @@
     &.section--organizing {
          @include image-header("img/v2/calgary-v3.jpg", $organizing-color);
 
-        .padded-multiline span, .toplink { 
+        .padded-multiline span.pad, .toplink { 
             background-color: $organizing-color; //rgba($organizing-color, 0.9); 
         }
     }
@@ -192,7 +192,7 @@
     &.section--talent {
          @include image-header("img/v2/hub-ottawa-v2.jpg", $talent-color);
 
-        .padded-multiline span, .toplink { 
+        .padded-multiline span.pad, .toplink { 
             background-color: $talent-color; //rgba($talent-color, 0.9); 
         }
     }
@@ -200,7 +200,7 @@
     &.section--design {
          @include image-header("img/v2/vancouver-v2a.jpg", $design-color);
 
-        .padded-multiline span, .toplink { 
+        .padded-multiline span.pad, .toplink { 
             background-color: $design-color; //rgba($design-color, 0.9); 
         }
     }
@@ -208,7 +208,7 @@
     &.section--foundations {
          @include image-header("img/v2/construction.jpg", $foundations-color);
 
-        .padded-multiline span, .toplink { 
+        .padded-multiline span.pad, .toplink { 
             background-color: $foundations-color; //rgba($foundations-color, 0.9); 
         }
     }
@@ -216,7 +216,7 @@
     &.section--yourthoughts {
          @include image-header("img/v2/ottawa-v2.jpg", $yourthoughts-color);
 
-        .padded-multiline span, .toplink { 
+        .padded-multiline span.pad, .toplink { 
             background-color: $yourthoughts-color; //rgba($yourthoughts-color, 0.9); 
         }
     }

--- a/_sass/engagement/_print.scss
+++ b/_sass/engagement/_print.scss
@@ -70,4 +70,32 @@
     .table-bordered td {
         border: 1px solid #ddd !important;
     }
+
+    /* Additional print fixes */
+
+    body {
+        /*padding: 0 5em;*/
+    }
+
+    .engagement-report-section {
+        margin: 0 5em;
+
+        li + li,
+        li ul:first-child  { margin-top: 0.75em; }
+    }
+
+    a.toplink {
+        display:none!important;
+    }
+
+    .comment-panel {
+        border-top: 3px solid #1d344b;
+        border-bottom: 3px solid #1d344b;
+        margin: 2em;
+        padding: 1em 4em;
+    }
+
+    .heading-container {
+        margin: 2em 1em;
+    }
 }

--- a/_sass/engagement/_print.scss
+++ b/_sass/engagement/_print.scss
@@ -24,11 +24,18 @@
     a[href^="javascript:"]:after {
         content: "";
     }
-    pre,
-    blockquote {
+    pre {
         border: 1px solid #999;
         page-break-inside: avoid;
     }
+
+    blockquote {
+        page-break-inside: avoid;
+        margin-left: 2em;
+        border: none;
+        font-size: 18px;
+    }
+
     thead {
         display: table-header-group;
     }
@@ -75,13 +82,38 @@
 
     body {
         /*padding: 0 5em;*/
+        font-size: 18px;
+        line-height: 1.5;
+    }
+
+    h2 {
+        font-size: 32px;
+    }
+
+    h3 {
+        font-size: 26px;
+    }
+
+    p {
+        margin: 0 0 1.1em;
+    }
+
+    ul {
+        margin: 0 0 1.6em;
+    }
+
+    p em.caption {
+        margin: 0.3em 0;
+        display: block;
     }
 
     .engagement-report-section {
-        margin: 0 5em;
+        margin: 0 4em;
 
         li + li,
-        li ul:first-child  { margin-top: 0.75em; }
+        li ul:first-child  { margin-top: 1.1em; }
+
+
     }
 
     a.toplink {
@@ -89,13 +121,107 @@
     }
 
     .comment-panel {
-        border-top: 3px solid #1d344b;
-        border-bottom: 3px solid #1d344b;
-        margin: 2em;
-        padding: 1em 4em;
+
+        page-break-inside: avoid;
+
+        border: 5px solid #1d344b;
+        margin: 1.8em 0em;
+        padding: 1.8em 2.8em;
+
+        p:last-child {
+            margin: 0;
+        }
+
+        background: transparent;
+
+        &.section--intro {
+            border-color: #1d344b;
+            background: transparent !important;
+        }
+        &.section--engagement {
+            border-color: $engagement-color;
+            background: transparent !important;
+        }
+        &.section--organizing {
+            border-color: $organizing-color;
+            background: transparent !important;
+        }
+        &.section--talent {
+            border-color: $talent-color;
+            background: transparent !important;
+        }
+        &.section--design {
+            border-color: $design-color;
+            background: transparent !important;
+        }
+        &.section--foundations {
+            border-color: $foundations-color;
+            background: transparent !important;
+        }
+        &.section--your-thoughts {
+            border-color: $yourthoughts-color;
+            background: transparent !important;
+        }
     }
 
     .heading-container {
+
+        page-break-after: avoid;
+
         margin: 2em 1em;
+
+        .title {
+            font-size: 40px;
+        }
+
+        .subtitle {
+            font-size: 30px;
+        }
+
+
+        h2 {
+            font-size: 36px;
+
+            border-bottom: 4px solid #1d344b;
+
+            /* Previous margin-bottom was 11.5px */
+            margin-bottom: 9px;
+            padding-bottom: 7px;
+
+        }
+
+        /* H2 border colours */
+        &.section--engagement {
+            h2 {
+                border-color: $engagement-color;
+            }
+        }
+        &.section--organizing {
+            h2 {
+                border-color: $organizing-color;
+            }
+        }
+        &.section--talent {
+            h2 {
+                border-color: $talent-color;
+            }
+        }
+        &.section--design {
+            h2 {
+                border-color: $design-color;
+            }
+        }
+        &.section--foundations {
+            h2 {
+                border-color: $foundations-color;
+            }
+        }
+        &.section--your-thoughts {
+            h2 {
+                border-color: $yourthoughts-color;
+            } 
+        }
     }
+
+
 }


### PR DESCRIPTION
At long last - print-friendly updates for the [Engagement Report](https://digital.canada.ca/beginning-the-conversation/full-report/).

Previous print output:
![screen shot 2018-03-01 at 11 44 53](https://user-images.githubusercontent.com/263472/36859366-16b6ebb2-1d4c-11e8-9235-5064a7d259e6.png)

New print output:
![screen shot 2018-03-01 at 12 26 28](https://user-images.githubusercontent.com/263472/36859377-20414934-1d4c-11e8-862a-0b0a37c777db.png)

Includes fixes to headings, layout, theme colours, and overall font-size, line-height, and margins for text elements.