### PR TITLE
Added Head of Talent page and related link to the Work With Us page

### DIFF
--- a/_pages/en/chief-of-staff.html
+++ b/_pages/en/chief-of-staff.html
@@ -1,6 +1,6 @@
 ---
 title: "Chief of Staff"
-description:
+description: "We’re looking for someone to support our CEO and senior management team. From streamlining activities in a high-volume office to coordinating the execution of strategic initiatives, you’ll ensure the priorities of the CEO stay on track and get done."
 image:
 lang: en
 layout: cds/page

--- a/_pages/en/head-of-engineering.html
+++ b/_pages/en/head-of-engineering.html
@@ -1,6 +1,6 @@
 ---
 title: "Head of Engineering"
-description: "Thank you for your interest. For further information on the Head of Engineering position at the Canadian Digital Service please contact us at CDSRecruitment.RecrutementSNC@tbs-sct.gc.ca."
+description: "We’re looking for someone to lead our engineering team. As the head of engineering, you’ll set the vision and tone, shape our technical direction and choices, assess our needs and recruit to fulfill them, and support the team’s learning and development."
 image:
 lang: en
 layout: cds/page

--- a/_pages/en/head-of-talent.html
+++ b/_pages/en/head-of-talent.html
@@ -1,0 +1,49 @@
+---
+title: "Head of Talent"
+description: "We’re looking for someone to lead our talent operations. In this role, you’ll set a clear, compelling vision for how to attract, develop, and retain top talent. You’ll lead our talent acquisition function with a specific focus on developing and driving sourcing and recruitment efforts."
+image:
+lang: en
+layout: cds/page
+permalink: /head-of-talent/
+trans_url: '/responsable-du-talent/'
+---
+<section class="section page--outer-container-padding">
+	<div class="row">
+		<div class="col-sm-10 col-sm-offset-1 col-xs-12">
+			<h2 class="section--title">We're Hiring</h2>
+			<p>The Canadian Digital Service (CDS) works with federal departments to make the services people depend on simple and easy-to-use. We’re a small but mighty team that is rethinking service design and delivery, engaging users every step of the way. By working in the open, and connecting partners with tools, talent, and training grounded in practice, we’re building capacity across the government for better service delivery. And we need you.</p>
+			<p>We’re looking for someone to lead our talent operations. In this role, you’ll set a clear, compelling vision for how to attract, develop, and retain top talent. You’ll lead our talent acquisition function with a specific focus on developing and driving sourcing and recruitment efforts. You’ll create strategies that enhance our ability to develop and retain a highly motivated, creative, diverse, and effective workforce —including compensation, culture, and development. This will include establishing talent pipelines and programs for key communities and institutions. You’ll solve policy and operational roadblocks while navigating the rules — and help us rewrite those rules when necessary to modernize how government attracts people with much needed skills to public service.</p>
+
+			<h3>What we’re looking for:</h3>
+
+			<ul>
+				<li>You enjoy building high-performing teams and have a proven record of hiring the right candidates for the right positions, particularly in design and tech-centric environments. You revisit regularly to evaluate progress and make adjustments.</li>
+				<li>You understand the complexities of recruiting and hiring in large organizations, but you can differentiate between true compliance requirements and practices that have built up over time.</li>
+				<li>You are excited about establishing modern talent practices and models that have the potential to scale across government and help drive much-needed increased mobility in and out of the Public Service. </li>
+				<li>You have a bias toward action and an appetite for challenging the status quo. You are passionate about making Canada a better place and strive to keep people focused on that outcome.</li>
+			</ul>
+			
+			<h3>An excellent candidate will be able to:</h3>
+			
+			<ul>
+				<li>Collaborate at all levels -- from leadership to front-line employees -- to build strong partnerships and drive a comprehensive human capital strategy.</li>
+				<li>Source, cultivate, recruit, interview, and hire diverse technical talent that reflects and represents the best of Canada.</li>
+				<li>Contribute to the entire talent lifecycle for the CDS “tour of duty” model, from hiring through onboarding, development and support, and offboarding, ensuring that CDSers have good experiences with government and that CDS alumni become champions for the organization and for the methods it is scaling across government.</li>
+				<li>Establish human capital programs and processes, and oversee forecasting activity for headcount across CDS.</li>
+				<li>Handle challenging conversations with candidates, team members, and leadership from across the businesses you support.</li>
+				<li>Learn from failure.</li>
+				<li>Model a culture of inclusivity and uphold principles of openness, integrity, and fairness.</li>
+				<li>Communicate in both official languages.</li>
+			</ul>
+			
+			<p>At CDS, we don’t just accept difference, we celebrate it. We proudly, passionately, and actively strive to make CDS more reflective and inclusive of the society that we serve. Our ability to deliver better public services — accessible, inclusive services — can only be realized if we can recognise and harness the most diverse range of thoughts, experiences, and skills. We work hard to create an environment where different perspectives and experiences are valued. We are committed to helping diverse talent thrive.</p>
+			
+			<p>CDS welcomes all applicants regardless of race, ethnicity, religion, sexual orientation, gender identity or expression, national origin, disability, age, veteran status, marital status, pregnancy or family commitments.</p>
+			
+			<h3>Interested?</h3>
+			
+			<p>Email us at <a href="mailto:CDSRecruitment.RecrutementSNC@tbs-sct.gc.ca">CDSRecruitment.RecrutementSNC@tbs-sct.gc.ca</a> with [Head of Talent] in the subject line. Tell us why you’re right for the job. We recognize that everyone brings different skills and experiences to the table, and that nobody “checks all the boxes.” Include a link to a CV, examples of your work, and/or whatever you think we should see to get to know you.
+			</p>
+		</div>
+	</div>
+</section>

