### PR TITLE
Removed youtube video on home page & a few small changes.

### DIFF
--- a/_includes/cds/en/mailing-list.html
+++ b/_includes/cds/en/mailing-list.html
@@ -9,7 +9,7 @@
 
                 <div class="mc-field-group form-group">
                     <label for="mce-EMAIL">Email address </label>
-                    <input type="email" value="" name="EMAIL" class="required email form-control" id="mce-EMAIL" placeholder="Email address">
+                    <input type="email" value="" name="EMAIL" class="required email form-control" id="mce-EMAIL">
                 </div>
 
                 <div id="mce-responses" class="clear">

--- a/_includes/cds/fr/mailing-list.html
+++ b/_includes/cds/fr/mailing-list.html
@@ -9,7 +9,7 @@
 
                 <div class="mc-field-group form-group">
                     <label for="mce-EMAIL">Votre courriel </label>
-                    <input type="email" value="" name="EMAIL" class="required email form-control" id="mce-EMAIL" placeholder="Votre courriel">
+                    <input type="email" value="" name="EMAIL" class="required email form-control" id="mce-EMAIL">
                 </div>
 
                 <div id="mce-responses" class="clear">

--- a/_posts/en/2018-06-12-setting-users-up for-success-with-content-design.html
+++ b/_posts/en/2018-06-12-setting-users-up for-success-with-content-design.html
@@ -5,7 +5,7 @@ author: Zak Kain, Content Designer
 date: 2018-06-12 09:00:00 -0400
 image: blog-setting-up-users-for-success.jpg
 image-alt: Paper prototypes of an early version of the IRCC Reschedule a Citizenship Test service. Four pages are laid out on a table. They  include a web form, a calendar, a confirmation and checkboxes with appointment times.
-image-alt: Des prototypes en format papier d’une version précédente du service pour reporter un rendez-vous de citoyenneté. Quatre pages sont présentées sur une table. Elles montrent un formulaire en ligne, un calendrier, une confirmation et des cases pour choisir une heure de rendez-vous.
+description: "As you might have already read, CDS is working with Immigration, Refugees and Citizenship Canada (IRCC) to make the process of rescheduling a citizenship appointment as convenient and stress-free as possible for applicants, while empowering office staff."
 image-translation: 
 lang: en
 layout: cds/post

--- a/_posts/fr/2018-06-12-donner-aux-utilisateurs-les-moyens-de-réussir.html
+++ b/_posts/fr/2018-06-12-donner-aux-utilisateurs-les-moyens-de-réussir.html
@@ -1,11 +1,10 @@
 ---
 title: "Donner aux utilisateurs les moyens de réussir grâce à la conception de contenu"
-description:
 author: Zak Kain, concepteur de contenu
 date: 2018-06-12 09:00:00 -0400
 image: blog-setting-up-users-for-success.jpg
 image-alt: Des prototypes en format papier d’une version précédente du service pour reporter un rendez-vous de citoyenneté. Quatre pages sont présentées sur une table. Elles montrent un formulaire en ligne, un calendrier, une confirmation et des cases pour choisir une heure de rendez-vous.
-image-alt: Des prototypes en format papier d’une version précédente du service pour reporter un rendez-vous de citoyenneté. Quatre pages sont présentées sur une table. Elles montrent un formulaire en ligne, un calendrier, une confirmation et des cases pour choisir une heure de rendez-vous.
+description: "Vous avez peut-être déjà lu que le SNC travaille avec Immigration, Réfugiés et Citoyenneté Canada (IRCC) pour rendre le processus de report d’un rendez-vous d’examen de citoyenneté aussi pratique et facile que possible pour les demandeurs, tout en facilitant la vie du personnel administratif."
 image-translation: 
 lang: fr
 layout: cds/post

