### PR TITLE
Removed comma between month and year for French blog dates

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -15,7 +15,7 @@
                     {{ end }}     
 
                     {{ if eq .Lang "fr" }}                
-                        {{ .Date.Day }} {{ index $.Site.Data.mois (printf "%d" .Date.Month) }}, {{ .Date.Year }} 
+                        {{ .Date.Day }} {{ index $.Site.Data.mois (printf "%d" .Date.Month) }} {{ .Date.Year }} 
                     {{ end }}                 
                 </div>
                 <div class="author">{{ .Params.author }}</div>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -29,7 +29,7 @@
               {{ end }}     
 
               {{ if eq .Lang "fr" }}                
-                 {{ .Date.Day }} {{ index $.Site.Data.mois (printf "%d" .Date.Month) }}, {{ .Date.Year }} 
+                 {{ .Date.Day }} {{ index $.Site.Data.mois (printf "%d" .Date.Month) }} {{ .Date.Year }} 
               {{ end }}  
               </time>          
               <span class="author" itemprop="author" itemscope itemtype="http://schema.org/Person">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -98,7 +98,7 @@
                       {{ .Date.Format "Jan 2, 2006" }}
                     {{ end }}     
                     {{ if eq .Lang "fr" }}                
-                      {{ .Date.Day }} {{ index $.Site.Data.mois (printf "%d" .Date.Month) }}, {{ .Date.Year }} 
+                      {{ .Date.Day }} {{ index $.Site.Data.mois (printf "%d" .Date.Month) }} {{ .Date.Year }} 
                    {{ end }}  
                   </div>
               </div>


### PR DESCRIPTION
This PR removes the comma between the month and year for blog dates in French, featured on:
- The homepage
- Blog page
- Individual blog posts

For example, dates now read as "30 août 2019" instead of "30 août, 2019"