### PR TITLE
Fixed the blogpost font size being larger on mobile

### DIFF
--- a/_sass/cds/_components.scss
+++ b/_sass/cds/_components.scss
@@ -385,6 +385,8 @@
 	p {
 		margin-bottom: 2.75rem;
 		line-height: 1.6em;
-		font-size: 2.25rem;
+		@include desktop{
+			font-size: 2.25rem;
+		}
 	}
 }


### PR DESCRIPTION
It was pointed out that the font size of links was smaller on mobile than the body font size. This was because the blog post size was larger than it was supposed to be (vs the rest of the site). For now just reduced blogpost body font size to match the rest of the site and solve the issue. 