### PR TITLE
Added the french section navigation highlight fixes

### DIFF
--- a/content/fr/blog/_index.md
+++ b/content/fr/blog/_index.md
@@ -2,7 +2,7 @@
 type: section
 layout: blog
 image: blog.jpg
-title: blog
+title: blogue
 aliases: [/blog/]
 url: "/blogue/"
 ---

--- a/content/fr/our-team.html
+++ b/content/fr/our-team.html
@@ -2,7 +2,7 @@
 type: section
 layout: our-team
 ref: our-team
-title: our-team
+title: notre-equipe
 aliases: [/our-team/]
 url: /notre-equipe/
 lang: fr

--- a/content/fr/products/_index.html
+++ b/content/fr/products/_index.html
@@ -1,6 +1,6 @@
 ---
 type: section
-title: products
+title: produits
 layout: products
 aliases: [/products/]
 url: /produits/

--- a/content/fr/what-we-do.html
+++ b/content/fr/what-we-do.html
@@ -1,6 +1,6 @@
 ---
 type: section
-title: what-we-do
+title: ce-que-nous-faisons
 layout: page
 aliases: [/what-we-do/]
 url: /ce-que-nous-faisons/

--- a/content/fr/work-with-us/_index.html
+++ b/content/fr/work-with-us/_index.html
@@ -1,6 +1,6 @@
 ---
 type: section
-title: work-with-us
+title: travaillez-avec-nous 
 image: work-with-us.jpg
 layout: work-with-us
 aliases: [/work-with-us/]


### PR DESCRIPTION
It was just missing translation that broke the logic for this .active CSS class assignment- in french pages it was looking for the english section titles names instead.  

The navigation should now work as expected.