### PR TITLE
added github logic to exec section

### DIFF
--- a/_includes/cds/team-listing.html
+++ b/_includes/cds/team-listing.html
@@ -36,6 +36,13 @@
 									</a>
 								</span>
 							{% endif %}
+							{% if member.github != null %}
+								<span class="social-icons">
+									<a href="https://github.com/{{ member.github }}" aria-label="Link to {{ member.name }}'s GitHub profile">
+										<i class="fa fa-github-alt" aria-hidden="true"></i>
+									</a>
+								</span>
+							{% endif %}
 						</div>
 					</div>
 					


### PR DESCRIPTION
The exec section of the team page didn't have the logic to add GitHub links to people's profiles. Added so I can claim what little cred I have left in that department.