### PR TITLE
Content changes to "Meet the team" page

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -37,7 +37,7 @@ languages:
         url: /blog/
         weight: 5
       - identifier: our-team
-        name: Our team
+        name: Meet our team
         url: /our-team/
         weight: 3 
   fr:

--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -76,6 +76,6 @@ languages:
         url: /blogue/
         weight: 5
       - identifier: notre-equipe
-        name: Notre équipe
+        name: Rencontrez l’équipe
         url: /notre-equipe/
         weight: 3

--- a/content/en/our-team.html
+++ b/content/en/our-team.html
@@ -9,13 +9,10 @@ aliases: [/notre-equipe/]
     <section class="section page-intro--outer-container-padding">
         <div class="row">
             <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-                <p class="lead">The Canadian Digital Service is a team of passionate people committed to using our digital skills and knowledge to make it easier to access and use government services.</p>
+                <p>We are a team of passionate people committed to making it easier to access and use government
+                    services. We all bring something different to CDS, whether that’s experiences from inside or outside
+                    government. Interested in joining us? <a href="/work-with-us/">See what positions we're hiring for</a>.</p>
 
-                <p>We are driven by empathy in our approach to discovery and design, and we use proven technologies to get the job done.</p>
-
-                <p>To break down challenging problems and build great solutions we need to bring together top talent with diverse skills and perspectives. Our growing team comes from both outside and inside government.</p>
-
-                <p>We're currently hiring!  Learn more about <a href="/work-with-us/">what we're looking for and how to apply</a>. We are building a talented and diverse team to work on some of Canada's biggest service delivery opportunities, and we would love to hear from you.</p>
             </div>
         </div>
     </section>

--- a/content/fr/our-team.html
+++ b/content/fr/our-team.html
@@ -11,13 +11,10 @@ lang: fr
     <section class="section page-wide--outer-container-padding">
         <div class="row">
             <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-                <p class="lead">Le Service numérique canadien est une équipe de personnes passionnées, résolue à utiliser ses compétences et ses connaissances numériques pour faciliter l’accès et l’utilisation des services gouvernementaux.</p>
-                
-                <p>Nous sommes poussés par l’empathie dans notre approche de découverte et de conception, et nous utilisons des technologies éprouvées pour y arriver.</p>
-                
-                <p>Pour résoudre des problèmes difficiles et élaborer d’excellentes solutions, nous devons regrouper les meilleurs talents avec des compétences et des points de vue divers. Notre équipe grandissante provient du gouvernement et de l’extérieur.</p>
-                
-                <p>Nous embauchons! Apprenez-en <a href="/travaillez-avec-nous/">plus sur les profils recherchés et la façon de postuler</a>. Nous voulons créer une équipe talentueuse et diversifiée qui travaillera sur certains des plus importants projets de prestation de services du Canada. Nous serions très intéressés à faire votre connaissance.</p>
+                <p>Nous sommes une équipe de personnes passionnées et déterminées à rendre les services gouvernementaux
+                    accessibles et faciles à utiliser. Nous apportons tous quelque chose de différent au SNC, qu’il
+                    s’agisse d’expériences internes ou externes au gouvernement. Vous aimeriez vous joindre à nous? <a
+                        href="/travaillez-avec-nous/">Jetez un œil aux postes que nous offrons</a>.</p>
             </div>
         </div>
     </section>

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -31,7 +31,7 @@ homepage-tag-line:
 in-flight:
   other: "In flight products"
 key-contacts:
-  other: "Key Contacts"
+  other: "Key contacts"
 language-code:
   other: "en-ca"
 language-selection:
@@ -41,11 +41,11 @@ lang-switch-label:
 links:
   other: "Links"
 meet-the-full-team: 
-  other: "Meet the Full Team"
+  other: "The full team"
 next-post:
   other: "Next post"
 our-team:
-  other: "Our team"
+  other: "Meet our team"
 partner:
   other: "Partner"
 past-products:

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -29,7 +29,7 @@ homepage-tag-line:
 in-flight:
   other: "Produits en cours"
 key-contacts:
-  other: "Contacts"
+  other: "Contacts principaux"
 language-code:
   other: "fr-ca"
 language-selection:
@@ -39,11 +39,11 @@ lang-switch-label:
 links:
   other: "Liens"
 meet-the-full-team:
-  other: "Rencontrer l'équipe"
+  other: "Toute l’équipe"
 next-post:
   other: "Prochaine billet"
 our-team:
-  other: "Notre équipe"
+  other: "Rencontrez l’équipe"
 partner:
   other: "Partenaire"
 past-products:


### PR DESCRIPTION
Includes English + French version changes to the following:

ENG:
- Content changes to main paragraph of 'Meet the team' page
- Changed Our team to Meet the team. (Menu bar and page title)
- Changed Key Contacts to Key contacts. (Heading above the management photos)
- Changed Meet the Full Team to The full team. (Heading above the full team’s photos)

FR:
- Content changes to main paragraph of 'Rencontrez l’équipe' page
- Changed Notre Equipe to Rencontrez l’équipe. (Menu bar and page title)
- Changed Contacts to Contacts principaux. (Heading above the management photos)
- Changed Rencontrer l'équipe to Toute l’équipe. (Heading above the full team’s photos)
