### PR TITLE
Style fixes: Homepage + Tools & Resources page

### DIFF
--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -128,8 +128,10 @@
   }
 
   p {
-    margin-bottom: 0;
+    margin-bottom: 10px;
   }
+
+ 
 }
 
 .homepage--our-team {

--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -130,7 +130,6 @@
   p {
     margin-bottom: 10px;
   }
-
  
 }
 
@@ -488,8 +487,7 @@ span.livefr {
 }
 
 .work-in-progress--platform-module {
-  padding-top: 0;
-  padding-bottom: 0;
+  padding: 10px;
 }
 
 .work-in-progress--product-summary {

--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -373,7 +373,8 @@ span.livefr {
   }
 
 
-  h4 {
+  h4, 
+  .title-link {
     font-weight: 500;
     margin: 12px 0;
   
@@ -399,6 +400,10 @@ span.livefr {
   a {
     text-decoration: underline;
     color: $black;
+
+    &:hover {
+      color: $dark-grey;
+    }
   }
 
   h4.live::after,

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -19,11 +19,11 @@ title: Home
       <div class="col-md-8 col-xs-12">
         <h2>Working together</h2>
       </div>
-      <div class='col-xs-12 col-md-4 title-align'>
-        <a href="/partnerships" class="title-link">
+      <!-- <div class='col-xs-12 col-md-4 title-align'> -->
+        <!-- <a href="/partnerships" class="title-link">
           Learn more <i class='fas fa-arrow-circle-right'></i>
-        </a>
-      </div>
+        </a> -->
+      <!-- </div> -->
     </div>
     <div class="row">
       <div class="col-xs-12">
@@ -31,6 +31,9 @@ title: Home
            collaborate with people who work in government to address service
            delivery problems. And we test with people who need government
            services to find design solutions that are easy to use.</p>
+        <a href="/partnerships" class="title-link">
+            Learn more <i class='fas fa-arrow-circle-right'></i>
+        </a>
       </div>
     </div>
   </section>

--- a/content/en/tools-and-resources/guide-interviewing.html
+++ b/content/en/tools-and-resources/guide-interviewing.html
@@ -1,7 +1,7 @@
 ---
 type: section
 layout: page
-title: A guide to interviewing
+title: A guide to research interviewing
 aliases: [/guide-entrevue/]
 ---
 <section>

--- a/content/en/tools-and-resources/tools-and-resources/branch-review.md
+++ b/content/en/tools-and-resources/tools-and-resources/branch-review.md
@@ -9,6 +9,6 @@ contact:
     name: The Platform Team
 status: in-flight
 links:
-  - name: GitHub
+  - name: Kubernetes branch reviews
     url: "https://github.com/cds-snc/kubernetes-branch-review"
 ---

--- a/content/en/tools-and-resources/tools-and-resources/bundle-tracker.md
+++ b/content/en/tools-and-resources/tools-and-resources/bundle-tracker.md
@@ -9,6 +9,6 @@ contact:
     name: The Platform Team
 status: in-flight
 links:
-  - name: GitHub
+  - name: Bundle size tracker
     url: "https://github.com/cds-snc/bundle-size-tracker"
 ---

--- a/content/en/tools-and-resources/tools-and-resources/dependancy-checker.md
+++ b/content/en/tools-and-resources/tools-and-resources/dependancy-checker.md
@@ -9,6 +9,6 @@ contact:
     name: The Platform Team
 status: in-flight
 links:
-  - name: GitHub
+  - name: Dependency checker
     url: "https://github.com/cds-snc/dependency-checker"
 ---

--- a/content/en/tools-and-resources/tools-and-resources/evaluation-framework.md
+++ b/content/en/tools-and-resources/tools-and-resources/evaluation-framework.md
@@ -10,6 +10,6 @@ contact:
     name: Ross Ferguson
 status: in-flight
 links:
-  - name: Documentation
+  - name: CDS Product Evaluation Framework
     url: "/tools-and-resources/evaluation-framework/"
 ---

--- a/content/en/tools-and-resources/tools-and-resources/github-actions.md
+++ b/content/en/tools-and-resources/tools-and-resources/github-actions.md
@@ -9,7 +9,7 @@ contact:
     name: The Platform Team
 status: in-flight
 links:
-  - name: GitHub
+  - name: GitHub actions
     url: 'https://github.com/cds-snc/github-actions'
 ---
 

--- a/content/en/tools-and-resources/tools-and-resources/guide-interviewing.md
+++ b/content/en/tools-and-resources/tools-and-resources/guide-interviewing.md
@@ -10,6 +10,6 @@ contact:
     name: Colin MacArthur
 status: in-flight
 links:
-  - name: Documentation
+  - name: A guide to research interviewing
     url: "/tools-and-resources/guide-interviewing/"
 ---

--- a/content/en/tools-and-resources/tools-and-resources/guide-interviewing.md
+++ b/content/en/tools-and-resources/tools-and-resources/guide-interviewing.md
@@ -1,9 +1,9 @@
 ---
-title: A guide to interviewing
+title: A guide to research interviewing
 translationKey: guide-interviewing
 phase: live
 description: >-
-  A 101 on interviewing.
+  A 101 on research interviewing.
 phase: live
 contact:
   - email: colin.macarthur@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/tools-and-resources/guide-usability-testing.md
+++ b/content/en/tools-and-resources/tools-and-resources/guide-usability-testing.md
@@ -10,6 +10,6 @@ contact:
     name: Colin MacArthur
 status: in-flight
 links:
-  - name: Documentation
+  - name: A guide to usability testing
     url: "/tools-and-resources/guide-usability-testing/"
 ---

--- a/content/en/tools-and-resources/tools-and-resources/log-driver.md
+++ b/content/en/tools-and-resources/tools-and-resources/log-driver.md
@@ -9,6 +9,6 @@ contact:
     name: The Platform Team
 status: in-flight
 links:
-  - name: GitHub
+  - name: CDS log driver 🇨🇦
     url: "https://github.com/cds-snc/logDriver"
 ---

--- a/content/en/tools-and-resources/tools-and-resources/pii-tracker.md
+++ b/content/en/tools-and-resources/tools-and-resources/pii-tracker.md
@@ -9,6 +9,6 @@ contact:
     name: The Platform Team
 status: in-flight
 links:
-  - name: GitHub
+  - name: Personal identifiable information checking
     url: "https://github.com/cds-snc/pii-checker"
 ---

--- a/content/en/tools-and-resources/tools-and-resources/security-goals.md
+++ b/content/en/tools-and-resources/tools-and-resources/security-goals.md
@@ -9,6 +9,6 @@ contact:
     name: The Platform Team
 status: in-flight
 links:
-  - name: GitHub
+  - name: Security goals
     url: "https://github.com/cds-snc/security-goals"
 ---

--- a/content/en/tools-and-resources/tools-and-resources/time-to-interactive.md
+++ b/content/en/tools-and-resources/tools-and-resources/time-to-interactive.md
@@ -9,6 +9,6 @@ contact:
     name: The Platform Team
 status: in-flight
 links:
-  - name: GitHub
+  - name: Time to interactive tracking
     url: "https://github.com/cds-snc/tti-tools-tracker"
 ---

--- a/content/fr/tools-and-resources/guide-interviewing.html
+++ b/content/fr/tools-and-resources/guide-interviewing.html
@@ -1,7 +1,7 @@
 ---
 type: section
 layout: page
-title: Un guide pour les entrevues
+title: Un guide pour les entrevues de recherche
 aliases: [/tools-and-resources/guide-interviewing/]
 url: /outils-et-ressources/guide-entrevue/
 ---

--- a/content/fr/tools-and-resources/tools-and-resources/branch-review.md
+++ b/content/fr/tools-and-resources/tools-and-resources/branch-review.md
@@ -9,7 +9,7 @@ contact:
     name: Équipe des plateformes
 status: in-flight
 links:
-  - name: GitHub
+  - name: Examens Kubernetes des branches
     url: 'https://github.com/cds-snc/kubernetes-branch-review'
 ---
 

--- a/content/fr/tools-and-resources/tools-and-resources/bundle-tracker.md
+++ b/content/fr/tools-and-resources/tools-and-resources/bundle-tracker.md
@@ -9,7 +9,7 @@ contact:
     name: Équipe des plateformes
 status: in-flight
 links:
-  - name: GitHub
+  - name: Outil de suivi de la taille des paquets
     url: 'https://github.com/cds-snc/bundle-size-tracker'
 ---
 

--- a/content/fr/tools-and-resources/tools-and-resources/dependancy-recommendations.md
+++ b/content/fr/tools-and-resources/tools-and-resources/dependancy-recommendations.md
@@ -9,7 +9,7 @@ contact:
     name: Équipe des plateformes
 status: in-flight
 links:
-  - name: GitHub
+  - name: Vérificateur des dépendances
     url: 'https://github.com/cds-snc/dependency-checker'
 ---
 

--- a/content/fr/tools-and-resources/tools-and-resources/evaluation-framework.md
+++ b/content/fr/tools-and-resources/tools-and-resources/evaluation-framework.md
@@ -10,6 +10,6 @@ contact:
 phase: live
 status: in-flight
 links:
-  - name: Documentation
+  - name: Cadre d’évaluation des produits du SNC
     url: "/outils-et-ressources/cadre-devaluation/"
 ---

--- a/content/fr/tools-and-resources/tools-and-resources/github-actions.md
+++ b/content/fr/tools-and-resources/tools-and-resources/github-actions.md
@@ -9,7 +9,7 @@ contact:
     name: Équipe des plateformes
 status: in-flight
 links:
-  - name: GitHub
+  - name: Actions GitHub
     url: 'https://github.com/cds-snc/github-actions'
 ---
 

--- a/content/fr/tools-and-resources/tools-and-resources/guide-interviewing.md
+++ b/content/fr/tools-and-resources/tools-and-resources/guide-interviewing.md
@@ -10,6 +10,6 @@ contact:
 phase: live
 status: in-flight
 links:
-  - name: Documentation
+  - name: Un guide pour les entrevues de recherche
     url: "/outils-et-ressources/guide-entrevue/"
 ---

--- a/content/fr/tools-and-resources/tools-and-resources/guide-interviewing.md
+++ b/content/fr/tools-and-resources/tools-and-resources/guide-interviewing.md
@@ -1,9 +1,9 @@
 ---
-title: Un guide pour les entrevues
+title: Un guide pour les entrevues de recherche
 translationKey: guide-interviewing
 phase: live
 description: >-
-  L’abc des entrevues.
+  L’abc des entrevues de recherche.
 contact:
   - email: colin.macarthur@tbs-sct.gc.ca
     name: Colin MacArthur

--- a/content/fr/tools-and-resources/tools-and-resources/guide-usability-testing.md
+++ b/content/fr/tools-and-resources/tools-and-resources/guide-usability-testing.md
@@ -10,6 +10,6 @@ contact:
 phase: live
 status: in-flight
 links:
-  - name: Documentation
+  - name: Un guide pour les tests d’utilisabilité
     url: "/outils-et-ressources/guide-tests-d-utilisabilite/"
 ---

--- a/content/fr/tools-and-resources/tools-and-resources/log-driver.md
+++ b/content/fr/tools-and-resources/tools-and-resources/log-driver.md
@@ -9,7 +9,7 @@ contact:
     name: Équipe des plateformes
 status: in-flight
 links:
-  - name: GitHub
+  - name: Camelot du SNC 🇨🇦
     url: 'https://github.com/cds-snc/logDriver'
 ---
 

--- a/content/fr/tools-and-resources/tools-and-resources/pii-tracker.md
+++ b/content/fr/tools-and-resources/tools-and-resources/pii-tracker.md
@@ -9,7 +9,7 @@ contact:
     name: Équipe des plateformes
 status: in-flight
 links:
-  - name: GitHub
+  - name: Vérificateur de renseignements d’identification personnelle
     url: 'https://github.com/cds-snc/pii-checker'
 ---
 

--- a/content/fr/tools-and-resources/tools-and-resources/security-goals.md
+++ b/content/fr/tools-and-resources/tools-and-resources/security-goals.md
@@ -9,7 +9,7 @@ contact:
     name: Équipe des plateformes
 status: in-flight
 links:
-  - name: GitHub
+  - name: Objectifs de sécurité
     url: 'https://github.com/cds-snc/security-goals'
 ---
 

--- a/content/fr/tools-and-resources/tools-and-resources/time-to-interactive.md
+++ b/content/fr/tools-and-resources/tools-and-resources/time-to-interactive.md
@@ -9,7 +9,7 @@ contact:
     name: Équipe des plateformes
 status: in-flight
 links:
-  - name: GitHub
+  - name: Outil de suivi du temps d’interactivité
     url: 'https://github.com/cds-snc/tti-tools-tracker'
 ---
 

--- a/layouts/section/tools-and-resources.html
+++ b/layouts/section/tools-and-resources.html
@@ -1,4 +1,4 @@
-{{ define "title"}}
+{{ define "title" }}
 {{partial "menu.html" . }}
 <div class="page-banner">
   <div class="container">

--- a/layouts/tools-and-resources/list.html
+++ b/layouts/tools-and-resources/list.html
@@ -5,9 +5,9 @@
     <div class="col-sm-10 col-sm-offset-1 col-xs-12">
       <div class="title-container">
         <div>
-          <h3 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
+          <h4 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
             {{ .Params.title }}
-          </h3>
+          </h4>
         </div>
       </div>
     </div>
@@ -38,7 +38,7 @@
   <div class="row">
     <div class="col-sm-10 col-sm-offset-1 col-xs-12">
       <div class="work-in-progress--team">
-        <h4>Contact</h4>
+        <h5>Contact:</h5>
         {{ range .Params.contact }}
         <p><a href='mailto:{{.email}}'>{{ .name }}</a></p>
         {{ end }}
@@ -49,7 +49,7 @@
       <div class="work-in-progress--links">
         {{with .Params.links }}
           {{ if gt (len .) 0 }}
-            <h4>{{ i18n "links" }}</h4>
+            <h5>{{ i18n "links" }}:</h5>
             {{range .}}
               <p><a href="{{ .url }}">{{.name}}</a></p>
             {{ end }}

--- a/layouts/tools-and-resources/list.html
+++ b/layouts/tools-and-resources/list.html
@@ -6,7 +6,9 @@
       <div class="title-container">
         <div>
           <h4 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
-            {{ .Params.title }}
+            {{ range .Params.links }}
+              <a class="title-link" href="{{ .url }}">{{.name}}</a>
+            {{ end }}
           </h4>
         </div>
       </div>
@@ -35,6 +37,7 @@
   </div>
   <!-- End DESC -->
 
+  <!-- CONTACT -->
   <div class="row">
     <div class="col-sm-10 col-sm-offset-1 col-xs-12">
       <div class="work-in-progress--team">
@@ -44,8 +47,9 @@
         {{ end }}
       </div>
     </div>
+  <!-- END CONTACT -->
 
-    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+    <!-- <div class="col-sm-10 col-sm-offset-1 col-xs-12">
       <div class="work-in-progress--links">
         {{with .Params.links }}
           {{ if gt (len .) 0 }}
@@ -56,6 +60,6 @@
           {{ end }}
         {{ end }}
       </div>
-    </div>
+    </div> -->
   </div>
 </section>


### PR DESCRIPTION
This PR includes the following changes:
- Updating header styles for cards on Tools and Resources page to resemble Product cards
- Tools and resources cards now have phase labels
- Changed title and blurb in Tools and resources page from "Guide to interviewing" to "Guide to research interviewing"
- on Homepage: moved "Learn more" link to below paragraph for accessibility reasons