### PR TITLE
Draft for ESDC recruitment page

### DIFF
--- a/content/en/cppd-research.html
+++ b/content/en/cppd-research.html
@@ -1,0 +1,31 @@
+---
+type: section
+layout: page
+title: cppd-research
+aliases: [/cppd-research/]
+---
+<section class="section page--outer-container-padding">
+    <div class="row">
+        <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+            <h2 class="section--title"> We need your help</h2>
+
+            <p>We are conducting research to learn about medical professional’s experience with filling out Medical Reports for the Canada Pension Plan Disability Benefit. This research will help us understand medical professional’s challenges and limitations when providing medical information for their patients.</p>
+            <p>If you are interested in participating, or know someone who is, please contact <a href="mailto:michelle.ngai@tbs-sct.gc.ca">michelle.ngai@tbs-sct.gc.ca</a> for more information on how to be involved.</p>
+            
+            <h2>What it looks like</h2>
+    
+            <p>To do this we will ask you about your experience with filling out the CPP disability benefit medical report in a 30 minute phone conversation we will schedule at a time most convenient for you.</p>
+            <p>Please note:</p>
+            <ul>
+                <li>Participation is <strong>voluntary</strong> and participants may stop at any time for any reason;</li>
+                <li>Responses will be <strong>confidential</strong>, which means they will not be linked back to anyone;</li>
+                <li>Your participation and answers <strong>will not impact</strong> your relationship with CDS or the Government of Canada; and</li>
+                <li>CDS handles personal information in accordance with the Privacy Act, participants will be given a copy of our Privacy Statement.</li>
+            </ul>
+            <p>For any further questions about this research, please contact:<br>
+            <strong>Michelle Ngai</strong><br>
+            <strong>613-314-4800</strong><br>
+            <a href="mailto:michelle.ngai@tbs-sct.gc.ca"><strong>michelle.ngai@tbs-sct.gc.ca</strong></a></p>
+        </div>
+    </div>	
+    </section>

--- a/content/fr/cppd-research.html
+++ b/content/fr/cppd-research.html
@@ -1,0 +1,31 @@
+---
+type: section
+layout: page
+title: cppd-research
+aliases: [/cppd-research/]
+---
+<section class="section page--outer-container-padding">
+    <div class="row">
+        <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+            <h2 class="section--title">Nous avons besoin de votre aide</h2>
+
+            <p>TRADUIREWe are conducting research to learn about medical professional’s experience with filling out Medical Reports for the Canada Pension Plan Disability Benefit. This research will help us understand medical professional’s challenges and limitations when providing medical information for their patients.</p>
+            <p>Si vous souhaitez participer, ou connaissez quelqu’un qui souhaite participer, veuillez communiquer avec <a href="mailto:michelle.ngai@tbs-sct.gc.ca">michelle.ngai@tbs-sct.gc.ca</a> pour obtenir plus de renseignements sur la participation.</p>
+            
+            <h2>Déroulement</h2>
+    
+            <p>TRADUIRETo do this we will ask you about your experience with filling out the CPP disability benefit medical report in a 30 minute phone conversation we will schedule at a time most convenient for you.</p>
+            <p>Remarques&nbsp;:</p>
+            <ul>
+                <li>La participation est <strong>volontaire</strong> et les participants peuvent arrêter à tout moment pour n’importe quelle raison.</li>
+                <li>Les réponses seront <strong>confidentielles</strong>, ce qui signifie qu’elles ne pourront pas être reliées à une personne.</li>
+                <li>Votre participation et vos réponses <strong>n’auront aucune incidence</strong> sur votre relation avec le SNC ou le gouvernement du Canada.</li>
+                <li>Le Service numérique canadien traite les renseignements personnels conformément à la Loi sur la protection des renseignements personnels. Les participants recevront une copie de notre déclaration de confidentialité.</li>
+            </ul>
+            <p>Pour toute autre question concernant cette recherche, veuillez communiquer avec&nbsp;:<br>
+            <strong>Michelle Ngai</strong><br>
+            <strong>613-314-4800</strong><br>
+            <a href="mailto:michelle.ngai@tbs-sct.gc.ca"><strong>michelle.ngai@tbs-sct.gc.ca</strong></a></p>
+        </div>
+    </div>	
+    </section>

--- a/content/fr/cppd-research.html
+++ b/content/fr/cppd-research.html
@@ -9,12 +9,12 @@ aliases: [/cppd-research/]
         <div class="col-sm-10 col-sm-offset-1 col-xs-12">
             <h2 class="section--title">Nous avons besoin de votre aide</h2>
 
