### PR TITLE
Fix URL

### DIFF
--- a/content/en/products/products/vac-benefits.md
+++ b/content/en/products/products/vac-benefits.md
@@ -11,7 +11,8 @@ contact:
 status: "in-flight"
 links:
     - {name: "GitHub", url: "https://github.com/veteransaffairscanada/vac-benefits-directory"}
-    - {name: "Documentation", url: "https://cds-snc.github.io/vac-benefits-directory-documentation"}
+    - {name: "Documentation", url: "https://cds-snc.github.io/find-benefits-and-services-documentation/"}
+    
 ---
 # Product 1
 

--- a/content/fr/products/products/vac-benefits.md
+++ b/content/fr/products/products/vac-benefits.md
@@ -16,5 +16,5 @@ partners:
 status: in-flight
 links:
   - name: Documentation
-    url: 'https://cds-snc.github.io/vac-benefits-directory-documentation/accueil/'
+    url: 'https://cds-snc.github.io/find-benefits-and-services-documentation/accueil/'
 ---


### PR DESCRIPTION
The VAC doc URL was updated to reflect the product name; this PR fixes it on the website so there's no 404s 🙅.