### PR TITLE
Revert purple homepage header back to default colours

### DIFF
--- a/assets/sass/cds/_layout.scss
+++ b/assets/sass/cds/_layout.scss
@@ -134,7 +134,7 @@
 
   // Page Banner for Front Page
   .home &, .accueil & {
-    background  : #6e1b7d;
+    background  : $dark-grey;
     clear       : both;
     display     : block;
     height      : 40rem;


### PR DESCRIPTION
Reverts changes in 18fddca now that International Day of Persons with Disabilities 2018 is complete. <https://github.com/cds-snc/digital-canada-ca/pull/418>

Thanks @brdunfield for catching the .home / .accueil classes that I missed on the first edit!