-            <p>TRADUIREWe are conducting research to learn about medical professional’s experience with filling out Medical Reports for the Canada Pension Plan Disability Benefit. This research will help us understand medical professional’s challenges and limitations when providing medical information for their patients.</p>
+            <p>Nous menons une recherche afin de connaître l’expérience des professionnels médicaux lorsqu’ils remplissent les rapports médicaux des prestations d’invalidité du Régime de pensions du Canada. Cette recherche nous aidera à comprendre les enjeux et les limites rencontrés par ces professionnels lorsqu’ils fournissent des informations médicales à leurs patients.</p>
             <p>Si vous souhaitez participer, ou connaissez quelqu’un qui souhaite participer, veuillez communiquer avec <a href="mailto:michelle.ngai@tbs-sct.gc.ca">michelle.ngai@tbs-sct.gc.ca</a> pour obtenir plus de renseignements sur la participation.</p>
             
             <h2>Déroulement</h2>
     
-            <p>TRADUIRETo do this we will ask you about your experience with filling out the CPP disability benefit medical report in a 30 minute phone conversation we will schedule at a time most convenient for you.</p>
+            <p>Pour ceci, nous vous demanderons de nous parler de votre éxperience avec le remplissage d’un rapport médical des prestations d’invalidité du Régime de pensions du Canada. Une rencontre téléphonique de 30 minutes pourra être planifiée selon les disponibilités qui vous conviennent. Aucune préparation n’est requise.</p>
             <p>Remarques&nbsp;:</p>
             <ul>
                 <li>La participation est <strong>volontaire</strong> et les participants peuvent arrêter à tout moment pour n’importe quelle raison.</li>

--- a/content/fr/cppd-research.html
+++ b/content/fr/cppd-research.html
@@ -9,12 +9,12 @@ aliases: [/cppd-research/]
         <div class="col-sm-10 col-sm-offset-1 col-xs-12">
             <h2 class="section--title">Nous avons besoin de votre aide</h2>
 
-            <p>Nous menons une recherche afin de connaître l’expérience des professionnels médicaux lorsqu’ils remplissent les rapports médicaux des prestations d’invalidité du Régime de pensions du Canada. Cette recherche nous aidera à comprendre les enjeux et les limites rencontrés par ces professionnels lorsqu’ils fournissent des informations médicales à leurs patients.</p>
-            <p>Si vous souhaitez participer, ou connaissez quelqu’un qui souhaite participer, veuillez communiquer avec <a href="mailto:michelle.ngai@tbs-sct.gc.ca">michelle.ngai@tbs-sct.gc.ca</a> pour obtenir plus de renseignements sur la participation.</p>
+            <p>Nous menons une recherche afin de connaître l’expérience des professionnels médicaux lorsqu’ils remplissent les rapports médicaux pour les prestations d’invalidité du Régime de pensions du Canada. Cette recherche nous aidera à comprendre les limites et les enjeux rencontrés par ces professionnels lorsqu’ils fournissent des informations médicales à leurs patients.</p>
+            <p>Si vous souhaitez participer, ou si vous connaissez quelqu’un qui souhaite participer, veuillez communiquer avec <a href="mailto:michelle.ngai@tbs-sct.gc.ca">michelle.ngai@tbs-sct.gc.ca</a> pour obtenir plus de renseignements sur la participation.</p>
             
             <h2>Déroulement</h2>
     
-            <p>Pour ceci, nous vous demanderons de nous parler de votre éxperience avec le remplissage d’un rapport médical des prestations d’invalidité du Régime de pensions du Canada. Une rencontre téléphonique de 30 minutes pourra être planifiée selon les disponibilités qui vous conviennent. Aucune préparation n’est requise.</p>
+            <p>Pour cette recherche, nous vous demanderons de nous parler de votre expérience avec le remplissage d’un rapport médical pour les prestations d’invalidité du Régime de pensions du Canada. Une rencontre téléphonique de 30 minutes pourra être planifiée selon vos disponibilités. Aucune préparation n’est requise.</p>
             <p>Remarques&nbsp;:</p>
             <ul>
                 <li>La participation est <strong>volontaire</strong> et les participants peuvent arrêter à tout moment pour n’importe quelle raison.</li>

--- a/content/fr/cppd-research.html
+++ b/content/fr/cppd-research.html
@@ -7,25 +7,31 @@ aliases: [/cppd-research/]
 <section class="section page--outer-container-padding">
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-            <h2 class="section--title">Nous avons besoin de votre aide</h2>
+            <h2 class="section--title">Aidez-nous à améliorer le Programme de prestations d’invalidité du RPC (PPIRPC)</h2>
 
-            <p>Nous menons une recherche afin de connaître l’expérience des professionnels médicaux lorsqu’ils remplissent les rapports médicaux pour les prestations d’invalidité du Régime de pensions du Canada. Cette recherche nous aidera à comprendre les limites et les enjeux rencontrés par ces professionnels lorsqu’ils fournissent des informations médicales à leurs patients.</p>
-            <p>Si vous souhaitez participer, ou si vous connaissez quelqu’un qui souhaite participer, veuillez communiquer avec <a href="mailto:michelle.ngai@tbs-sct.gc.ca">michelle.ngai@tbs-sct.gc.ca</a> pour obtenir plus de renseignements sur la participation.</p>
+            <p>Nous menons une recherche pour tenter d’améliorer le Programme de prestations d’invalidité du Régime de pensions du Canada (PPIRPC).</p>
+
+            <p>Au Service numérique canadien, nous essayons d’en apprendre davantage sur le processus de demande de prestations et sur les difficultés rencontrées lors du remplissage du formulaire de demande.</p>
+
+            <p>Si vous désirez nous aider, ou si vous connaissez quelqu’un qui pourrait nous aider, veuillez communiquer avec <a href="mailto:antoine.garcia-suarez@tbs-sct.gc.ca">antoine.garcia-suarez@tbs-sct.gc.ca</a> pour savoir comment participer.</p>
             
