### PR TITLE
Temporary purple change to the homepage header

### DIFF
--- a/assets/sass/cds/_layout.scss
+++ b/assets/sass/cds/_layout.scss
@@ -86,7 +86,7 @@
 }
 
 .page-banner {
-  background-color    : $dark-grey;
+  background-color    : #6e1b7d;
   background-size     : cover;
   background-position : center center;
   height              : 12rem;


### PR DESCRIPTION
Tomorrow (2018-12-03) is International Day of Persons with Disabilities. @JuliannaR suggested, making our homepage purple to commemorate it, per <https://www.purplespace.org/purple-light-up> and <https://www.un.org/development/desa/disabilities/news/dspd/idpd.html>. 

This changes the homepage header background colour behind "People expect government services to be simple and easy to use." This can be reverted back as of the following day.