### PR TITLE
Update Blog Page styles based on mockup

### DIFF
--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -932,15 +932,6 @@ span.livefr {
         color: $white;
       }
     }
-
-    @include mobile_only {
-      :first-child {
-        padding-left: 0;
-      }
-      :last-child {
-        padding-right: 0;
-      }
-    }
   }
 }
 

--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -839,7 +839,7 @@ span.livefr {
 
   .date {
     font-size: 1.5rem;
-    margin: 0rem 0 1rem 0;
+    color: $date-grey;
 
     @include tablet {
       font-size: 1.75rem;
@@ -848,9 +848,9 @@ span.livefr {
   }
 
   .author {
-    margin: 2rem 0 0 0;
     font-weight: 500;
     font-size: 2.25rem;
+    margin-bottom: 1.25rem;
   }
 
   .photo {
@@ -860,17 +860,17 @@ span.livefr {
     background-size: cover;
     background-position: center center;
 
-    @include tablet {
-      margin-top: 1rem;
-    }
-
     @include desktop {
       height: 20rem;
     }
   }
 
   h2 {
-    margin-top: 1.5rem;
+    margin-top: 0;
+
+    @include mobile_only {
+      margin-top: 1.5rem;
+    }
   }
 
   .text {
@@ -881,6 +881,10 @@ span.livefr {
     @include desktop {
       font-size: 2.25rem;
     }
+  }
+
+  .summary {
+    color: $icon-grey;
   }
 
   .readmore {

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,17 +1,24 @@
 <li class="post">
     <div class="row">
         <div class="col-xs-12 col-sm-4">
-            <div class="photo" role="img" aria-label='{{ index .Params "image-alt" }}' style="background-image: url('{{ .Params.thumb }}')"></div>
+            <div class="photo" role="img" aria-label='{{ index .Params "image-alt" }}'
+                style="background-image: url('{{ .Params.thumb }}')"></div>
         </div>
         <div class="col-xs-12 col-sm-8">
             <div class="text">
-                <div class="title"><a href="{{ .RelPermalink }}"><h2>{{ .Title | markdownify }}</h2></a></div>
+                <div class="title"><a href="{{ .RelPermalink }}">
+                        <h2>{{ .Title | markdownify }}</h2>
+                    </a></div>
+                <div class="date">
+                    {{ .Date.Format "Jan 2, 2006" }}
+                </div>
                 <div class="author">{{ .Params.author }}</div>
-            <div class="date">
-                {{ .Date.Format "Jan 2, 2006" }}
-            </div>
                 <div class="summary">{{ .Params.description | truncate 300 | markdownify }}</div>
-                <div class="readmore"><a href="{{ .Permalink }}" aria-label="Lire la suite de {{ .Params.title }}">{{ i18n "read-more" }}</a></div>
+                <div class="readmore">
+                    <a href="{{ .Permalink }}" aria-label="Lire la suite de {{ .Params.title }}">{{ i18n "read-more" }}
+                        <i class='fas fa-arrow-circle-right'></i>
+                    </a>
+                </div>
             </div>
         </div>
     </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -113,7 +113,6 @@
           <a href="{{ with $.Site.GetPage "blog" }}{{.URL}}{{ end }}"
              class='title-link'>
             {{i18n "read-all-blogs" }}
-            <!-- <i class='fas fa-arrow-circle-right'></i> -->
           </a>
           <i class='fas fa-arrow-circle-right'></i>
         </div>


### PR DESCRIPTION
This PR includes style changes to the Blog Page to match the design mockup: https://app.zeplin.io/project/5cb8c2c34ef04a6a787fbe65/screen/5d7961cd9cbbe89d9747bdc5

*still iterating on how to address responsive image sizes 

Trello:
https://trello.com/c/QW58G4wI/114-update-styles-for-blog-page-based-on-mockup