--- a/_posts/fr/2018-06-14-parlons-de-l’expérience-utilisateur.html
+++ b/_posts/fr/2018-06-14-parlons-de-l’expérience-utilisateur.html
@@ -1,6 +1,7 @@
 ---
 title: "Parlons de l’expérience <em>utilisateur</em>&nbsp;:&nbsp;S’éloigner des pixels, se tourner vers les gens"
 excerpt: "De nombreux organismes et ministères reconnaissent la nécessité d’inclure l’expérience utilisateur à leur processus. Mais à quel titre? Et comment? Cela se manifeste souvent simplement par l’embauche d’une personne qui, dans l’équipe, agit comme concepteur d’expérience utilisateur dédié. Bien qu’il s’agisse d’un bon début, cette pratique rate la cible."
+description: "De nombreux organismes et ministères reconnaissent la nécessité d’inclure l’expérience utilisateur à leur processus. Mais à quel titre? Et comment? Cela se manifeste souvent simplement par l’embauche d’une personne qui, dans l’équipe, agit comme concepteur d’expérience utilisateur dédié. Bien qu’il s’agisse d’un bon début, cette pratique rate la cible."
 author: Eman El-Fayomi, conceptrice principale
 date: 2018-06-14 09:00:00 -0400
 image: blog-user-experience.jpg

--- a/_sass/cds/_components.scss
+++ b/_sass/cds/_components.scss
@@ -84,17 +84,6 @@
 
 }
 
