### PR TITLE
[security-patch] serialize-javascript upgrade to 2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8476,9 +8476,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
-      "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
     },
     "serve-static": {
       "version": "1.13.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "netlify-cms": "^2.9.1",
     "set-value": "^3.0.1",
     "sharp": "^0.22.1",
+    "serialize-javascript": "^2.1.2",
     "snyk": "^1.221.0",
     "style-loader": "^0.23.1",
     "webpack": "^4.35.3"


### PR DESCRIPTION
Remediation
Upgrade serialize-javascript to version 2.1.1 or later. For example:

"dependencies": {
  "serialize-javascript": ">=2.1.1"
}
or…
"devDependencies": {
  "serialize-javascript": ">=2.1.1"
}