### PR TITLE
Fix Markdown rendering in roadmap

### DIFF
--- a/layouts/shortcodes/roadmap/div.html
+++ b/layouts/shortcodes/roadmap/div.html
@@ -1,3 +1,4 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
 <div class="{{ .Get "class" }}">
     {{.Inner}}
 </div>


### PR DESCRIPTION
We had a Hugo 0.54 vs 0.55 issue, causing the Markdown to not render in the live site. Oops!

See Hugo 0.55 changelog: https://gohugo.io/news/0.55.0-relnotes/