--- a/_pages/en/work-with-us.html
+++ b/_pages/en/work-with-us.html
@@ -51,6 +51,7 @@ trans_url: '/travaillez-avec-nous/'
 						<ul>
 							<li><a href="/chief-of-staff">Chief of Staff</a></li>
 							<li><a href="/head-of-engineering">Head of Engineering</a></li>
+							<li><a href="/head-of-talent">Head of Talent</a></li>
 						</ul>
 					</div>
 				</div>

--- a/_pages/fr/chef-de-cabinet.html
+++ b/_pages/fr/chef-de-cabinet.html
@@ -1,6 +1,6 @@
 ---
 title: "Chef de cabinet"
-description:
+description: "Nous sommes à la recherche d’une personne pour soutenir notre dirigeant principal et notre équipe de la haute direction. De la simplification d’activités réalisées dans un bureau à volume élevé à la coordination de l’exécution d’initiatives stratégiques, vous veillerez à ce que les priorités du dirigeant principal restent sur la bonne voie et se concrétisent."
 image:
 lang: fr
 layout: cds/page

--- a/_pages/fr/chef-de-l-ingenierie.html
+++ b/_pages/fr/chef-de-l-ingenierie.html
@@ -1,6 +1,6 @@
 ---
 title: "Chef de l’ingénierie"
-description:
+description: "Nous sommes à la recherche d’une personne pour diriger notre équipe d’ingénierie. À ce titre, vous serez responsable d’établir la vision et le ton, de façonner notre orientation et nos choix techniques, d’évaluer nos besoins et de recruter du personnel pour répondre à ces besoins, ainsi que d’appuyer l’apprentissage et le perfectionnement de l’équipe."
 image:
 lang: fr
 layout: cds/page

