### PR TITLE
Fixup Read The Blog on French site

### DIFF
--- a/content/fr/blog/_index.md
+++ b/content/fr/blog/_index.md
@@ -2,7 +2,7 @@
 type: section
 layout: blog
 image: blog.jpg
-title: blogue
+title: blog
 aliases: [/blog/]
 url: "/blogue/"
 ---

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -4,7 +4,7 @@ about-this-site:
   other: "À propos du site"
 aria-canada-website:
   other: "Gouvernement du Canada"
-blogue:
+blog:
   other: "Lire notre blogue"
 canada-ca-link:
   other: "https://www.canada.ca/fr.html"


### PR DESCRIPTION
This CL fixes the translation page for the 'Read The Blog' link on the French site.