### PR TITLE
added Newsletter Banner to webpages

### DIFF
--- a/assets/sass/cds/_base.scss
+++ b/assets/sass/cds/_base.scss
@@ -174,9 +174,9 @@ html .container {
 
 .section--title {
 	color: $black;
-	font-size: 4rem;
 	font-weight: 300;
 	position: relative;
+	font-size: 4rem;
 	margin: 0 0 3.5rem 0;
 	padding: 0;
 	text-align: center;

--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -1213,10 +1213,12 @@ article.post {
 
   h2 {
     text-align: left;
+    font-size: 3.5rem;
+    margin-bottom: 2rem;
   }
 
   p {
-   font-size: 1.25em;
+   font-size: 2rem;
    line-height: 1.1em;
   }
 

--- a/layouts/section/join-our-team.en.html
+++ b/layouts/section/join-our-team.en.html
@@ -48,4 +48,7 @@
 
 {{ .Content }}
 
+<section class="section section--mailing-list">
+  {{ partial "mailing-list.html" }}
+</section>
 {{ end }}

--- a/layouts/section/join-our-team.fr.html
+++ b/layouts/section/join-our-team.fr.html
@@ -46,5 +46,8 @@
 </div>
 
 {{ .Content }}
+<section class="section section--mailing-list">
+  {{ partial "mailing-list.html" }}
+</section>
 
 {{ end}}

--- a/layouts/section/meet-the-team.html
+++ b/layouts/section/meet-the-team.html
@@ -118,4 +118,8 @@
     </div>
   </div>
 </section>
+
+<section class="section section--mailing-list">
+  {{ partial "mailing-list.html" }}
+</section>
 {{ end }}

--- a/layouts/section/partnerships.html
+++ b/layouts/section/partnerships.html
@@ -126,4 +126,8 @@
   </div>
 </section>
 
+<section class="section section--mailing-list">
+  {{ partial "mailing-list.html" }}
+</section>
+
 {{ end }}

--- a/layouts/section/tools-and-resources.html
+++ b/layouts/section/tools-and-resources.html
@@ -28,4 +28,7 @@
       </div>
   </section>
 </div>
+<section class="section section--mailing-list">
+  {{ partial "mailing-list.html" }}
+</section>
 {{ end }}


### PR DESCRIPTION
This PR adds the yellow newsletter subscribe banner (currently on on the homepage) to the following pages:
- Partnerships
- Tools and resources
- Join our team
- Meet the team
