### PR TITLE
Fixed scaling on font-size for links. 

### DIFF
--- a/_pages/en/blog.html
+++ b/_pages/en/blog.html
@@ -25,7 +25,7 @@ trans_url: '/blogue'
 			    	<div class="col-xs-12 col-sm-8">
 				    	<div class="text">
 				        	<div class="title"><a href="{{ post.url }}"><h2>{{ post.title }}</h2></a></div>
-				        	<div class="author">By: {{ post.author }}</div>
+				        	<div class="author">{{ post.author }}</div>
 						<div class="date">{{ post.date | date: '%B %-d, %Y' }}</div>
 				        	<div class="summary">{{ post.excerpt | strip_html | truncatewords:75 }}</div>
 				        	<div class="readmore"><a href="{{ post.url }}" aria-label="Continue reading {{ post.title }}">Read More</a></div>

--- a/_sass/cds/_base.scss
+++ b/_sass/cds/_base.scss
@@ -32,7 +32,18 @@ a {
 	color 			: $secondary-color;
 	font-weight 	: 500;
 	text-decoration : none;
-    font-size: 2.25rem;
+	
+	@include mobile-only{
+		font-size: 1.75rem;
+	}
+	
+	@include tablet{
+		font-size: 2rem;
+	}
+	
+	@include desktop{
+		font-size: 2.25rem;
+	}
 
 	&:visited { color: $secondary-color; }
 


### PR DESCRIPTION
Font-size for any <a> tag was staying the desktop size because it wasn't explicitly set to scale like the rest of the fonts. 
Also removed the "By" from the author name on blog page. It was already gone on French, so only did on English. 