### PR TITLE
added ids and classes to elements for Google Tag Manager

### DIFF
--- a/layouts/section/join-our-team.en.html
+++ b/layouts/section/join-our-team.en.html
@@ -20,7 +20,7 @@
                                 {{ range $p := (where .Pages ".Params.archived" "==" false) }}
                                 <div class="col-xs-12 col-md-6">
                                     <div class="post border-primary ">
-                                        <h3><a href={{ .RelPermalink }}>{{ .Title }}</a></h3>
+                                        <h3><a class="job-posting-link" href={{ .RelPermalink }}>{{ .Title }}</a></h3>
                                     </div>
                                 </div>
                                 {{ end }}

--- a/layouts/section/partnerships.html
+++ b/layouts/section/partnerships.html
@@ -56,7 +56,7 @@
       <p>{{ i18n "partnerships-interested-in-chatting" }}</p>
     </div>
     <div class='col-md-5 col-xs-12'>
-      <a href="mailto:CDS-SNC@tbs-sct.gc.ca">
+      <a href="mailto:CDS-SNC@tbs-sct.gc.ca" id="partnerships-contact-us-link">
         {{ i18n "partnerships-contact-us" }}
       </a>
     </div>

--- a/layouts/tools-and-resources/list.html
+++ b/layouts/tools-and-resources/list.html
@@ -7,7 +7,7 @@
         <div>
           <h4 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
             {{ range .Params.links }}
-              <a class="title-link" href="{{ .url }}">{{.name}}</a>
+              <a class="title-link tool-resource-link" href="{{ .url }}">{{.name}}</a>
             {{ end }}
           </h4>
         </div>


### PR DESCRIPTION
This PR includes some additional IDs and classes assigned to the following elements (to track specific metrics through Google Tag Manager and Google Analytics):
- Added the ID "partnerships-contact-us-link" to "contact us" link on Partnerships page
- Added class of "tool-resource-link" to individual Tools/Resources title links
- Added class of "job-posing-link" to individual job postings on Join our team page