### PR TITLE
Blog description previews

### DIFF
--- a/_pages/en/blog.html
+++ b/_pages/en/blog.html
@@ -40,17 +40,17 @@ pagination:
 		<ul class="blogpost-paginator">
 			{% if paginator.first_page and paginator.page != paginator.first_page %}
 				<li class="pagination">
-					<a href="{{paginator.first_page_path | prepend: site.baseurl }}">First</a>
+					<a href="{{paginator.first_page_path | prepend: site.baseurl | remove: "index.html" }}">First</a>
 				</li>
 			{% endif %}
 			{% for trail in paginator.page_trail %}
 				<li class = "pagination {% if page.url == trail.path %}active{% endif %} " >
-					<a href="{{trail.path | prepend: site.baseurl }}" title="{{trail.title}}">{{ trail.num}}</a>
+					<a href="{{trail.path | prepend: site.baseurl | remove: "index.html" }}" title="{{trail.title}}">{{ trail.num}}</a>
 				</li>
 			{% endfor %}
 			{% if paginator.last_page and paginator.page != paginator.last_page %}
 				<li class="pagination">
-					<a href="{{paginator.last_page_path | prepend: site.baseurl }}">Last</a>
+					<a href="{{paginator.last_page_path | prepend: site.baseurl | remove: "index.html" }}">Last</a>
 				</li>
 			{% endif %}
 		</ul>

--- a/_pages/en/blog.html
+++ b/_pages/en/blog.html
@@ -40,17 +40,17 @@ pagination:
 		<ul class="blogpost-paginator">
 			{% if paginator.first_page and paginator.page != paginator.first_page %}
 				<li class="pagination">
-					<a href="{{paginator.first_page_path | prepend: site.baseurl | remove: "index.html" }}">First</a>
+					<a href="{{paginator.first_page_path | prepend: site.baseurl | remove: 'index.html' }}">First</a>
 				</li>
 			{% endif %}
 			{% for trail in paginator.page_trail %}
 				<li class = "pagination {% if page.url == trail.path %}active{% endif %} " >
-					<a href="{{trail.path | prepend: site.baseurl | remove: "index.html" }}" title="{{trail.title}}">{{ trail.num}}</a>
+					<a href="{{trail.path | prepend: site.baseurl | remove: 'index.html' }}" title="{{trail.title}}">{{ trail.num}}</a>
 				</li>
 			{% endfor %}
 			{% if paginator.last_page and paginator.page != paginator.last_page %}
 				<li class="pagination">
-					<a href="{{paginator.last_page_path | prepend: site.baseurl | remove: "index.html" }}">Last</a>
+					<a href="{{paginator.last_page_path | prepend: site.baseurl | remove: 'index.html' }}">Last</a>
 				</li>
 			{% endif %}
 		</ul>

--- a/_pages/en/blog.html
+++ b/_pages/en/blog.html
@@ -29,7 +29,7 @@ pagination:
 				        	<div class="title"><a href="{{ post.url }}"><h2>{{ post.title }}</h2></a></div>
 				        	<div class="author">{{ post.author }}</div>
 						<div class="date">{{ post.date | date: '%B %-d, %Y' }}</div>
-				        	<div class="summary">{{ post.excerpt | strip_html | truncatewords:75 }}</div>
+				        	<div class="summary">{{ post.description }}</div>
 				        	<div class="readmore"><a href="{{ post.url }}" aria-label="Continue reading {{ post.title }}">Read More</a></div>
 				        </div>
 				    </div>

--- a/_pages/en/blog.html
+++ b/_pages/en/blog.html
@@ -29,7 +29,7 @@ pagination:
 				        	<div class="title"><a href="{{ post.url }}"><h2>{{ post.title }}</h2></a></div>
 				        	<div class="author">{{ post.author }}</div>
 						<div class="date">{{ post.date | date: '%B %-d, %Y' }}</div>
