### PR TITLE
French vocabulary update on civic leave post

### DIFF
--- a/content/fr/blog/posts/congé-civique-intégrer-les-talents-du-privé-dans-le-secteur-technologique-public.md
+++ b/content/fr/blog/posts/congé-civique-intégrer-les-talents-du-privé-dans-le-secteur-technologique-public.md
@@ -1,10 +1,10 @@
 ---
 layout: blog
 title: >-
-  Congé civique : intégrer les talents du privé dans le secteur technologique
+  Congé pour fonctions civiques : intégrer les talents du privé dans le secteur technologique
   public
 description: >-
-  Le congé civique, c’est l’occasion pour un employé du secteur privé de
+  Le congé pour fonctions civiques, c’est l’occasion pour un employé du secteur privé de
   partager son expertise lors d’une période de service dans le secteur public ou
   dans la société civile.
 author: 'Andrea Gilbrook, chef du talent'
@@ -25,7 +25,7 @@ Au sein du gouvernement du Canada, il existe de nombreux fonctionnaires dévoué
 
 
 
-De fait, le congé civique est un moyen pour les entreprises et leurs employés de contribuer à la prestation de services gouvernementaux. Nous avons fondé notre approche sur le modèle mis à l’essai aux États-Unis. Dans ce modèle de congé civique, des employés de Microsoft et de Google ont eu la possibilité d’effectuer une période de service au sein du service numérique des États-Unis (USDS) ou de l’agence de services numériques 18F. Le congé civique, c’est l’occasion pour un employé du secteur privé de partager son expertise lors d’une période de service dans le secteur public ou dans la société civile. 
+De fait, le congé pour fonctions civiques est un moyen pour les entreprises et leurs employés de contribuer à la prestation de services gouvernementaux. Nous avons fondé notre approche sur le modèle mis à l’essai aux États-Unis. Dans ce modèle de congé, des employés de Microsoft et de Google ont eu la possibilité d’effectuer une période de service au sein du service numérique des États-Unis (USDS) ou de l’agence de services numériques 18F. Le congé pour fonctions civiques, c’est l’occasion pour un employé du secteur privé de partager son expertise lors d’une période de service dans le secteur public ou dans la société civile. 
 
 
 
@@ -33,17 +33,17 @@ Ce programme profite à l’employé, à l’organisation partenaire et au gouve
 
 
 
-Voilà ce qui fait la force du programme de congé civique. Il donne aux talents du secteur privé l’occasion de toucher de façon positive et profondément gratifiante la vie de leurs concitoyens. L’interaction avec le gouvernement est souvent obligatoire, mais ils peuvent rendre cette expérience formidable.
+Voilà ce qui fait la force du programme de congé pour fonctions civiques. Il donne aux talents du secteur privé l’occasion de toucher de façon positive et profondément gratifiante la vie de leurs concitoyens. L’interaction avec le gouvernement est souvent obligatoire, mais ils peuvent rendre cette expérience formidable.
 
 
 
-Ici au SNC, nous avons mis à l’essai notre programme de congé civique en janvier 2018 avec un ingénieur des données chevronné de Shopify. Au cours de ses trois mois dans une équipe de prestation de services du SNC, cet employé a découvert comment offrir des produits numériques dans un environnement gouvernemental. Il en a appris davantage sur l’application du bilinguisme, l’accessibilité et d’autres aspects des services inclusifs dans un contexte gouvernemental. Il a également eu l’occasion d’élaborer la façon dont le gouvernement fournira ses services numériques après son passage au SNC. Récemment, un développeur de logiciels de Google s’est aussi joint à nous pour une période de service dans notre bureau de Kitchener-Waterloo. 
+Ici au SNC, nous avons mis à l’essai notre programme de congé pour fonctions civiques en janvier 2018 avec un ingénieur des données chevronné de Shopify. Au cours de ses trois mois dans une équipe de prestation de services du SNC, cet employé a découvert comment offrir des produits numériques dans un environnement gouvernemental. Il en a appris davantage sur l’application du bilinguisme, l’accessibilité et d’autres aspects des services inclusifs dans un contexte gouvernemental. Il a également eu l’occasion d’élaborer la façon dont le gouvernement fournira ses services numériques après son passage au SNC. Récemment, un développeur de logiciels de Google s’est aussi joint à nous pour une période de service dans notre bureau de Kitchener-Waterloo. 
 
 
 
-Le programme de congé civique est une occasion pour les travailleurs du secteur technologique d’intégrer le secteur public afin de : découvrir ce qu’est vraiment la fonction publique, voir comment on peut bâtir un gouvernement numérique au service de tous les citoyens, et remettre en question certaines hypothèses qui peuvent exister. 
+Le programme de congé pour fonctions civiques est une occasion pour les travailleurs du secteur technologique d’intégrer le secteur public afin de : découvrir ce qu’est vraiment la fonction publique, voir comment on peut bâtir un gouvernement numérique au service de tous les citoyens, et remettre en question certaines hypothèses qui peuvent exister. 
 
 
 
-Il n’est pas nécessaire d’être fonctionnaire toute sa vie pour avoir un impact réel sur la vie des Canadiens. Si vous voulez mettre vos compétences numériques au profit du SNC en effectuant une période de service encadrée par le programme de congé civique, [veuillez communiquer avec nous](mailto:cds-snc@tbs-sct.gc.ca). Les entreprises peuvent aussi communiquer directement avec nous. Si vous cherchez à travailler avec le SNC et à profiter de tous les avantages que le congé civique offre à vos employés, [veuillez nous en informer](mailto:cds-snc@tbs-sct.gc.ca).
+Il n’est pas nécessaire d’être fonctionnaire toute sa vie pour avoir un impact réel sur la vie des Canadiens. Si vous voulez mettre vos compétences numériques au profit du SNC en effectuant une période de service encadrée par le programme de congé pour fonctions civiques, [veuillez communiquer avec nous](mailto:cds-snc@tbs-sct.gc.ca). Les entreprises peuvent aussi communiquer directement avec nous. Si vous cherchez à travailler avec le SNC et à profiter de tous les avantages que le congé pour fonctions civiques offre à vos employés, [veuillez nous en informer](mailto:cds-snc@tbs-sct.gc.ca).
 


### PR DESCRIPTION
This PR changes "congé civique" for "congé pour fonctions civiques"