### PR TITLE
Fix: in blog pagination, apply 'active' style to the link for the currently active page

### DIFF
--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -972,7 +972,7 @@ span.livefr {
     padding: 0 0.4em;
   }
 
-  .pagination:first-child a{
+  .pagination.active a{
     background: $primary-color;
     border: 2.5px solid $primary-color;
 

--- a/layouts/section/blog.html
+++ b/layouts/section/blog.html
@@ -43,7 +43,7 @@
             {{ $.Scratch.Set "page_number_flag" true }}
           {{ end }}
           {{ if eq ($.Scratch.Get "page_number_flag") true }}
-            <li class = "pagination {{ if eq . $paginator }}active{{ end }} " >
+            <li class = "pagination {{ if eq $paginator.PageNumber $trail.PageNumber }}active{{ end }}" >
               <a href="{{$trail.URL }}">{{ $trail.PageNumber }}</a>
             </li>
           {{ end }}


### PR DESCRIPTION
On the blog, in the pagination, the first page link (either **First** or **1**) is always shown with a yellow background, as if it's highlighted/selected. This doesn't seem right!

![Screenshot from 2019-10-01 01-03-48](https://user-images.githubusercontent.com/22176050/65935566-7c11c280-e3e7-11e9-9423-f80713c0754c.png)

In the template it looks like there's supposed to be an `active` class added to the `<li>` corresponding to the currently active page, but the `if eq` statement doesn't check the right thing. 

In the CSS, yellow background is applied to the first `.pagination` child: https://github.com/cds-snc/digital-canada-ca/blob/11be118d10ca58d8337b82a7bab8754167e0e736/assets/sass/cds/_sections.scss#L975

Meanwhile, the `active` class seems to just [add an invisible line through the middle of the element](https://github.com/pt8o/digital-canada-ca/blob/088e3402eade013a19f80ceafb65058648793ab5/assets/sass/cds/_sections.scss#L984).

This PR fixes the logic for the `active` class on the pagination links, and applies the yellow background style on this class.