### PR TITLE
Remove 'escape' templating logic from post.title to avoid stripping html tags

### DIFF
--- a/index-fr.html
+++ b/index-fr.html
@@ -182,7 +182,7 @@ permalink: '/'
                             {% endcase %}
                             {{ post.date | date: "%Y" }}
                         </div>
-                        <h3>{{ post.title | escape }}</h3>
+                        <h3>{{ post.title }}</h3>
                     </div>
                 </a>
             </div>

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@ trans_url: '/'
                     <div class="image" style="background-image:url('/assets/img/cds/post-images/{{ post.image }}')"></div>
                     <div class="text">
                         <div class="date">{{ post.date | date: '%B %-d, %Y' }}</div>
-                        <h3>{{ post.title | escape }}</h3>
+                        <h3>{{ post.title }}</h3>
                     </div>
                 </a>
             </div>


### PR DESCRIPTION
Unclear if this was put in orginally for safety of dynamic parsing... If someone has write access to the repo, this is probably going to be the least of our concerns.

This commit is to fix the visibility of <strong>not</strong> on the main page in the 'more blog posts' auto generated tiles that @szinck1 reported on slack earlier.

