### PR TITLE
NRCan Fix + Team Update

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -26,7 +26,7 @@ exec:
     email: jason.white@tbs-sct.gc.ca
 
   - name: Lena Trudeau
-    title: 
+    title:
       en: Senior Advisor
       fr: Conseillère principale
     image-name: lena-trudeau.jpg
@@ -35,7 +35,7 @@ exec:
     email: Lena.Trudeau@tbs-sct.gc.ca
 
   - name: Pascale Elvas
-    title: 
+    title:
       en: Director
       fr: Directrice
     image-name: pascale-elvas.jpg
@@ -44,7 +44,7 @@ exec:
     email: Pascale.Elvas@tbs-sct.gc.ca
 
   - name: Wendy Luciani
-    title: 
+    title:
       en: Partnership Lead
       fr: Gestionnaire des partenariats
     image-name: wendy-luciani.jpg
@@ -86,19 +86,19 @@ team:
     twitter: dsamojlenko
     github: dsamojlenko
 
-  - name: Dave Toeg 
+  - name: Dave Toeg
     title:
       en: Senior Advisor | Partnerships
       fr: Conseiller principal aux partenariats
     image-name: dave-toeg.jpg
     twitter: davetoeg
     linkedin: davetoeg
-    email: dave.toeg@tbs-sct.gc.ca 
+    email: dave.toeg@tbs-sct.gc.ca
 
   - name: David Buckley
     title:
       en: Developer | Data Scientist
-      fr: Développeur | Scientifique des données 
+      fr: Développeur | Scientifique des données
     image-name: david-buckley.jpg
     linkedin: david-buckley-0aba5783
     github: buckley-w-david
@@ -154,7 +154,7 @@ team:
   - name: Jennifer Morin
     title:
       en: Operations | Staffing
-      fr: Opérations | Dotation 
+      fr: Opérations | Dotation
     image-name: jennifer-morin.jpg
     email: Jennifer.Morin@tbs-sct.gc.ca
 
@@ -204,7 +204,7 @@ team:
     github: mcman12
 
   - name: Meera Makim Cunningham
-    title: 
+    title:
       en: Operations | Staffing
       fr: Opérations | Dotation
     image-name: meera-cunningham.jpg
@@ -228,7 +228,7 @@ team:
 
   - name: Nick Makuch
     title:
-      en: Design | Multimedia 
+      en: Design | Multimedia
       fr: Design | Multimédia
     image-name: nick-makuch.jpg
     twitter: makuch_nick
@@ -243,7 +243,7 @@ team:
     email: Priyanka.Rahman@tbs-sct.gc.ca
 
   - name: Raluca Ene
-    title: 
+    title:
       en: Code For Canada Fellow | UX Designer
       fr: Associée de Code for Canada | Designer UX
     image-name: raluca-ene.jpg
@@ -252,7 +252,7 @@ team:
     linkedin: eneraluca
 
   - name: Sean Boots
-    title: 
+    title:
       en: Tech | Advice
       fr: Technologie | Conseil
     image-name: sean-boots.jpg
@@ -271,18 +271,9 @@ team:
   - name: Shelley Bagg
     title:
       en: Operations | Administration
-      fr: Opérations | Administration 
+      fr: Opérations | Administration
     image-name: shelley-bagg.jpg
     email: Shelley.Bagg@tbs-sct.gc.ca
-
-  - name: Stéphane Tourangeau
-    title:
-      en: Capacity building lead
-      fr: Responsable du renforcement de la capacité
-    image-name: stephane-tourangeau.jpg
-    twitter: stourang
-    linkedin: stephanetourangeau
-    email: stephane.tourangeau@tbs-sct.gc.ca
 
   - name: Stevie-Ray Talbot
     title:
@@ -292,10 +283,10 @@ team:
     twitter: StevieRayTalbot
     email: Steven.Talbot@tbs-sct.gc.ca
 
-  # - name: 
+  # - name:
   #   title:
   #     en:
-  #     fr: 
+  #     fr:
   #   image-name:
   #   twitter:
   #   linkedin:

