### PR TITLE
French updates on Partnerships page

### DIFF
--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -65,17 +65,17 @@ partnerships-how-it-works:
 partnerships-how-we-do-it-1st:
   other: "Nous travaillons avec nos partenaires de façon ouverte, en partageant régulièrement nos progrès sur des plateformes publiques. Cette démarche crée une culture de l’apprentissage et favorise des pratiques exemplaires. Elle permet par le fait même aux ministères non partenaires de recourir à notre travail et d’<a href=\"https://numerique.canada.ca/outils-et-ressources/\">utiliser nos ressources</a> pour développer leurs propres services. "
 partnerships-how-we-do-it-2nd:
-  other: "Ensemble, nous formons une équipe qui suit la « <a href=\"https://numerique.canada.ca/2018/11/29/de-la-conception-dabord-aux-utilisateurs-dabord/#the-details\">méthode de développement agile</a> ». Nous commençons avec une phase de recherche intensive appelée <span class=\"term\">«&nbsp;découverte&nbsp;»</span>, où nous explorons les besoins des utilisateurs et les solutions possibles d’y répondre. Puis nous passons en phase <span class=\"term\">«&nbsp;alpha&nbsp;»</span>, où nous construisons des prototypes pour trouver et tester des moyens de satisfaire les besoins des utilisateurs. Vient ensuite la phase <span class=\"term\">«&nbsp;bêta&nbsp;»</span>, où nous faisons paraître une solution publique pour la tester de façon intensive. Enfin, dans la phase de <span class=\"term\">«&nbsp;mise en ligne&nbsp;»</span>, le service entre entièrement en fonction et continue d’être surveillé et amélioré."
+  other: "Ensemble, nous formons une équipe qui suit la « <a href=\"https://numerique.canada.ca/2018/11/29/de-la-conception-dabord-aux-utilisateurs-dabord/#the-details\">méthode de développement agile</a> ». Nous commençons avec une phase de recherche intensive appelée <span class=\"term\">«&nbsp;découverte&nbsp;»</span>, où nous explorons les besoins des utilisateurs et les solutions possibles d’y répondre. Puis nous passons en phase <span class=\"term\">«&nbsp;alpha&nbsp;»</span>, où nous construisons des prototypes pour trouver et tester des moyens de répondre aux besoins des utilisateurs. Vient ensuite la phase <span class=\"term\">«&nbsp;bêta&nbsp;»</span>, où nous faisons paraître une solution publique pour la tester de façon intensive. Enfin, dans la phase de <span class=\"term\">«&nbsp;mise en service&nbsp;»</span>, le service entre entièrement en fonction et continue d’être surveillé et amélioré."
 partnerships-how-we-do-it-3d:
-  other: "Entre la phase <span class=\"term\">bêta</span> et la <span class=\"term\">mise en ligne</span>, les membres de notre équipe se retirent. L’équipe du ministère partenaire continue alors à maintenir et à développer le service. Nous pouvons aider les partenaires à recruter leur équipe de service à partir de sources internes et externes."
+  other: "Entre la phase <span class=\"term\">bêta</span> et la <span class=\"term\">mise en service</span>, les membres de notre équipe se retirent. L’équipe du ministère partenaire continue alors à maintenir et à développer le service. Nous pouvons aider les partenaires à recruter leur équipe de service à partir de sources internes et externes."
 partnerships-how-we-do-it-4th:
-    other: "Avant le début de chaque phase, le SNC et le partenaire signent une entente de partenariat. Celle-ci décrit l’objectif et les résultats de la phase à venir, la façon d’y parvenir ainsi qu’un engagement à les réaliser."
+    other: "Avant le début de chaque phase, le Service numérique canadien et le partenaire signent une entente de partenariat. Celle-ci décrit l’objectif et les résultats de la phase à venir, la façon d’y parvenir ainsi qu’un engagement à les réaliser."
 partnerships-team:
   other: "Composition de l’équipe"
 partnerships-team-blurb:
-  other: "Chaque équipe est composée de membres du SNC et de membres du ministère partenaire, de sorte que nous pouvons partager nos façons de travailler et avoir une vision commune du problème que nous tentons de résoudre ensemble."
+  other: "Chaque équipe est composée de membres du Service numérique canadien et de membres du ministère partenaire, de sorte que nous pouvons partager nos façons de travailler et avoir une vision commune du problème que nous tentons de résoudre ensemble."
 partnerships-cds:
-  other: "En provenance du SNC :"
+  other: "En provenance du Service numérique canadien :"
 partnerships-cds-pm:
   other: "Un <a class=\"dark-bg\" href=\"https://numerique.canada.ca/2019/07/23/cest-quoi-au-juste-un-gestionnaire-de-produits/\">gestionnaire de produits</a> : cette personne établit la vision du service et les priorités de l’équipe"
 partnerships-cds-researcher:
@@ -95,11 +95,11 @@ partnerships-partner-experts:
 partnerships-partner-for-beta:
   other: "Des chercheurs, des concepteurs, des développeurs et des analystes politiques de façon à refléter ceux provenant du SNC (pour les phases <span class=\"term\">alpha</span> et <span class=\"term\">bêta</span>)"
 partnerships-partner-for-live:
-  other: "Une équipe multidisciplinaire autonome à temps plein dédiée à améliorer de façon continue le service (pour la phase de <span class=\"term\">mise en ligne</span>)"
+  other: "Une équipe multidisciplinaire autonome à temps plein dédiée à améliorer de façon continue le service (pour la phase de <span class=\"term\">mise en service</span>)"
 partnerships-interested-in-chatting:
   other: "Vous aimeriez discuter d’un partenariat potentiel?"
 partnerships-partner-overview:
-  other: "Voici un aperçu des produits sur lesquels le SNC travaille! Pour savois comment nous choisissons nos partenariats, lisez ce"
+  other: "Voici un aperçu des produits sur lesquels le SNC travaille! Pour savoir comment nous choisissons nos partenariats, lisez ce"
 partnerships-past:
   other: "Partenariats passés"
 partnerships-inflight:


### PR DESCRIPTION
This PR includes the following updates on the FR Partnerships page:
- Change “satisfaire les” for “répondre aux”
- Change “mise en ligne” for “mise en service” (3 times)
- Change “SNC” for “Service numérique canadien” (3 times)
- Change “savois” for “savoir”
