### PR TITLE
Proof of concept - Use node to post process images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,8 @@ jobs:
           name: "Build admin section"
           command: |
             npm install
-            npm run build_admin
+            npm run build:admin
+            npm run image:process
 
       # Store compiled cache (persisted across jobs)
       - run: echo $CIRCLE_SHA1 > .circle-sha

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/*
 static/admin/bundle.js
 public/*
 resources/*
+.DS_store

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,68 +1,83 @@
 {{ define "title" }}
-    <div class="page-banner">     
-        {{ partial "menu.html" . }}
-        <div class="page-banner--tag-line">
-            <div class="container">
-                <section class="page-wide--outer-container-padding">
-                    <div class="row">
-                        <div class="col-sm-offset-1">
-                            <div class="page-banner--tag-line--logo-container col-xs-12 col-sm-3">
-                                <object type="image/svg+xml" tabindex="-1" data="/img/cds/cds-logo-{{ string (.Site.Language) }}.svg" class="page-banner--tag-line--logo"></object>
-                                <h1 class="wb-inv">{{ i18n "canadian-digital-service" }}</h1>
-                            </div>
-                            <div class="h1 col-xs-12 col-sm-8 col-md-8">{{ i18n "homepage-tag-line" }}</div>
+<div class="page-banner">
+    {{ partial "menu.html" . }}
+    <div class="page-banner--tag-line">
+        <div class="container">
+            <section class="page-wide--outer-container-padding">
+                <div class="row">
+                    <div class="col-sm-offset-1">
+                        <div class="page-banner--tag-line--logo-container col-xs-12 col-sm-3">
+                            <object type="image/svg+xml" tabindex="-1" data="/img/cds/cds-logo-{{ string (.Site.Language) }}.svg"
+                                class="page-banner--tag-line--logo"></object>
+                            <h1 class="wb-inv">{{ i18n "canadian-digital-service" }}</h1>
                         </div>
+                        <div class="h1 col-xs-12 col-sm-8 col-md-8">{{ i18n "homepage-tag-line" }}</div>
                     </div>
-                </section>
+                </div>
+            </section>
+        </div>
+    </div>
+</div>
+{{ end }}
+{{ define "index" }}
+<section class="section section--featured-blogposts">
+    <div class="container">
+        <h2 class="section--title">Featured blog posts</h2>
+
+        <div class="row blog-posts">
+
+            {{ $posts := where .Pages "Section" "blog" }}
+
+            {{ range first 4 $posts }}
+
+            {{ $imageScratch := newScratch }}
+            {{ $src:= .Params.image}}
+            {{ $imageScratch.Add "img" $src }}
+            {{ $imageScratch.Set "img" $src }}
+            {{ if getenv "HUGO_ENV" }}
+            {{ $src:= replace $src "cds" "cds/min" }}
+            {{ $src:= replace $src "png" "jpg"}}
+            {{ $imageScratch.Set "img" $src }}
+            {{end}}
+
+            {{ $src:= $imageScratch.Get "img"}}
+
+
+            <div class="col-xs-12 col-sm-4 col-md-3">
+                <a class="post" href="{{ .RelPermalink }}">
+                    <div class="image" style="background-image:url('{{ $src }}')"></div>
+                    <div class="text">
+                        <h3>{{ .Params.title }}</h3>
+                        <div class="date">{{ .Date.Format "Mon, Jan 2, 2006" }}</div>
+                    </div>
+                </a>
+            </div>
+            {{ end }}
+        </div>
+
+        <div class="button-center">
+            <a href="/blog">More blog posts</a>
+        </div>
+    </div>
+</section>
+
+<section class="section section--contact page-wide--outer-container-padding">
+    <div class="container">
+        <div class="row">
+            <div class="col-xs-12 col-sm-6 hidden-xs">
+                <div class="hiGraphic"></div>
+            </div>
+            <div class="col-xs-12 col-sm-6">
+                <h2>Connect with us!</h2>
+                {{ partial "contact-info.html" . }}
             </div>
         </div>
     </div>
-{{ end }}
-{{ define "index" }}
-    <section class="section section--featured-blogposts">
-            <div class="container">
-                <h2 class="section--title">Featured blog posts</h2>
-        
-                <div class="row blog-posts">
+</section>
 
-                    {{ $posts := where .Pages "Section" "blog" }}
-        
-                    {{ range first 4 $posts }}
-                    <div class="col-xs-12 col-sm-4 col-md-3">
-                        <a class="post" href="{{ .RelPermalink }}">
-                            <div class="image" style="background-image:url('{{ .Params.image }}')"></div>
-                            <div class="text">
-                                <h3>{{ .Params.title }}</h3>
-                            <div class="date">{{ .Date.Format "Mon, Jan 2, 2006" }}</div>
-                            </div>
-                        </a>
-                    </div>
-                    {{ end }}
-                </div>
-        
-                <div class="button-center">
-                    <a href="/blog">More blog posts</a>
-                </div>
-            </div>
-        </section>
-
-    <section class="section section--contact page-wide--outer-container-padding">
-            <div class="container">
-                <div class="row">
-                    <div class="col-xs-12 col-sm-6 hidden-xs">
-                        <div class="hiGraphic"></div>
-                    </div>
-                    <div class="col-xs-12 col-sm-6">
-                        <h2>Connect with us!</h2>
-                        {{ partial "contact-info.html" . }}
-                </div>
-            </div>
-        </div>
-    </section>	   
-        
-    <section class="section section--mailing-list">
-        {{ $path := printf "%s%s%s" "mailing-list." (string ($.Site.Language)) ".html" }}
-        {{ partial  $path }}
-    </section>
+<section class="section section--mailing-list">
+    {{ $path := printf "%s%s%s" "mailing-list." (string ($.Site.Language)) ".html" }}
+    {{ partial $path }}
+</section>
 
 {{ end }}

--- a/layouts/section/our-team.html
+++ b/layouts/section/our-team.html
@@ -1,110 +1,133 @@
 {{ define "main" }}
 
-  {{ .Content }}
-  
-  <section class="section our-team--listing">
-      <h2 class="section--title">{{ i18n "key-contacts" }}</h2>
-  
-    <div class="container">
-      <div class="row team-listing exec wb-eqht">
-        {{ range $member := $.Site.Data.team.exec }}
-        <div class="col-xs-12 col-sm-6 col-md-4">
-          <div class="team-member">
-    
-            <div class="photo-container">
-              <div class="photo" style="background-image: url('{{ index $member "image-name" }}');"></div>
-            </div>
-    
-            <div class="text">
-              <span class="name">{{ $member.name }}</span>
-              <span class="title" >{{ index $member.title (string ( $.Site.Language) ) }}</span>
-              <div class="social-links">
-                {{ if ne $member.email nil }}
-                  <span class="social-icons">
-                    <a href="mailto:{{ $member.email }}" aria-label="Link to {{ $member.name }}'s Email">
-                      <i class="fa fa-envelope" aria-hidden="true"></i>
-                    </a>
-                  </span>
-                {{ end }}
-                {{ if ne $member.twitter nil }}
-                  <span class="social-icons">
-                    <a href="https://twitter.com/{{ $member.twitter }}" aria-label="Link to {{ $member.name }}'s Twitter Account">
-                      <i class="fab fa-twitter" aria-hidden="true"></i>
-                    </a>
-                  </span>
-                {{ end }}
-                {{ if ne $member.linkedin nil }}
-                  <span class="social-icons">
-                    <a href="https://linkedin.com/in/{{ $member.linkedin }}" aria-label="Link to {{ $member.name }}'s Linkedin Profile">
-                      <i class="fab fa-linkedin" aria-hidden="true"></i>
-                    </a>
-                  </span>
-                {{ end }}
-                {{ if ne $member.github nil }}
-                  <span class="social-icons">
-                    <a href="https://github.com/{{ $member.github }}" aria-label="Link to {{ $member.name }}'s GitHub profile">
-                      <i class="fab fa-github-alt" aria-hidden="true"></i>
-                    </a>
-                  </span>
-                {{ end }}
-              </div>
+{{ .Content }}
+
+{{ $imageScratch := newScratch }}
+{{ $imageScratch.Add "team" "" }}
+
+<section class="section our-team--listing">
+  <h2 class="section--title">{{ i18n "key-contacts" }}</h2>
+
+  <div class="container">
+    <div class="row team-listing exec wb-eqht">
+      {{ range $member := $.Site.Data.team.exec }}
+      <div class="col-xs-12 col-sm-6 col-md-4">
+        <div class="team-member">
+
+          {{ $profileImage:= index $member "image-name"}}
+          {{ $imageScratch.Set "team" $profileImage }}
+          {{ if getenv "HUGO_ENV" }}
+          {{ $profileImage:= replace $profileImage "cds" "cds/min" }}
+          {{ $profileImage:= replace $profileImage "png" "jpg"}}
+          {{ $imageScratch.Set "team" $profileImage }}
+          {{end}}
+
+          {{ $profileImage:= $imageScratch.Get "team"}}
+
+          <div class="photo-container">
+            <div class="photo" style="background-image: url('{{ $profileImage }}');"></div>
+          </div>
+
+          <div class="text">
+            <span class="name">{{ $member.name }}</span>
+            <span class="title">{{ index $member.title (string ( $.Site.Language) ) }}</span>
+            <div class="social-links">
+              {{ if ne $member.email nil }}
+              <span class="social-icons">
+                <a href="mailto:{{ $member.email }}" aria-label="Link to {{ $member.name }}'s Email">
+                  <i class="fa fa-envelope" aria-hidden="true"></i>
+                </a>
+              </span>
+              {{ end }}
+              {{ if ne $member.twitter nil }}
+              <span class="social-icons">
+                <a href="https://twitter.com/{{ $member.twitter }}" aria-label="Link to {{ $member.name }}'s Twitter Account">
+                  <i class="fab fa-twitter" aria-hidden="true"></i>
+                </a>
+              </span>
+              {{ end }}
+              {{ if ne $member.linkedin nil }}
+              <span class="social-icons">
+                <a href="https://linkedin.com/in/{{ $member.linkedin }}" aria-label="Link to {{ $member.name }}'s Linkedin Profile">
+                  <i class="fab fa-linkedin" aria-hidden="true"></i>
+                </a>
+              </span>
+              {{ end }}
+              {{ if ne $member.github nil }}
+              <span class="social-icons">
+                <a href="https://github.com/{{ $member.github }}" aria-label="Link to {{ $member.name }}'s GitHub profile">
+                  <i class="fab fa-github-alt" aria-hidden="true"></i>
+                </a>
+              </span>
+              {{ end }}
             </div>
           </div>
         </div>
-        {{ end }}
       </div>
+      {{ end }}
     </div>
-  
-    <h2 class="section--title">{{i18n "meet-the-full-team"}}</h2>
-  
-    <div class="container">
-      <div class="row team-listing wb-eqht">
-        {{ range $member := .Site.Data.team.team }}
-        <div class="col-xs-12 col-sm-6 col-md-4">
-          <div class="team-member">
-  
-              <div class="photo-container">
-                <div class="photo" style="background-image: url('{{ index $member "image-name" }}');"></div>
-              </div>
-  
-              <div class="text">
-                <span class="name">{{ $member.name }}</span>
-                <span class="title">{{ index $member.title (string ( $.Site.Language) ) }}</span>
-                <div class="social-links">
-                  {{ if ne $member.email nil }}
-                    <span class="social-icons">
-                      <a href="mailto:{{ $member.email }}" aria-label="Link to {{ $member.name }}'s Email">
-                        <i class="fa fa-envelope" aria-hidden="true"></i>
-                      </a>
-                    </span>
-                  {{ end }}
-                  {{ if ne $member.twitter nil }}
-                    <span class="social-icons">
-                      <a href="https://twitter.com/{{ $member.twitter }}" aria-label="Link to {{ $member.name }}'s Twitter account">
-                        <i class="fab fa-twitter" aria-hidden="true"></i>
-                      </a>
-                    </span>
-                  {{ end }}
-                  {{ if ne $member.linkedin nil }}
-                    <span class="social-icons">
-                      <a href="https://ca.linkedin.com/in/{{ $member.linkedin }}" aria-label="Link to {{ $member.name }}'s LinkedIn Profile">
-                        <i class="fab fa-linkedin" aria-hidden="true"></i>
-                      </a>
-                    </span>
-                  {{ end }}
-                  {{ if ne $member.github nil }}
-                    <span class="social-icons">
-                      <a href="https://github.com/{{ $member.github }}" aria-label="Link to {{ $member.name }}'s GitHub profile">
-                        <i class="fab fa-github-alt" aria-hidden="true"></i>
-                      </a>
-                    </span>
-                  {{ end }}
-                </div>
-              </div>
+  </div>
+
+  <h2 class="section--title">{{i18n "meet-the-full-team"}}</h2>
+
+  <div class="container">
+    <div class="row team-listing wb-eqht">
+      {{ range $member := .Site.Data.team.team }}
+      <div class="col-xs-12 col-sm-6 col-md-4">
+        <div class="team-member">
+          {{ $profileImage:= index $member "image-name"}}
+          {{ $imageScratch.Set "team" $profileImage }}
+          {{ if getenv "HUGO_ENV" }}
+          {{ $profileImage:= replace $profileImage "cds" "cds/min" }}
+          {{ $profileImage:= replace $profileImage "png" "jpg"}}
+          {{ $imageScratch.Set "team" $profileImage }}
+          {{end}}
+
+          {{ $profileImage:= $imageScratch.Get "team"}}
+
+
+          <div class="photo-container">
+            <div class="photo" style="background-image: url('{{ $profileImage }}');"></div>
+          </div>
+
+          <div class="text">
+            <span class="name">{{ $member.name }}</span>
+            <span class="title">{{ index $member.title (string ( $.Site.Language) ) }}</span>
+            <div class="social-links">
+              {{ if ne $member.email nil }}
+              <span class="social-icons">
+                <a href="mailto:{{ $member.email }}" aria-label="Link to {{ $member.name }}'s Email">
+                  <i class="fa fa-envelope" aria-hidden="true"></i>
+                </a>
+              </span>
+              {{ end }}
+              {{ if ne $member.twitter nil }}
+              <span class="social-icons">
+                <a href="https://twitter.com/{{ $member.twitter }}" aria-label="Link to {{ $member.name }}'s Twitter account">
+                  <i class="fab fa-twitter" aria-hidden="true"></i>
+                </a>
+              </span>
+              {{ end }}
+              {{ if ne $member.linkedin nil }}
+              <span class="social-icons">
+                <a href="https://ca.linkedin.com/in/{{ $member.linkedin }}" aria-label="Link to {{ $member.name }}'s LinkedIn Profile">
+                  <i class="fab fa-linkedin" aria-hidden="true"></i>
+                </a>
+              </span>
+              {{ end }}
+              {{ if ne $member.github nil }}
+              <span class="social-icons">
+                <a href="https://github.com/{{ $member.github }}" aria-label="Link to {{ $member.name }}'s GitHub profile">
+                  <i class="fab fa-github-alt" aria-hidden="true"></i>
+                </a>
+              </span>
+              {{ end }}
             </div>
           </div>
-        {{ end }}
+        </div>
       </div>
+      {{ end }}
     </div>
-  </section>
+  </div>
+</section>
 {{ end }}

--- a/layouts/section/our-team.html
+++ b/layouts/section/our-team.html
@@ -17,7 +17,6 @@
           {{ $profileImage:= index $member "image-name"}}
           {{ $imageScratch.Set "team" $profileImage }}
           {{ if getenv "HUGO_ENV" }}
-          {{ $profileImage:= replace $profileImage "cds" "cds/min" }}
           {{ $profileImage:= replace $profileImage "png" "jpg"}}
           {{ $imageScratch.Set "team" $profileImage }}
           {{end}}
@@ -78,13 +77,11 @@
           {{ $profileImage:= index $member "image-name"}}
           {{ $imageScratch.Set "team" $profileImage }}
           {{ if getenv "HUGO_ENV" }}
-          {{ $profileImage:= replace $profileImage "cds" "cds/min" }}
           {{ $profileImage:= replace $profileImage "png" "jpg"}}
           {{ $imageScratch.Set "team" $profileImage }}
           {{end}}
 
           {{ $profileImage:= $imageScratch.Get "team"}}
-
 
           <div class="photo-container">
             <div class="photo" style="background-image: url('{{ $profileImage }}');"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -328,6 +328,16 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1116,6 +1126,22 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
     },
+    "bindings": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
+      "dev": true
+    },
+    "bl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
@@ -1252,6 +1278,28 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
       }
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dev": true,
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "dev": true
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1489,6 +1537,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.0.tgz",
+      "integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -1501,6 +1559,16 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "comma-separated-tokens": {
       "version": "1.0.5",
@@ -1553,6 +1621,12 @@
       "requires": {
         "date-now": "^0.1.4"
       }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
     },
     "consolidated-events": {
       "version": "1.1.1",
@@ -1795,6 +1869,21 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -1845,6 +1934,12 @@
         }
       }
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
     "des.js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -1869,6 +1964,12 @@
       "requires": {
         "repeating": "^2.0.0"
       }
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "dev": true
     },
     "diacritics": {
       "version": "1.3.0",
@@ -2132,6 +2233,12 @@
         }
       }
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2334,6 +2441,27 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
+    "fs-copy-file-sync": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fs-copy-file-sync/-/fs-copy-file-sync-1.1.1.tgz",
+      "integrity": "sha512-2QY5eeqVv4m2PfyMiEuy9adxNP+ajf+8AR05cEi+OAzPcOj90hvFImeZhTmKLBgSd9EvG33jsD7ZRxsx9dThkQ==",
+      "dev": true
+    },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -2362,21 +2490,25 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "optional": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -2385,11 +2517,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2397,29 +2531,35 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "optional": true,
           "requires": {
             "ms": "2.0.0"
@@ -2427,22 +2567,26 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -2450,12 +2594,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -2470,7 +2616,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -2483,12 +2630,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "optional": true,
           "requires": {
             "safer-buffer": "^2.1.0"
@@ -2496,7 +2645,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -2504,7 +2654,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
             "once": "^1.3.0",
@@ -2513,39 +2664,46 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2553,7 +2711,8 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -2561,19 +2720,22 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "optional": true,
           "requires": {
             "debug": "^2.1.2",
@@ -2583,7 +2745,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -2600,7 +2763,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
             "abbrev": "1",
@@ -2609,12 +2773,14 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -2623,7 +2789,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -2634,33 +2801,39 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -2669,17 +2842,20 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "optional": true,
           "requires": {
             "deep-extend": "^0.5.1",
@@ -2690,14 +2866,16 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2711,7 +2889,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "optional": true,
           "requires": {
             "glob": "^7.0.5"
@@ -2719,36 +2898,43 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2757,7 +2943,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -2765,19 +2952,22 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "optional": true,
           "requires": {
             "chownr": "^1.0.1",
@@ -2791,12 +2981,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "optional": true,
           "requires": {
             "string-width": "^1.0.2"
@@ -2804,11 +2996,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
     },
@@ -2821,6 +3015,44 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/fuzzy/-/fuzzy-0.1.3.tgz",
       "integrity": "sha1-THbsL/CsGjap3M+aAN+GIweNTtg="
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
+      }
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -2851,6 +3083,12 @@
       "requires": {
         "get-document": "1"
       }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.3",
@@ -2953,6 +3191,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -3292,6 +3536,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     },
     "inline-style-prefixer": {
       "version": "3.0.8",
@@ -3902,6 +4152,12 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
+    },
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
@@ -3932,6 +4188,25 @@
       "version": "0.0.8",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
     },
     "mississippi": {
       "version": "3.0.0",
@@ -4003,8 +4278,7 @@
     "nan": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-      "optional": true
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -4047,6 +4321,12 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
+    },
+    "napi-build-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
+      "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA==",
+      "dev": true
     },
     "neo-async": {
       "version": "2.6.0",
@@ -4333,6 +4613,15 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-abi": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.5.1.tgz",
+      "integrity": "sha512-oDbFc7vCFx0RWWCweTer3hFm1u+e60N5FtGnmRV6QqvgATGFH/XRR6vqWIeBVosCYCqt6YdIr2L0exLZuEdVcQ==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -4405,6 +4694,12 @@
         }
       }
     },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+      "dev": true
+    },
     "nopt": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
@@ -4428,6 +4723,18 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -4773,6 +5080,59 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
+    "prebuild-install": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.2.tgz",
+      "integrity": "sha512-4e8VJnP3zJdZv/uP0eNWmr2r9urp4NECw7Mt1OSAi3rcLrbBRxGiAkfUFtre2MhQ5wfREAjRV+K1gubvs/GPsA==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.2.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^2.0.1",
+        "rc": "^1.2.7",
+        "simple-get": "^2.7.0",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "simple-get": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+          "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+          "dev": true,
+          "requires": {
+            "decompress-response": "^3.3.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
+          }
+        }
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -4898,6 +5258,26 @@
       "requires": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
       }
     },
     "react": {
@@ -5687,6 +6067,33 @@
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
+    "sharp": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.21.1.tgz",
+      "integrity": "sha512-XPRi/nosSHk2GG6Zl+uquJ8vZ+00TpNjzrSKah4DGBHYXRxw7nixBBBewJtw3jetUJi0Oaw/n6AO3/myDVVqFg==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.3.1",
+        "color": "^3.1.0",
+        "detect-libc": "^1.0.3",
+        "fs-copy-file-sync": "^1.1.1",
+        "nan": "^2.11.1",
+        "npmlog": "^4.1.2",
+        "prebuild-install": "^5.2.2",
+        "semver": "^5.6.0",
+        "simple-get": "^3.0.3",
+        "tar": "^4.4.8",
+        "tunnel-agent": "^0.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "dev": true
+        }
+      }
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -5707,6 +6114,40 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+      "dev": true
+    },
+    "simple-get": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.0.3.tgz",
+      "integrity": "sha512-Wvre/Jq5vgoz31Z9stYWPLn0PqRqmBDpFSdypAnHu5AvRVCYPRYGnvryNLiXu8GOBNDH82J2FRHUGMjjHUpXFw==",
+      "dev": true,
+      "requires": {
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+          "dev": true
+        }
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -6155,6 +6596,12 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
     "style-loader": {
       "version": "0.22.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.22.1.tgz",
@@ -6188,6 +6635,60 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
       "integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA=="
+    },
+    "tar": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
+      }
+    },
+    "tar-fs": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
+    "tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "dev": true,
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      }
     },
     "teeny-tap": {
       "version": "0.2.0",
@@ -6330,6 +6831,12 @@
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
     },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "dev": true
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -6457,6 +6964,15 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "type-of": {
       "version": "2.0.1",
@@ -6886,6 +7402,21 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
     },
     "worker-farm": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,14 @@
     "webpack": "^4.26.1"
   },
   "devDependencies": {
-    "webpack-cli": "^3.1.2"
+    "webpack-cli": "^3.1.2",
+    "sharp": "^0.21.1"
   },
   "scripts": {
     "dev": "webpack && hugo server -D",
-    "build": "webpack && hugo",
-    "build_admin": "webpack --config webpack.config.js"
+    "build": "export HUGO_ENV='production' && webpack && hugo && npm run image:process",
+    "build_admin": "webpack --config webpack.config.js",
+    "image:process": "node process.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "dev": "webpack && hugo server -D",
     "build": "export HUGO_ENV='production' && webpack && npm run image:process && hugo",
-    "build_admin": "webpack --config webpack.config.js",
+    "build:admin": "webpack --config webpack.config.js",
     "image:process": "node process.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "dev": "webpack && hugo server -D",
-    "build": "export HUGO_ENV='production' && webpack && hugo && npm run image:process",
+    "build": "export HUGO_ENV='production' && webpack && npm run image:process && hugo",
     "build_admin": "webpack --config webpack.config.js",
     "image:process": "node process.js"
   },

--- a/process.js
+++ b/process.js
@@ -9,11 +9,10 @@ const getFileInfo = file => {
   return { name, ext };
 };
 
-
 const saveFile = (dirname, filename) => {
 
   const filePath = `${dirname}/${filename}`;
-  const targetPath = `${dirname}/min`
+  const targetPath = `${dirname}`
   const fileInfo = getFileInfo(filePath);
 
   if (!fs.existsSync(targetPath)) {
@@ -32,14 +31,15 @@ const saveFile = (dirname, filename) => {
       fit: "inside",
       position: "entropy",
       withoutEnlargement: true
-
     })
     .toFormat('jpeg')
-    .toFile(`${targetPath}/${fileInfo.name}.jpg`, (err, info) => {
-      if (err) {
-        console.log(err);
-        return;
-      }
+    .toBuffer(function(err, buffer) {
+      fs.writeFile(`${targetPath}/${fileInfo.name}.jpg`, buffer, function(err) {
+        if (err) {
+          console.log(err);
+          return;
+        }
+      });
     });
 };
 
@@ -62,4 +62,4 @@ function moveFiles(dirname, target) {
   });
 }
 
-moveFiles("public/en/img/cds/");
+moveFiles("static/img/cds/");

--- a/process.js
+++ b/process.js
@@ -1,0 +1,65 @@
+const sharp = require("sharp");
+const fs = require("fs");
+const path = require("path");
+
+const getFileInfo = file => {
+  const name = path.parse(file).name; // hello
+  const ext = path.parse(file).ext;
+
+  return { name, ext };
+};
+
+
+const saveFile = (dirname, filename) => {
+
+  const filePath = `${dirname}/${filename}`;
+  const targetPath = `${dirname}/min`
+  const fileInfo = getFileInfo(filePath);
+
+  if (!fs.existsSync(targetPath)) {
+    fs.mkdirSync(targetPath);
+  }
+
+  if (!fileInfo.ext || fileInfo.ext === ".svg") {
+    return
+  }
+
+  //const name = filename.slice(0, -1).join(".");
+  sharp(filePath)
+    .resize({
+      width: 800,
+      height: 800,
+      fit: "inside",
+      position: "entropy",
+      withoutEnlargement: true
+
+    })
+    .toFormat('jpeg')
+    .toFile(`${targetPath}/${fileInfo.name}.jpg`, (err, info) => {
+      if (err) {
+        console.log(err);
+        return;
+      }
+    });
+};
+
+function moveFiles(dirname, target) {
+  fs.readdir(dirname, function (err, filenames) {
+    if (err) {
+      console.log("Error reading files");
+      return;
+    }
+    if (filenames.length > 0) {
+
+      filenames.forEach((file) => {
+        console.log(file)
+        saveFile(dirname, file)
+      })
+
+    } else {
+      process.exit();
+    }
+  });
+}
+
+moveFiles("public/en/img/cds/");


### PR DESCRIPTION
Given we haven't found a way to process the site images using Hugo or Netlify CMS as this time I have created a workaround to speed up the homepage and team page.  This could be applied to other pages as well (for now testing with a few templates).

This PR adds a node script that will run as part of the build process to process the site images into a public  "min" directory.

```
"scripts": {
    "dev": "webpack && hugo server -D",
    "build": "export HUGO_ENV='production' && webpack && hugo && npm run image:process",
   ...
```

"image:process" uses a Node script to process the images that are output by Hugo to the "public" dir. 

They will write to a new dir call "min"  and will all be jpegs.  The site has a mix of jpegs and png images at the moment.  

This gets a bit yucky on the template end as I am doing some string replacement to point to the "new" images.

```
{{ $profileImage:= replace $profileImage "cds" "cds/min" }} . // point to the min dir
{{ $profileImage:= replace $profileImage "png" "jpg"}}  // swap the ext
```

There's likely a cleaner way to do this but again "proof of concept".

### Next steps
Can we deploy this to a demo url for testing / review?


