### PR TITLE
Removed Medium social icon from website's bottom contact banner

### DIFF
--- a/layouts/partials/social-links.html
+++ b/layouts/partials/social-links.html
@@ -32,13 +32,6 @@
         </li>
         <li>
             <div class="contact-icon">
-                <a title="Medium" href={{ index $.Site.Data.contact.medium (string ($.Site.Language))  "url" }}>
-                    <i class="icon-medium" aria-hidden="true"></i>
-                </a>
-            </div>
-        </li>
-        <li>
-            <div class="contact-icon">
                 <a title="Mailchimp" href={{ index $.Site.Data.contact.mailchimp (string ($.Site.Language)) "url" }}>
                     <i class="icon-mailchimp" aria-hidden="true"></i>
                 </a>


### PR DESCRIPTION
The Outreach team has decided to no longer publish blogs in the CDS/SNC Medium accounts. As a result, we this PR takes the Medium social icon off the bottom contact banner. 