### PR TITLE
updated dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.4)
+    activesupport (5.2.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.5.2)
@@ -13,8 +13,8 @@ GEM
     concurrent-ruby (1.0.5)
     ethon (0.11.0)
       ffi (>= 1.3.0)
-    ffi (1.9.18)
-    font-awesome-sass (4.7.0)
+    ffi (1.9.23)
+    font-awesome-sass (5.0.9)
       sass (>= 3.2)
     forwardable-extended (2.6.0)
     html-proofer (3.8.0)
@@ -26,7 +26,7 @@ GEM
       parallel (~> 1.3)
       typhoeus (~> 1.3)
       yell (~> 2.0)
-    i18n (0.9.3)
+    i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     jekyll (3.4.3)
       addressable (~> 2.4)
@@ -39,9 +39,9 @@ GEM
       pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
-    jekyll-feed (0.9.2)
+    jekyll-feed (0.9.3)
       jekyll (~> 3.3)
-    jekyll-sass-converter (1.5.1)
+    jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-watch (1.5.1)
       listen (~> 3.0)
@@ -53,20 +53,20 @@ GEM
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
     mini_portile2 (2.3.0)
-    minitest (5.11.1)
-    nokogiri (1.8.1)
+    minitest (5.11.3)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
-    public_suffix (3.0.1)
-    rb-fsevent (0.10.2)
+    public_suffix (3.0.2)
+    rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rouge (1.11.1)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sass (3.5.5)
+    sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -74,7 +74,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.3.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     yell (2.0.7)
 
@@ -89,7 +89,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.4.1p111
+   ruby 2.5.0p0
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
addresses the security warning regarding nokogiri 1.8.1