### PR TITLE
Homepage team section button styles

### DIFF
--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -159,12 +159,18 @@
   }
 
   .btn {
+    text-align: left;
+    width: 100%;
+
     @include mobile_only {
-      text-align: left;
       margin-bottom: 10px;
     }
-    @include tablet { text-align: left; }
-    @include desktop { text-align: right; }
+  }
+
+  .need-help {
+    h2 {
+      margin-top: 40px;
+    }
   }
 
   .fr-team-link {

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -35,7 +35,7 @@
  </div>
 
   <section class="section homepage--our-team">
-    <div class="container">
+    <div class="container meet-team">
       <div class="row">
         <div class="col-md-8 col-xs-12">
           <h2>{{ i18n "great-team" }} ...</h2>
@@ -56,7 +56,7 @@
          src="/img/cds/placeholder.gif"
          alt="{{ i18n "cds-team" }}" /> -->
 
-    <div class="container">
+    <div class="container need-help">
       <div class="row">
         <div class="col-md-8 col-xs-12">
           <h2>... {{ i18n "but-need-help" }}</h2>


### PR DESCRIPTION
This PR includes the following changes:
- Moved two buttons (Meet the team and Apply now) featured in the Team section of the Homepage to the left
- Added margin-top styles to "...but we need your help" heading to provide more spacing between elements 