### PR TITLE
Remove HTML tags from <title> in base layout

### DIFF
--- a/_layouts/cds/base.html
+++ b/_layouts/cds/base.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
             wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-    <title>{{ page.title }} - {{ site.data.trans[page.lang].canadian-digital-service }}</title>
+    <title>{{ page.title | strip_html }} - {{ site.data.trans[page.lang].canadian-digital-service }}</title>
     <meta content="width=device-width,initial-scale=1" name="viewport">
     <!-- Meta data -->
     <meta name="description" content="{{ page.description }}">


### PR DESCRIPTION
I noticed in [the latest blog post](https://digital.canada.ca/2018/03/26/automated-testing-blog/) that the `<strong>` tag in the post title was rendering to the browser title in plaintext. The `<title>` element [doesn’t support tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title), so I used the `strip_html` filter to take them out.

Before:

![screen shot 2018-03-27 at 10 21 21 am](https://user-images.githubusercontent.com/343884/37973507-aaef4818-31a8-11e8-80db-baa912f00135.png)

After:

![screen shot 2018-03-27 at 10 21 38 am](https://user-images.githubusercontent.com/343884/37973512-affbcd4a-31a8-11e8-8571-f00232214069.png)

The `<strong>` also appears in social media embeds, so it seems worth removing.