### PR TITLE
Added Lucas' changes to the menu nav

### DIFF
--- a/_includes/cds/site-menu.html
+++ b/_includes/cds/site-menu.html
@@ -17,7 +17,8 @@
 				<div class="mobile-lang">{% include cds/lang-switch.html %}</div>
                     <ul class="top-nav">
                         {% for menu in site.data.menu[page.lang] %}
-                        <li class="top-nav--link{% if menu[1].url == page.url %} active{% endif %}">
+                         {% assign active_state_comparison_url = menu[1].url | append: "/" %}
+					<li class="top-nav--link{% if active_state_comparison_url == page.url %} active{% endif %}">
                             <a href="{{ menu[1].url }}">{{ menu[1].name }}</a>
                         </li>
                         {% endfor %}


### PR DESCRIPTION
Lucas: "The Jekyll variable page.url returns page slugs with trailing slashes (e.g. /work-with-us/). Our site.data.menu array lists URLs without the trailing slashes (e.g. /work-with-us). When they were comparing, they never matched because of the slash mismatch.

I created a temporary variable inside the menu loop that adds the trailing slash, to enable comparison.

A more robust solution might be to add trailing slashes in the _data/menu.yml file, but that could have unintended consequences; figured this was good enough for this purpose."