### PR TITLE
added "Read all our blog posts" text (EN + FR) to Homepage blog section

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -122,6 +122,8 @@ products:
   other: "View our products"
 read-more:
   other: "Read full post"
+read-all-blogs:
+  other: "Read all our blog posts"
 rss-feed-url:
   other: "/blog/index.xml"
 skip-to-content:

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -122,6 +122,8 @@ products:
   other: "Découvrir nos produits"
 read-more:
   other: "Lire le billet"
+read-all-blogs:
+  other: "Lisez tous nos articles de blog"
 rss-feed-url:
   other: "/blogue/index.xml"
 skip-to-content:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -109,7 +109,7 @@
         <div class='col-xs-12 col-md-3'>
           <a href="{{ with $.Site.GetPage "blog" }}{{.URL}}{{ end }}"
              class='title-link'>
-            {{i18n "more-blogs" }}
+            {{i18n "read-all-blogs" }}
             <i class='fas fa-arrow-circle-right'></i>
           </a>
         </div>


### PR DESCRIPTION
The "Read all our blog posts" text is missing on the homepage, so this PR adds that line on the English + French sections. 

https://trello.com/c/m6xGyd6P/108-the-read-all-our-blog-posts-text-is-missing-on-the-homepage