### PR TITLE
Add forgotten team members

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -259,6 +259,23 @@ team:
     linkedin: liamdavidson
     email: Liam.Davidson@tbs-scit.gc.ca
 
+  - name: Lucas Cherkewski
+    title:
+      en: Policy | Advice
+      fr: Politique | Conseil
+    image-name: lucas-cherkewski.jpg
+    twitter: lchski
+    linkedin: lchski
+    github: lchski
+    email: Lucas.Cherkewski@tbs-sct.gc.ca
+
+  - name: Lyn Elliott
+    title:
+      en: Storyteller
+      fr: Conteuse
+    image-name: lyn-elliott.jpg
+    email: Lyn.Elliott@tbs-sct.gc.ca
+
   - name: Lynn Chalati
     title:
       en: Communications


### PR DESCRIPTION
We had joined the CDS team
To be on the site was our dream
Our photos were there
(We both have great hair)
But @liam-davidson had run out of steam [when adding us to the site]

I think this is everyone, might have missed some ;)