### PR TITLE
Fix for french translation, getting 404 not found error again

### DIFF
--- a/_posts/en/2018-06-14-lets-talk-user-experience.html
+++ b/_posts/en/2018-06-14-lets-talk-user-experience.html
@@ -7,7 +7,7 @@ image: blog-user-experience.jpg
 image-alt: Trois membres de l'équipe du SNC présentent un atelier avec du personnel de IRCC à Vancouver. Deux d'entre eux figurent dans l'image. Ils travaillent ensemble pour écrire des idées sur des notes auto-collantes et ils les placent dans un des quatre quadrants sur le mur.
 lang: en
 layout: cds/post
-trans_url: "/2018/06/14/parlons-de-l'expérience-utilisateur"
+trans_url: "/2018/06/14/parlons-de-l-expérience-utilisateur"
 ---
 
 <img width="100%" alt="Pixel evolving into a person — There are five shapes, starting with a square (pixel) on the left-hand side, eventually morphing into a full human figure on the right-hand side." src="/assets/img/cds/post-images/ux-drawing.jpg">

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ trans_url: '/'
 <div class="container">
 	<section class="section homepage--intro page-intro--outer-container-padding">
 			<div class="row">
-				<div class="col-lg-10 col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12">
+				<div class="col-sm-10 col-sm-offset-1 col-xs-12">
 					<p class="lead"><a id="mission"></a>The Government of Canada must embrace new methods and tools to improve how it designs, builds, and delivers services.</p>
 					<p>The Canadian Digital Service (CDS) is bringing together the skills and expertise needed to accelerate this change.</p>
 				</div>


### PR DESCRIPTION
I think it was the difference between - and ' in l'experience (original was written as l-experience).