--- a/_posts/en/2018-02-15-b-colocating-with-NRCan.md
+++ b/_posts/en/2018-02-15-b-colocating-with-NRCan.md
@@ -10,24 +10,24 @@ layout: cds/post
 trans_url: "/2018/02/15/b-travailler-dans-les-locaux-de-RNCan"
 ---
 
-We are building a public-facing application programming interface (API) for National Resources Canada to open up access to EnerGuide Home Energy Ratings data. We talk about the details of this partnership in our post [Conducting user research with NRCan to inform an API build - Part 1](/2018/02/15/a-conducting-user-research-with-NRCan/).
+We are building a public-facing application programming interface (API) for Natural Resources Canada to open up access to EnerGuide Home Energy Ratings data. We talk about the details of this partnership in our post [Conducting user research with NRCan to inform an API build - Part 1](/2018/02/15/a-conducting-user-research-with-NRCan/).
 
 As we recently switched to the “build phase”, we had a lot of questions about the source data. Even though we had been provided with a wide range of documentation, sample data, schema files, etc. by email, there was a lot of uncertainty on our side over how the existing systems worked together, and what some of the sample data meant.
 
 At this stage, **we didn’t know what we didn’t know, but we knew we needed to meet the people working with these systems day-to-day.** And since both parties to this partnership were in the National Capital Region, we asked NRCan if they would be willing to host us at their facility for a short time. NRCan graciously offered us the use of an office at their beautiful space. [Dave](https://www.linkedin.com/in/david-buckley-0aba5783/) and I immediately headed over for some heads-down time.
 
-It’s an interesting paradox in a world where all sorts of tools allow us to collaborate remotely. When possible, face-to-face communication and colocating is a great shortcut for establishing trust on both sides. It is not only helpful, it's irreplaceable. 
+It’s an interesting paradox in a world where all sorts of tools allow us to collaborate remotely. When possible, face-to-face communication and colocating is a great shortcut for establishing trust on both sides. It is not only helpful, it's irreplaceable.
 
 A half-hour conversation with the right person providing much-needed context would often provide essential clarity into the problem, spurring hours of follow-up work. The proximity was critical to accelerating our work and helping us get on the right track, and yet we didn’t need to take much of their time while there. So much so, that we must have seemed like odd intruders to our new NRCan roommates, working by ourselves most of the time. This would not be an unfair observation from their perspective.
 
-We’re back with our CDS team now, armed with additional information that gives us a higher probability of success. Also, critically, thanks to all the networking that we did on site, we are using those personal connections to facilitate communication over email and phones. 
+We’re back with our CDS team now, armed with additional information that gives us a higher probability of success. Also, critically, thanks to all the networking that we did on site, we are using those personal connections to facilitate communication over email and phones.
 
 ## Some lessons learned for future co-locating:
-Given the benefits of our co-locating experience, we would recommend the following: 
+Given the benefits of our co-locating experience, we would recommend the following:
 1. Try to plan co-locating ahead of time. Put it directly in the project plan from the beginning. Prepare all sides for what to expect as much as possible.
-2. Bring your own WiFi: Access to WiFi and network at other facilities is unlikely. 
+2. Bring your own WiFi: Access to WiFi and network at other facilities is unlikely.
 3. Arrange for any network accounts/logins ahead of time.
 4. Have a plan for standups/meetings with a distributed team.
-5. Have team conversations in public on [Slack](https://slack.com); it’s easy to feel isolated and disconnected from the team. 
+5. Have team conversations in public on [Slack](https://slack.com); it’s easy to feel isolated and disconnected from the team.
 
-As always, [we would love to hear](mailto:cds-snc@tbs-sct.gc.ca) your feedback on this specific partnership and on our work in general. 
+As always, [we would love to hear](mailto:cds-snc@tbs-sct.gc.ca) your feedback on this specific partnership and on our work in general.


### PR DESCRIPTION
This PR consists of:
- Changing "National Resources Canada" -> "Natural Resources Canada" on the Co-locating with NRCan pt.2 blog post
- Removing Stephane Tourangeau from the team page