--- a/_pages/fr/responsable-du-talent.html
+++ b/_pages/fr/responsable-du-talent.html
@@ -1,0 +1,48 @@
+---
+title: "Responsable du talent"
+description: "Nous recherchons une personne pour diriger nos opérations relatives au talent. Dans ce rôle, vous établirez une vision claire et inspirante de la manière d’attirer, de perfectionner et de conserver les principaux talents."
+image:
+lang: fr
+layout: cds/page
+permalink: /responsable-du-talent/
+trans_url: '/head-of-talent/'
+---
+<section class="section page--outer-container-padding">
+	<div class="row">
+		<div class="col-sm-10 col-sm-offset-1 col-xs-12">
+			<h2 class="section--title">Nous embauchons</h2>
+			<p>Le SNC collabore avec les ministères fédéraux pour s’assurer que les services dont les gens dépendent sont simples et faciles à utiliser. Nous sommes une petite équipe, mais efficace, qui repense la conception et la prestation des services et qui mobilise les utilisateurs à chaque étape. En travaillant ouvertement et en faisant connaître à nos partenaires les outils, les talents et les formations ancrées dans la pratique, nous renforçons la capacité de l’ensemble du gouvernement à améliorer la prestation des services. Et nous avons besoin de vous.</p>
+			<p>Nous recherchons une personne pour diriger nos opérations relatives au talent. Dans ce rôle, vous établirez une vision claire et inspirante de la manière d’attirer, de perfectionner et de conserver les principaux talents. Vous dirigerez notre fonction d’acquisition des talents avec un accent mis sur l’élaboration et le déploiement des efforts de sélection et de recrutement. Vous créerez des stratégies qui améliorent notre capacité à bâtir et à conserver un effectif très motivé, créatif, diversifié et efficace – qui comprendront la rémunération, la culture et le perfectionnement. Pour ce faire, vous établirez un bassin de talents et des programmes pour les communautés et les institutions clés. Vous réglerez les obstacles stratégiques et opérationnels tout en naviguant parmi les règles — et vous nous aiderez à réécrire ces règles, au besoin, afin de moderniser la manière dont le gouvernement attire les gens ayant des compétences dont la fonction publique a grand besoin.</p>
+
+			<h3>Ce que nous recherchons&nbsp;:</h3>
+
+			<ul>
+				<li>vous aimez mettre sur pied des équipes très performantes et vous avez une réputation fondée d’embaucher les bons candidats pour les bons postes, en particulier dans des environnements de conception et axés sur la technologie. Vous procédez régulièrement à un réexamen pour évaluer l’avancement et pour procéder à des ajustements;</li>
+				<li>vous comprenez les complexités du recrutement et de l’embauche dans de grandes organisations, mais vous êtes capable de faire la différence entre les réelles exigences de conformité et les pratiques établies au fil du temps;</li>
+				<li>vous êtes enthousiaste à l’idée d’établir des pratiques et des modèles de talent modernes, qui pourraient être utilisées à l’échelle du gouvernement, et d’aider à mener une augmentation nécessaire de la mobilité dans la fonction publique et vers l’extérieur de celle-ci;</li>
+				<li>vous avez un parti-pris pour l’action et une volonté de remettre en question le statu quo. Vous avez à cœur de faire du Canada un meilleur endroit et vous vous efforcez de garder les gens concentrés sur ce résultat.</li>
+			</ul>
+			
+			<h3>Un excellent candidat pourra faire ce qui suit&nbsp;: </h3>
+			
+			<ul>
+				<li>collaborer à tous les niveaux – de la direction aux employés de première ligne – afin d’établir des partenariats solides et de mener une stratégie globale de capital humain;</li>
+				<li>trouver, entretenir, recruter, faire passer un entretien et embaucher divers talents techniques qui reflètent et représentent le meilleur du Canada;</li>
+				<li>contribuer à l’ensemble du cycle de vie du talent pour le modèle de « tour de garde » du SNC, de l’embauche à l’intégration, au perfectionnement et au soutien et au départ, garantissant que le personnel du SNC a une bonne expérience avec le gouvernement et que les anciens du SNC deviennent des champions de l’organisation et des méthodes qu’il porte à l’échelle du gouvernement;</li>
+				<li>établir des programmes et des processus de capital humain et surveiller les activités de prévision du décompte du personnel pour l’ensemble du SNC;</li>
+				<li>s’occuper des conversations difficiles avec les candidats, les membres d’équipe et la direction de l’ensemble des affaires que vous soutenez;</li>
+				<li>tirer des leçons des échecs;</li>
+				<li>façonner une culture inclusive et maintenir les principes d’ouverture, d’intégrité et d’équité;</li>
+				<li>communiquer dans les deux langues officielles.</li>
+			</ul>
+			
+			<p>Au SNC, nous ne nous contentons pas d’accepter la différence, nous la célébrons. C’est avec fierté et passion que nous nous efforçons activement de rendre le SNC plus représentatif et plus inclusif de la société que nous servons. Notre capacité à offrir de meilleurs services publics, c’est-à-dire des services accessibles et inclusifs, ne peut être démontrée que si nous pouvons reconnaître et exploiter la gamme la plus diversifiée de réflexions, d’expériences et de compétences. Nous travaillons fort pour créer un environnement où les différentes perspectives et expériences sont valorisées. Nous sommes déterminés à contribuer à l’épanouissement de talents diversifiés.</p>
+			
+			<p>Le SNC prend en considération tous les candidats, peu importe leur race, leur origine ethnique, leur religion, leur orientation sexuelle, leur identité ou leur expression de genre, leur origine nationale, leur handicap, leur âge, leur statut d’ancien combattant, leur situation matrimoniale, leur grossesse ou leurs obligations familiales.</p>
+			
+			<h3>Vous êtes intéressé?</h3>
+			
+			<p>Envoyez-nous un courriel à <a href="mailto:CDSRecruitment.RecrutementSNC@tbs-sct.gc.ca">CDSRecruitment.RecrutementSNC@tbs-sct.gc.ca</a> [Responsable du talent] à la ligne d’objet. Dites-nous pourquoi vous êtes le candidat idéal pour le poste. Nous sommes conscients du fait que chacun apporte des compétences et des expériences différentes, et que personne n’est le « candidat parfait ». Ajoutez un lien vers votre curriculum vitæ, des échantillons de votre travail ou toute autre ressource que nous devrions consulter pour apprendre à vous connaître.</p>
+		</div>
+	</div>
+</section>

--- a/_pages/fr/travaillez-avec-nous.html
+++ b/_pages/fr/travaillez-avec-nous.html
@@ -51,6 +51,7 @@ trans_url: '/work-with-us/'
 						<ul>
 							<li><a href="/chef-de-cabinet">Chef de cabinet</a></li>
 							<li><a href="/chef-de-l-ingenierie">Chef de l’ingénierie</a></li>
+							<li><a href="/responsable-du-talent">Responsable du talent</a></li>
 						</ul>
 					</div>
 				</div>


### PR DESCRIPTION
Comms needed the Head of Talent job posting added. Made a page for this, and then created another link on the Work With Us page. 

Also added descriptions to the existing job postings (for SEO). 