-				        	<div class="summary">{{ post.description }}</div>
+				        	<div class="summary">{{ post.description | strip_html | truncatewords:75 }}</div>
 				        	<div class="readmore"><a href="{{ post.url }}" aria-label="Continue reading {{ post.title }}">Read More</a></div>
 				        </div>
 				    </div>

--- a/_pages/fr/blogue.html
+++ b/_pages/fr/blogue.html
@@ -57,17 +57,17 @@ pagination:
 		<ul class="blogpost-paginator">
 			{% if paginator.first_page and paginator.page != paginator.first_page %}
 				<li class="pagination">
-					<a href="{{paginator.first_page_path | prepend: site.baseurl }}">Premier</a>
+					<a href="{{paginator.first_page_path | prepend: site.baseurl | remove: "index.html" }}">Premier</a>
 				</li>
 			{% endif %}
 			{% for trail in paginator.page_trail %}
 				<li class = "pagination {% if page.url == trail.path %}active{% endif %} " >
-					<a href="{{trail.path | prepend: site.baseurl }}" title="{{trail.title}}">{{ trail.num}}</a>
+					<a href="{{trail.path | prepend: site.baseurl | remove: "index.html" }}" title="{{trail.title}}">{{ trail.num}}</a>
 				</li>
 			{% endfor %}
 			{% if paginator.last_page and paginator.page != paginator.last_page %}
 				<li class="pagination">
-					<a href="{{paginator.last_page_path | prepend: site.baseurl }}">Dernier</a>
+					<a href="{{paginator.last_page_path | prepend: site.baseurl | remove: "index.html" }}">Dernier</a>
 				</li>
 			{% endif %}
 		</ul>

--- a/_pages/fr/blogue.html
+++ b/_pages/fr/blogue.html
@@ -57,17 +57,17 @@ pagination:
 		<ul class="blogpost-paginator">
 			{% if paginator.first_page and paginator.page != paginator.first_page %}
 				<li class="pagination">
-					<a href="{{paginator.first_page_path | prepend: site.baseurl | remove: "index.html" }}">Premier</a>
+					<a href="{{paginator.first_page_path | prepend: site.baseurl | remove: 'index.html' }}">Premier</a>
 				</li>
 			{% endif %}
 			{% for trail in paginator.page_trail %}
 				<li class = "pagination {% if page.url == trail.path %}active{% endif %} " >
-					<a href="{{trail.path | prepend: site.baseurl | remove: "index.html" }}" title="{{trail.title}}">{{ trail.num}}</a>
+					<a href="{{trail.path | prepend: site.baseurl | remove: 'index.html' }}" title="{{trail.title}}">{{ trail.num}}</a>
 				</li>
 			{% endfor %}
 			{% if paginator.last_page and paginator.page != paginator.last_page %}
 				<li class="pagination">
-					<a href="{{paginator.last_page_path | prepend: site.baseurl | remove: "index.html" }}">Dernier</a>
+					<a href="{{paginator.last_page_path | prepend: site.baseurl | remove: 'index.html' }}">Dernier</a>
 				</li>
 			{% endif %}
 		</ul>

--- a/_pages/fr/blogue.html
+++ b/_pages/fr/blogue.html
@@ -46,7 +46,7 @@ pagination:
 							{% endcase %}
 							{{ post.date | date: "%Y" }}
 						</div>
-				        	<div class="summary">{{post.excerpt | strip_html | truncatewords:75}}</div>
+				        	<div class="summary">{{ post.description }}</div>
 				        	<div class="readmore"><a href="{{ post.url }}" aria-label="Lire la suite de {{ post.title }}">Lire davantage</a></div>
 				        </div>
 				    </div>

--- a/_pages/fr/blogue.html
+++ b/_pages/fr/blogue.html
@@ -46,7 +46,7 @@ pagination:
 							{% endcase %}
 							{{ post.date | date: "%Y" }}
 						</div>