-.video-container {
-
-	@include desktop {
-		padding: 0 10rem;
-	}
-}
-
-
-
-
-
 .our-team--listing {
 	border-top: $medium-grey 5px solid;
 	max-width: 100% !important;

--- a/_sass/cds/_sections.scss
+++ b/_sass/cds/_sections.scss
@@ -403,7 +403,7 @@ span.alpha {
 }
 
 span.beta {
-    color: #ff5a02;
+    color: #22a7f0;
 }
 
 span.live {
@@ -536,7 +536,7 @@ span.live {
         position: relative;
         bottom: 10px;
         color: #ffffff;
-        background-color: #ff5a02;
+        background-color: #22a7f0;
         margin-left: 20px;
 
         @include mobile_only {
@@ -569,7 +569,7 @@ span.live {
         position: relative;
         bottom: 10px;
         color: #ffffff;
-        background-color: #ff5a02;
+        background-color: #22a7f0;
         margin-left: 20px;
 
         @include mobile_only {
@@ -760,7 +760,7 @@ span.live {
 	    }
 		a{
 			color: $white;
-			border-bottom: #fc3 1px dotted;
+			border-bottom: $primary-color 1px dotted;
 			
 			 &:hover {
             		border-bottom: $primary-color 1px solid;

--- a/index-fr.html
+++ b/index-fr.html
@@ -52,52 +52,6 @@ permalink: '/'
 	</section>
 </div>
 
-<section class="section section--featured-video">
-    <div class="container video-container">
-	    <div class="row">
-		    <div class="col-md-10 col-md-offset-1">
-			    <div class="embed-responsive embed-responsive-16by9">
-				    <iframe src="https://www.youtube.com/embed/oX1d4FERTP8" title="Canadian Digital Service Video" allowfullscreen></iframe>
-			    </div>
-			    <div>
-				    <a href="#video-transcript" title="Transcription" class="small wb-lbx lbx-modal">Transcription</a>
-			    </div>
-			    
-			    <section id="video-transcript" class="mfp-hide modal-dialog modal-content overlay-def">
-				    <header class="modal-header">
-					    <h2 class="modal-title">Transcription</h2>
-				    </header>
-				    
-				    <div class="modal-body">
-					    
-					    <p>Le numérique ne concerne pas simplement l’élaboration d’applications ou l’utilisation des dernières technologies.</p>
-					    
-					    <p>Il s’agit de mettre les gens au premier plan, en concevant des services qui sont axés sur les besoins des utilisateurs.</p>
-					    
-					    <p>Nous travaillons pour rendre l’accès aux services gouvernementaux en ligne plus rapide, plus simple et plus facile.</p>
-					    
-					    <p>Nous regroupons les meilleurs talents du gouvernement et de l’extérieur qui comprennent les développeurs, les concepteurs, les scientifiques de données et les chercheurs en expérience utilisateur.</p>
-					    
-					    <p>Nous collaborons avec les ministères pour régler les problèmes, en vue d’améliorer les services.</p>
-					    
-					    <p>Nous travaillons ouvertement, à l’aide des méthodes agiles et d’une itération constante, tout en nous concentrant inlassablement sur les besoins des utilisateurs.</p>
-					    
-					    <p>La vocation du SNC ne tourne pas autour des technologies de l’information, mais autour des services.</p>
-					    
-					    <p>Des services gouvernementaux axés sur l’utilisateur. Il s’agit de reconnaître que les services doivent être au cœur de nos priorités gouvernementales.</p>
-					    
-					    <p>Notre pertinence au yeux des citoyens est en péril si nous ne pouvons pas fournir des services numériques de classe mondiale.</p>
-					    
-					    <p>Nous apprenons des manœuvres numériques des gouvernements dans le monde entier, et travaillons avec la collectivité numérique partout au Canada, pour façonner un service numérique canadien.</p>
-					    
-					    <p>Ensemble, nous pouvons offrir des services de classe mondiale simples et faciles à utiliser. C'est ce que les Canadiens souhaitent. Ouverts, agiles et axés sur les résultats. Nous sommes le Service numérique canadien.</p>
-				    </div>
-			    </section>
-		    </div>
-	    </div>
-	</div>
-</section>
-
 <section class="section homepage--our-team">
 	<div class="page-banner--scrim"></div>
 	<div class="container">

--- a/index.html
+++ b/index.html
@@ -48,43 +48,6 @@ trans_url: '/'
 	</section>
 </div>
 
-<section class="section section--featured-video">
-	<div class="container video-container">
-		<div class="row">
-			<div class="col-md-10 col-md-offset-1">
-				<div class="embed-responsive embed-responsive-16by9">
-					<iframe src="https://www.youtube.com/embed/P_gjvWksYaA" title="Canadian Digital Service Video" allowfullscreen></iframe>
-				</div>
-				<div>
-					<a href="#video-transcript" title="Video Transcript" class="small wb-lbx lbx-modal">Transcript</a>
-				</div>
-				
-				<section id="video-transcript" class="mfp-hide modal-dialog modal-content overlay-def">
-					<header class="modal-header">
-						<h2 class="modal-title">Transcript</h2>
-					</header>
-					
-					<div class="modal-body">
-						<p>Digital isn't just about building apps, or using the latest technology. It's about putting people first, by designing services that are focused on what users need.</p>
-						
-						<p>We're about making it faster, simpler, and easier, to access government services online.</p>
-						
-						<p>We are bringing together top talent from inside and outside of government that includes developers, designers, data scientists and user experience researchers. We're partnering with departments to solve problems, in order to make services better.</p>
-						
-						<p>We're working in the open, using agile methods and constantly iterating, while relentlessly focusing on user needs.</p>
-						
-						<p>CDS is not about IT. It's about service. User centric government services. It's about recognizing services need to be at the centre of our priorities as a government. Our relevance to citizens is in jeopardy if we can't deliver digital services.</p>
-						
-						<p>We are learning from digital government movements across the globe, and working with the digital community across Canada, to shape a Canadian Digital Service.</p>
-						
-						<p>Together, we can deliver world-class services that are simple and easy to use. It's what Canadians expect. Open. Agile. And focused on delivery. We are the Canadian Digital Service.</p>
-					</div>
-				</section>
-			</div>
-		</div>
-	</div>
-</section>
-
 <section class="section homepage--our-team">
     <div class="page-banner--scrim"></div>
 	    <div class="container">


### PR DESCRIPTION
Removed the youtube video from the homepage (as discussed with Comms). 

Additionally: 
- Changed beta banner to blue on Product page. 
- Added description text to blog posts that were missing it. 
- Removed placeholder on email input field (home and contact includes)