### PR TITLE
UPDATED VERSION of pr #699: content + style changes to address Header Menu updates before the budget

### DIFF
--- a/assets/sass/cds/_mixins.scss
+++ b/assets/sass/cds/_mixins.scss
@@ -5,6 +5,10 @@
 @mixin desktop      { @media ( min-width: 992px )  { @content; } }
 @mixin tv           { @media ( min-width: 900px ) { @content; } }
 
+// the following mixins are meant to address content changes on our header menus 
+@mixin menu_break { @media (min-width: 1200px) { @content; } }
+@mixin logo_break { @media (max-width: 1200px) { @content; } }
+@mixin tablet_break { @media (max-width: 768px) { @content; } }
 @mixin retina {
 	@media
 		only screen and (-webkit-min-device-pixel-ratio: 2),

--- a/assets/sass/cds/_nav.scss
+++ b/assets/sass/cds/_nav.scss
@@ -8,7 +8,8 @@
   padding: 1rem;
   z-index: 999;
 
-  @include tablet {
+  // below used to be @include tablet
+  @include menu_break {
     padding-top: 5rem;
   }
 
@@ -24,7 +25,8 @@
 
   // TOPBAR SPECIFIC STYLE FOR HOMEPAGE
   .home &, .accueil & {
-    @include tablet {
+    // below used to be @include tablet
+    @include menu_break {
       padding-top: 3rem;
       position: absolute;
       left: 50%;
@@ -72,6 +74,14 @@
     top: -3.7rem;
   }
 
+  // added the below custom mixin to address menu content changes
+  @include logo_break {
+    height: 5rem;
+    width: 5rem;
+    position: absolute;
+    top: 0;
+}
+
   // FRONT PAGE SPECIFIC STYLES FOR CDS LOGO
   .home &, .accueil & {
     display: none;
@@ -91,16 +101,16 @@
 
 .top-nav {
   clear: both;
-  float: right;
+  text-align: center;
   list-style: none;
-  text-align: right;
   margin: 1rem 0 1rem 0;
   padding: 0;
 
-  @include mobile_only {
+  // below used to be @include tablet
+  @include logo_break {
     position: fixed;
     width: 100%;
-    top: 50%;
+    top: 45%;
     left: 50%;
     transform: translateX(-50%) translateY(-50%);
   }
@@ -113,8 +123,10 @@
 
     a {
       color: $white;
-      @include tablet {
-        font-size: 2.5rem;
+      
+      // below used to be @include tablet
+      @include menu_break {
+        font-size: 2rem;
       }
     }
   }
@@ -129,7 +141,8 @@
     margin: 2rem 0;
   }
 
-  @include tablet {
+  // below used to be @include tablet
+  @include menu_break {
     display: inline-block;
     position: relative;
 
@@ -148,30 +161,36 @@
     color: $white;
     font-size: 3.5rem;
     font-weight: 100;
-    margin: 1.5rem;
+    margin: 0.7rem;
     text-decoration: none;
     position: relative;
 
-    @include tablet {
+    // @include tablet {
+    //   color: $secondary-color;
+    //   font-size: 2rem;
+    //   margin: 0 1.25rem 0.25rem 1.25rem;
+
+    //   .fr & {
+    //     font-size: 2rem;
+    //     padding-left: 0em;
+    //     padding-right: 0em;
+    //   }
+    // }
+
+    // @include desktop {
+    //   font-size: 2rem;
+
+    //   .fr & {
+    //     font-size: 2rem;
+    //     padding-left: 0em;
+    //     padding-right: 0em;
+    //   }
+    // }
+
+    // replacing the above previous styles
+    @include menu_break {
       color: $secondary-color;
-      font-size: 1.5rem;
-      margin: 0 1.25rem 0.25rem 1.25rem;
-
-      .fr & {
-        font-size: 1.4rem;
-        padding-left: 0em;
-        padding-right: 0em;
-      }
-    }
-
-    @include desktop {
       font-size: 2rem;
-
-      .fr & {
-        font-size: 1.7rem;
-        padding-left: 0em;
-        padding-right: 0em;
-      }
     }
 
     &::after {
@@ -230,7 +249,8 @@
   -webkit-backface-visibility: none;
   -webkit-transform-style: preserve-3d;
 
-  @include tablet {
+  // below used to be @include tablet
+  @include menu_break {
     display: block;
   }
 
@@ -272,8 +292,8 @@
     color: $white;
     border: none;
     position: fixed;
-    right: 1rem;
-    top: 1rem;
+    right: 10rem;
+    top: 5rem;
     padding: 1rem;
 
     &:focus {
@@ -297,22 +317,34 @@
       border-radius: 50%;
     }
 
-    @include tablet {
+    // used to be @include tablet
+    @include menu_break {
       display: none;
+    }
+
+    @include mobile_only {
+      right: 1rem;
+      top: 1rem;
     }
   }
 	
 	.mobile-lang {
-	    	display    : block;
-	    	text-align : right;
-	    	color      : $white;
+	  display    : block;
+	  text-align : right;
+	  color      : $white;
 		position: fixed;
-		top: 2.3rem;
-		left: 2rem;
+		top: 5.5rem;
+		left: 10rem;
 		
-		@include tablet{
+		// used to be @include tablet
+		@include menu_break {
 			display: none;
-		}
+    }
+    
+    @include mobile_only {
+      top: 2.3rem;
+		  left: 2rem;
+    }
 
     a {
       display: inline-block;
@@ -367,7 +399,8 @@
     color: $dark-grey;
   }
 
-  @include tablet {
+  // below used to be @include tablet
+  @include menu_break {
     display: none;
   }
 }
@@ -414,7 +447,8 @@
   }
 
   .topbar {
-    @include tablet {
+    // below used to be @include tablet
+    @include menu_break {
       padding: 0.5rem 1rem;
       margin: 0;
       width: 100%;

--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -25,15 +25,15 @@ languages:
         url: /what-we-do/
         weight: 2
       - identifier: products
-        name: Products
+        name: View our products
         url: /products/
         weight: 6
       - identifier: work-with-us
-        name: Work with us
+        name: Join our team
         url: /work-with-us/
         weight: 4
       - identifier: blog
-        name: Blog
+        name: Read the blog
         url: /blog/
         weight: 5
       - identifier: our-team
@@ -64,11 +64,11 @@ languages:
         url: /ce-que-nous-faisons/
         weight: 2
       - identifier: produits
-        name: Produits
+        name: Découvrir nos produits
         url: /produits/
         weight: 6
       - identifier: travaillez-avec-nous
-        name: Carrières
+        name: Rejoindre notre équipe
         url: /travaillez-avec-nous/
         weight: 4
       - identifier: blogue

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -5,7 +5,7 @@ aria-canada-website:
 aria-cds-website: 
   other: "Canadian Digital Service"
 blog:
-  other: "Blog"
+  other: "Read the blog"
 canada-ca: 
   other: "Visit Canada.ca"
 canada-ca-link:
@@ -45,7 +45,7 @@ meet-the-full-team:
 next-post:
   other: "Next post"
 our-team:
-  other: "Meet the team"
+  other: "Join our team"
 partner:
   other: "Partner"
 past-products:
@@ -61,7 +61,7 @@ privacy:
 privacy-link: 
   other: "/legal/privacy/"
 products:
-  other: "Products"
+  other: "View our products"
 read-more:
   other: "Read More"
 rss-feed-url:

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -59,7 +59,7 @@ privacy-link:
 privacy:
   other: "Confidentialité"
 products:
-  other: "Produits"
+  other: "Découvrir nos produits"
 read-more:
   other: "Lire davantage"
 rss-feed-url:
@@ -83,7 +83,7 @@ twitter:
 view-product:
   other: "Voir ce produit"
 work-with-us:
-  other: "Travaillez avec nous"
+  other: "Rejoindre notre équipe"
 what-we-do:
   other: "Ce que nous faisons"
 contact-us:


### PR DESCRIPTION
*this is an updated version of a previous PR (#699). this good copy features the updated logo changes, which #699 did not. 

Made content changes to the website's menu headings. These changes ended up making the menu width longer, so the following changes are meant to address that:

Change to the actual menu content on files: config.yaml, en.yaml, fr.yaml
As a result of the above menu content changes on files, new styles are meant to bring the Waffle menu on earlier. Made the following style changes to sass files:

_mixins.scss (made 3 new mixins to address custom screen width breaks)
_nav.scss (replaced some pre-existing screenwidths like tablet and mobile_only with those mixins. Also centered the menu to middle of the screen in english and french)