### PR TITLE
second try at fixing missing thumbnail on blog post

### DIFF
--- a/content/en/blog/posts/attracting-and-recruiting-top-talent-with-a-little-help-from-our-friends.md
+++ b/content/en/blog/posts/attracting-and-recruiting-top-talent-with-a-little-help-from-our-friends.md
@@ -10,6 +10,7 @@ date: 2019-03-18T15:00:00.000Z
 image: /img/cds/beetletoy.jpg
 image-alt: A yellow Volkswagen beetle toy on wooden shelf filled with books.
 translationKey: help-from-friends-HR
+thumb: /img/cds/beetletoy.jpg
 ---
 *[We get by with a little help from our friends](https://digital.canada.ca/2019/01/31/we-get-by-with-a-little-help-from-our-friends/) is a blog series profiling the amazing public servants who enable us and our partners to design and deliver better services.*
 

--- a/content/fr/blog/posts/attirer-et-recruter-les-meilleurs-talents-avec-un-petit-coup-de-main-de-nos-amis.md
+++ b/content/fr/blog/posts/attirer-et-recruter-les-meilleurs-talents-avec-un-petit-coup-de-main-de-nos-amis.md
@@ -15,6 +15,7 @@ image-alt: >-
   Un jouet de voiture Volkswagen jaune sur une étagère en bois remplie de
   livres.
 translationKey: help-from-friends-HR
+thumb: /img/cds/beetletoy.jpg
 ---
 *[On s’en sort avec l’aide de nos amis] (https://numerique.canada.ca/2019/01/31/on-sen-sort-avec-laide-de-nos-amis/) est une série de billets de blogues mettant en vedette les fonctionnaires extraordinaires qui nous permettent, à nous et à nos partenaires, de concevoir et d’offrir de meilleurs services.*
 


### PR DESCRIPTION
Added this field to French + English blog posts: 

thumb: /img/cds/beetletoy.jpg