-            <h2>Déroulement</h2>
+            <h2>Comment vous pouvez nous aider</h2>
     
-            <p>Pour cette recherche, nous vous demanderons de nous parler de votre expérience avec le remplissage d’un rapport médical pour les prestations d’invalidité du Régime de pensions du Canada. Une rencontre téléphonique de 30 minutes pourra être planifiée selon vos disponibilités. Aucune préparation n’est requise.</p>
-            <p>Remarques&nbsp;:</p>
-            <ul>
-                <li>La participation est <strong>volontaire</strong> et les participants peuvent arrêter à tout moment pour n’importe quelle raison.</li>
-                <li>Les réponses seront <strong>confidentielles</strong>, ce qui signifie qu’elles ne pourront pas être reliées à une personne.</li>
-                <li>Votre participation et vos réponses <strong>n’auront aucune incidence</strong> sur votre relation avec le SNC ou le gouvernement du Canada.</li>
-                <li>Le Service numérique canadien traite les renseignements personnels conformément à la Loi sur la protection des renseignements personnels. Les participants recevront une copie de notre déclaration de confidentialité.</li>
-            </ul>
+            <p>Nous aimerions parler avec vous par téléphone de votre expérience du processus de demande de prestations. La conversation ne devrait pas prendre plus de 30 minutes, et nous pouvons vous appeler au moment qui vous conviendra le mieux.</p>
+
+            <h2>Confidentialité de vos renseignements</h2>
+            <p>Votre participation est volontaire. Vous pourrez donc décider de ne plus participer à tout moment, peu importe la raison.</p>
+
+            <p>Nous (le Service numérique canadien) nous assurerons que vos réponses sont confidentielles, ce qui signifie qu’elles ne permettront pas de vous identifier.</p>
+
+            <p>Votre participation et vos réponses n’auront pas d’incidence sur votre relation avec le Service numérique canadien, Emploi et Développement social Canada, ou n’importe quelle autre institution du Gouvernement du Canada.</p>
+
+            <p>Nous traitons vos renseignements personnels conformément à la Loi sur la protection des renseignements personnels. Vous recevrez une copie de notre déclaration de confidentialité.</p>
+            
             <p>Pour toute autre question concernant cette recherche, veuillez communiquer avec&nbsp;:<br>
-            <strong>Michelle Ngai</strong><br>
-            <strong>613-314-4800</strong><br>
-            <a href="mailto:michelle.ngai@tbs-sct.gc.ca"><strong>michelle.ngai@tbs-sct.gc.ca</strong></a></p>
+            <strong>Antoine Garcia-Suarez</strong><br>
+            <strong>343-550-6001</strong><br>
+            <a href="mailto:antoine.garcia-suarez@tbs-sct.gc.ca"><strong>antoine.garcia-suarez@tbs-sct.gc.ca</strong></a></p>
         </div>
     </div>	
     </section>

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -112,3 +112,5 @@ developer-tools-btn:
   other: "Tools and resources"
 website-usability-testing:
   other: "Website usability testing"
+cppd-research:
+  other: "Canada Pension Plan Disability Benefit Research"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -113,4 +113,4 @@ developer-tools-btn:
 website-usability-testing:
   other: "Test d’utilisabilité du site Web"
 cppd-research:
-  other: "Recherche sur les prestations d’invalidité du RPC"
+  other: "Participez à notre recherche"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -112,3 +112,5 @@ developer-tools-btn:
   other: "Outils et ressources"
 website-usability-testing:
   other: "Test d’utilisabilité du site Web"
+cppd-research:
+  other: "TRADUIRE"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -113,4 +113,4 @@ developer-tools-btn:
 website-usability-testing:
   other: "Test d’utilisabilité du site Web"
 cppd-research:
-  other: "TRADUIRE"
+  other: "Recherche sur les prestations d’invalidité du RPC"


### PR DESCRIPTION
French page has a few phrases that need translation. Specifically, those with `TRADUIRE` in them, in these files:

- `content/fr/cppd-research.html`
- `i18n/fr.yaml`

Also, the page title (“Canada Pension Plan Disability Benefit Research” in English) breaks poorly across three lines, because it’s so long and the font size so big. A shorter title and/or a CSS tweak to accommodate the title would be 👌 

Page links:

- EN: https://digital-canada-ca-pr-838.herokuapp.com/cppd-research/
- FR: https://digital-canada-ca-pr-838.herokuapp.com/fr/cppd-research/