### PR TITLE
Adding documentation links

### DIFF
--- a/content/en/products/products/secure-web-tool.md
+++ b/content/en/products/products/secure-web-tool.md
@@ -12,6 +12,7 @@ status: "past"
 links:
     - {name: "GitHub", url: "https://github.com/cds-snc/track-web"}
     - {name: "Github - Domain scanner", url: "https://github.com/cds-snc/tracker"}
+    - {name: "Documentation", url: "https://cds-snc.github.io/track-web-security-compliance"}
 ---
 # Product 1
 

--- a/content/fr/products/products/secure-web-tool.md
+++ b/content/fr/products/products/secure-web-tool.md
@@ -12,6 +12,7 @@ status: "past"
 links:
     - {name: "GitHub", url: "https://github.com/cds-snc/track-web"}
     - {name: "Github - Domain scanner", url: "https://github.com/cds-snc/tracker"}
+    - {name: "Documentation", url: "https://cds-snc.github.io/track-web-security-compliance/accueil/"}
 ---
 # Product 1
 


### PR DESCRIPTION
This PR adds a link to the companion documentation for _Track web security compliance_. 

[English url](https://cds-snc.github.io/track-web-security-compliance/)
[French url](https://cds-snc.github.io/track-web-security-compliance/accueil/)

Looks like: 
![image](https://user-images.githubusercontent.com/3474250/50120712-79612a80-0224-11e9-933e-6643e0665e16.png)

If there's another plan to better incorporate companion documentation on the product page, or if you don't think it should go there because it's not consistent with all products, no hard feelings on rejecting this! 

cc @rossferg ?