### PR TITLE
Add recruitment page for website usability testing

### DIFF
--- a/content/en/website-usability-testing.html
+++ b/content/en/website-usability-testing.html
@@ -1,0 +1,31 @@
+---
+type: section
+layout: page
+title: website-usability-testing
+aliases: [/test-d-utilisabilite-du-site-web/]
+---
+<section class="section page--outer-container-padding">
+    <div class="row">
+        <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+            <h2 class="section--title"> We need your help</h2>
+
+            <p>We are conducting research to improve the CDS website. This research will help us make the site easier to understand and more useful for all of government. Your participation would help us understand the website's audience.</p>
+            <p>If you are interested in participating, or know someone who is, please contact <a href="mailto:cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a> for more information on how to be involved.</p>
+            
+            <h2>What it looks like</h2>
+    
+            <p>To do this we will ask you to answer questions about the CDS website. We'd also like to ask about your experience with CDS. This will take 30 minutes.</p>
+            <p>Please note:</p>
+            <ul>
+                <li>Participation is <strong>voluntary</strong> and participants may stop at any time for any reason;</li>
+                <li>Responses will be <strong>confidential</strong>, which means they will not be linked back to anyone;</li>
+                <li>Your participation and answers <strong>will not impact</strong> your relationship with CDS; and</li>
+                <li>CDS handles personal information in accordance with the Privacy Act, participants will be given a copy of our Privacy Statement.</li>
+            </ul>
+            <p>For any further questions about this research, please contact:<br>
+            <strong>Adrianne Lee</strong><br>
+            <strong>613-222-7880</strong><br>
+            <a href="mailto:adrianne.lee@tbs-sct.gc.ca"><strong>adrianne.lee@tbs-sct.gc.ca</strong></a></p>
+        </div>
+    </div>	
+    </section>

--- a/content/fr/website-usability-testing.html
+++ b/content/fr/website-usability-testing.html
@@ -1,0 +1,32 @@
+---
+type: section
+layout: page
+title: website-usability-testing
+aliases: [/website-usability-testing/]
+url: /test-d-utilisabilite-du-site-web/
+---
+<section class="section page--outer-container-padding">
+    <div class="row">
+        <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+            <h2 class="section--title">Nous avons besoin de votre aide</h2>
+
+            <p>Nous menons une recherche afin d’améliorer le site Web du SNC. Cette étude nous aidera à rendre ce site plus facile à comprendre et plus utile pour l’ensemble du gouvernement. Votre participation nous permettra de mieux cerner le public cible du site.</p>
+            <p>Si vous souhaitez participer, ou connaissez quelqu’un qui souhaite participer, veuillez communiquer avec <a href="mailto:cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a> pour obtenir plus de renseignements sur la participation.</p>
+            
+            <h2>Déroulement</h2>
+    
+            <p>Pour ce faire, nous vous poserons des questions concernant le site Web du SNC, ainsi que sur votre expérience avec le SNC. ​Cela prendra entre 30 minutes.</p>
+            <p>Remarques&nbsp;:</p>
+            <ul>
+                <li>La participation est <strong>volontaire</strong> et les participants peuvent arrêter à tout moment pour n’importe quelle raison.</li>
+                <li>Les réponses seront <strong>confidentielles</strong>, ce qui signifie qu’elles ne pourront pas être reliées à une personne.</li>
+                <li>Votre participation et vos réponses <strong>n’auront aucune incidence</strong> sur votre relation avec le SNC.</li>
+                <li>Le Service numérique canadien traite les renseignements personnels conformément à la Loi sur la protection des renseignements personnels. Les participants recevront une copie de notre déclaration de confidentialité.</li>
+            </ul>
+            <p>Pour toute autre question concernant cette recherche, veuillez communiquer avec&nbsp;:<br>
+            <strong>Élise Cossette</strong><br>
+            <strong>343-548-4313</strong><br>
+            <a href="mailto:elise.cossette@cds-snc.ca"><strong>elise.cossette@cds-snc.ca</strong></a></p>
+        </div>
+    </div>	
+    </section>

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -110,3 +110,5 @@ products-btn:
   other: "Products"
 developer-tools-btn:
   other: "Tools and resources"
+website-usability-testing:
+  other: "Website usability testing"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -110,3 +110,5 @@ products-btn:
   other: "Produits"
 developer-tools-btn:
   other: "Outils et ressources"
+website-usability-testing:
+  other: "Test d'utilisabilité du site web"


### PR DESCRIPTION
First pass at this. To review next week:

- [ ] French URL: `/test-d-utilisabilite-du-site-web/`
- [ ] French title: `Test d'utilisabilité du site web`
- [ ] Need to include an explicit privacy notice? (this is based on the VAC page, so we should be good, to verify with SR/JM)
- [ ] Pages are coded/located correctly