### PR TITLE
removed Thumb and Processed fields for English and French

### DIFF
--- a/content/en/blog/posts/attracting-and-recruiting-top-talent-with-a-little-help-from-our-friends.md
+++ b/content/en/blog/posts/attracting-and-recruiting-top-talent-with-a-little-help-from-our-friends.md
@@ -12,8 +12,7 @@ image-alt: >-
   Émilie Payant (human resources) and Jessica Loadenthal (CDS) work together at
   the CDS office.
 translationKey: help-from-friends-HR
-thumb: ''
-processed: ''
+
 ---
 *[We get by with a little help from our friends](https://digital.canada.ca/2019/01/31/we-get-by-with-a-little-help-from-our-friends/) is a blog series profiling the amazing public servants who enable us and our partners to design and deliver better services.*
 

--- a/content/fr/blog/posts/attirer-et-recruter-les-meilleurs-talents-avec-un-petit-coup-de-main-de-nos-amis.md
+++ b/content/fr/blog/posts/attirer-et-recruter-les-meilleurs-talents-avec-un-petit-coup-de-main-de-nos-amis.md
@@ -15,8 +15,6 @@ image-alt: >-
   Émilie Payant des Ressources humaines (RH) et Jessica Loadenthal du Service
   numérique canadien (SNC) travaillent ensemble au bureau du SNC.
 translationKey: help-from-friends-HR
-thumb: ''
-processed: ''
 ---
 *[On s’en sort avec l’aide de nos amis] (https://numerique.canada.ca/2019/01/31/on-sen-sort-avec-laide-de-nos-amis/) est une série de billets de blogues mettant en vedette les fonctionnaires extraordinaires qui nous permettent, à nous et à nos partenaires, de concevoir et d’offrir de meilleurs services.*
 


### PR DESCRIPTION
Removed the "thumb" and "process" fields for English / FRench version of blog post that went up this AM ("Attracting and recruiting top talent, with a little help from our friends") to address issue of thumbnail image not showing...