-				        	<div class="summary">{{ post.description }}</div>
+				        	<div class="summary">{{ post.description | strip_html | truncatewords:75 }}</div>
 				        	<div class="readmore"><a href="{{ post.url }}" aria-label="Lire la suite de {{ post.title }}">Lire davantage</a></div>
 				        </div>
 				    </div>

--- a/_posts/en/2018-06-14-lets-talk-user-experience.html
+++ b/_posts/en/2018-06-14-lets-talk-user-experience.html
@@ -1,6 +1,6 @@
 ---
 title: "Let’s talk <em>user</em> experience: Moving away from pixels, to people"
-excerpt: "Many organizations and departments recognize the need to include user experience in their process. But in what capacity? And how? This can often manifest itself as simply hiring someone who acts as the team’s dedicated user experience designer. While this may be a good start, it misses the mark."
+description: "Many organizations and departments recognize the need to include user experience in their process. But in what capacity? And how? This can often manifest itself as simply hiring someone who acts as the team’s dedicated user experience designer. While this may be a good start, it misses the mark."
 author: Eman El-Fayomi, Senior designer
 date: 2018-06-14 09:00:00 -0400
 image: blog-user-experience.jpg

--- a/_posts/en/2018-08-17-lexicon.md
+++ b/_posts/en/2018-08-17-lexicon.md
@@ -1,6 +1,6 @@
 ---
 title: "Digital words: mots vs. maux"
-description: "When I started keeping a list of the technical terms we use at CDS it was to ensure some consistency in translations. The longer the list became, the more I noticed that the way people name digital things varies enormously, ranging from using English terms directly to using terms that couldn’t do justice to the meaning"
+description: "When I started keeping a list of the technical terms we use at CDS it was to ensure some consistency in translations. The longer the list became, the more I noticed that the way people name digital things varies enormously, ranging from using English terms directly to using terms that couldn’t do justice to the meaning."
 author: Annie Leblond, Communications
 date: 2018-08-17 09:00:00 -0400
 image: blog-lexicon.jpg

--- a/_posts/fr/2018-06-14-parlons-de-l’expérience-utilisateur.html
+++ b/_posts/fr/2018-06-14-parlons-de-l’expérience-utilisateur.html
@@ -1,6 +1,6 @@
 ---
 title: "Parlons de l’expérience <em>utilisateur</em>&nbsp;:&nbsp;S’éloigner des pixels, se tourner vers les gens"
-excerpt: "De nombreux organismes et ministères reconnaissent la nécessité d’inclure l’expérience utilisateur à leur processus. Mais à quel titre? Et comment? Cela se manifeste souvent simplement par l’embauche d’une personne qui, dans l’équipe, agit comme concepteur d’expérience utilisateur dédié. Bien qu’il s’agisse d’un bon début, cette pratique rate la cible."
+description: "De nombreux organismes et ministères reconnaissent la nécessité d’inclure l’expérience utilisateur à leur processus. Mais à quel titre? Et comment? Cela se manifeste souvent simplement par l’embauche d’une personne qui, dans l’équipe, agit comme concepteur d’expérience utilisateur dédié. Bien qu’il s’agisse d’un bon début, cette pratique rate la cible."
 description: "De nombreux organismes et ministères reconnaissent la nécessité d’inclure l’expérience utilisateur à leur processus. Mais à quel titre? Et comment? Cela se manifeste souvent simplement par l’embauche d’une personne qui, dans l’équipe, agit comme concepteur d’expérience utilisateur dédié. Bien qu’il s’agisse d’un bon début, cette pratique rate la cible."
 author: Eman El-Fayomi, conceptrice principale
 date: 2018-06-14 09:00:00 -0400


### PR DESCRIPTION
Tag team with @liam-davidson, this addresses #290 to switch the preview text to use the metadata description field instead of the post.excerpt (first paragraph etc.).