### PR TITLE
fixed blog post thumbnail image on Blog post

### DIFF
--- a/content/en/blog/posts/the-policy-pieces-for-conducting-research-with-vac.md
+++ b/content/en/blog/posts/the-policy-pieces-for-conducting-research-with-vac.md
@@ -9,6 +9,7 @@ date: 2019-02-27T16:13:50.918Z
 image: /img/cds/tim-swaan-45717-unsplash.jpg
 image-alt: footbridge-leading-towards-forest
 translationKey: user-interview-policy
+thumb: /img/cds/tim-swaan-45717-unsplash.jpg
 ---
 Public servants who want to conduct interviews with the people that use your service, this post is for you. Recruiting people for service design research can be difficult in any sector, but government has some additional requirements. Though many are warranted due to the government’s position of authority, [others may be due to culture or habit](https://digital.canada.ca/2018/09/07/policy). In this post, we’ll talk about how we recruited Veterans and conducted research.
 

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -5,7 +5,7 @@ about-this-site:
 aria-canada-website:
   other: "Gouvernement du Canada"
 blog:
-  other: "Blogue"
+  other: "Lire notre blogue"
 canada-ca-link:
   other: "https://www.canada.ca/fr.html"
 canada-ca:


### PR DESCRIPTION
Blog post: The policy pieces for conducting research with vac.md

*there wasn't a line for thumbnail image so I added this:

thumb: /img/cds/tim-swaan-45717-unsplash.jpg