### PR TITLE
Applying new design to Blog list page

### DIFF
--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -922,23 +922,60 @@ span.livefr {
 //
 ////////////////////////////////////////////////////
 .blogpost-list {
-  margin: 0 auto;
   padding: 0;
   list-style: none;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+
+  @include mobile_only {
+    flex-direction: column;
+    width: 80%;
+    margin: 0 auto 30px auto;
+  } 
 
   .post:first-child {
     padding-top: 0;
   }
 
   .post {
+    width: calc(50% - 30px/2);
+    margin-bottom: 30px;
+
+    @include mobile_only {
+      width: 100%;
+      margin: 0 auto 30px;
+    }
+  }
+
+  .post:nth-child(odd) {
+    margin-right: 30px;
+    
+    @include mobile_only {
+      margin-right: 0;
+    }
+  }
+
+  .post-container {
+    background-color: #FFFFFF;
+    box-shadow: 5px 8px 5px #E1E4E7;
+    border-bottom: 5px solid $primary-color;
     margin: 0 auto;
-    padding: 3rem 3rem;
-    border-bottom: #ccc 1px solid;
+    height: 700px;
+
+    @media (max-width: 1015px) {
+      height: 850px;
+    }
+
+    @include mobile_only {
+      height: 100%;
+    }
   }
 
   .date {
     font-size: 1.5rem;
     color: $section-bg-grey;
+    padding: 5px 0;
 
     @include tablet {
       font-size: 1.75rem;
@@ -952,84 +989,57 @@ span.livefr {
     margin-bottom: 1.25rem;
   }
 
-  .post-container {
-    display: flex;
-    flex-direction: row;
-
-    @media (max-width: 500px) {
-      display: block;
-    }
-  }
-
   .photo-container {
-    width: calc(30% - 30px/2);
-    margin-right: 30px;
-    height: 15rem;
+    height: 250px;
+    width: 100%;
 
-    @include desktop {
-      height: 20rem;
-    }
-
-    @include mobile_only {
-      margin-right: 20px;
-      width: calc(30% - 20px/2);
-    }
-
-    @media (max-width: 500px) {
-      width: 85%;
-      margin: 0 auto;
-      height: 20rem;
+    @include logo_break {
+      height: 200px;
     }
   }
 
   .photo {
-    display: block;
+    display: inline-block;
     height: 100%;
     width: 100%;
-    background-size: cover;
+    background-size: 100%;
     background-position: center center;
+    background-repeat: no-repeat;
   }
 
-  .text-container {
-    width: calc(70% - 30px/2);
-
-    @include mobile_only {
-      width: calc(70% - 20px/2);
-    }
-
-    @media (max-width: 500px) {
-      width: 85%;
-      margin: 0 auto;
-    }
+  .text {
+    line-height: 1.4;
   }
 
   h2 {
     margin-top: 0;
-
-    @media (max-width: 500px) {
-      margin-top: 1.5rem;
-    }
+    font-size: 24px;
   }
 
-  .text {
-    font-size: 2rem;
-    font-weight: 100;
-    line-height: 1.6em;
+  a {
+    text-decoration: none;
+  }
 
-    @include desktop {
-      font-size: 2.25rem;
-    }
+  .text-container {
+    padding: 25px;
+  }
+
+  .author {
+    font-size: 18.5px;
   }
 
   .summary {
     color: $icon-grey;
+    font-size: 18.5px;
   }
 
   .readmore {
     margin-top: 2rem;
 
     a {
+      font-size: 18px;
       display: inline-block;
+      text-decoration: underline;
     }
   }
 
@@ -1059,6 +1069,7 @@ span.livefr {
   & .blogpost-paginator {
     text-align: center;
     padding: 0;
+    width: 100%;
 
     a {
       text-decoration: none;
@@ -1073,11 +1084,13 @@ span.livefr {
   }
 }
 
-.blog-single {
-  background: $light-grey;
-}
-
 article.post {
+  padding: 6rem 0;
+
+  @include mobile_only {
+    padding: 3rem 0;
+  }
+
   img {
     width: 100%;
   }
@@ -1095,12 +1108,7 @@ article.post {
   .post-header {
     font-weight: 500;
     font-size: 1.5rem;
-    margin: 0rem 0 2rem 0;
-
-    .post-title-container {
-      background: $black;
-      padding: 25px 0;
-    }
+    margin: 1rem 0 2rem 0;
 
     time {
       display: block;

--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -1002,7 +1002,7 @@ span.livefr {
     display: inline-block;
     height: 100%;
     width: 100%;
-    background-size: 100%;
+    background-size: cover;
     background-position: center center;
     background-repeat: no-repeat;
   }

--- a/content/en/blog/posts/CDS-gets-its-first-CEO.md
+++ b/content/en/blog/posts/CDS-gets-its-first-CEO.md
@@ -9,7 +9,7 @@ date: '2018-03-09 09:00:00 -0400'
 image: /img/cds/blog-aaron-snow.jpg
 image-alt: Aaron Snow
 translationKey: CDS-gets-its-first-CEO
-thumb: /img/cds/thumbnails/blog-aaron-snow.jpg
+thumb: /img/cds/blog-aaron-snow.jpg
 processed: 1550672961644
 ---
 

--- a/content/en/blog/posts/a-conducting-user-research-with-NRCan.md
+++ b/content/en/blog/posts/a-conducting-user-research-with-NRCan.md
@@ -11,7 +11,7 @@ date: '2018-02-15 09:00:00 -0400'
 image: /img/cds/blog-conducting-user-research-with-NRCAN.jpg
 image-alt: Eman and Jennifer looking at the Value Proposition Canvas
 translationKey: conducting-user-research-with-NRCan
-thumb: /img/cds/thumbnails/blog-conducting-user-research-with-NRCAN.jpg
+thumb: /img/cds/blog-conducting-user-research-with-NRCAN.jpg
 processed: 1550687994416
 ---
 

--- a/content/en/blog/posts/always-a-challenge.md
+++ b/content/en/blog/posts/always-a-challenge.md
@@ -9,7 +9,7 @@ date: '2017-12-07 09:00:00 -0400'
 image: /img/cds/blog-always-a-challenge-2017.jpg
 image-alt: The homepage of the Impact Canada Challenge Platform
 translationKey: always-a-challenge
-thumb: /img/cds/thumbnails/blog-always-a-challenge-2017.jpg
+thumb: /img/cds/blog-always-a-challenge-2017.jpg
 processed: 1550672961655
 ---
 During our [engagement sessions](/beginning-the-conversation/full-report/), people told us that the government needed to identify ways to enable non-traditional players to work with government and co-create solutions.  

--- a/content/en/blog/posts/assessing-government-training-needs-for-the-future-of-digital-service-delivery.md
+++ b/content/en/blog/posts/assessing-government-training-needs-for-the-future-of-digital-service-delivery.md
@@ -16,7 +16,7 @@ image-alt: >-
   About 20 participants of a “Diversity in Digital Services” event sit around
   big round tables with laptops and sticky notes during a workshop.
 translationKey: assessing-training-needs
-thumb: /img/cds/thumbnails/tna-image.jpg
+thumb: /img/cds/tna-image.jpg
 processed: 1567559155888
 ---
 As the Government of Canada (GC) works to improve how it designs and delivers services, we can look to use new tools, methods and practices to help us build our capacity to get there. People — public servants — remain at the centre of these efforts. So, when we [teamed up](/2018/11/01/dear-colleagues-what-digital-training-do-you-need/) with the Faculty of Management at Dalhousie University late last year to better understand and assess the current training needs for digital disciplines across the GC, we started by talking to public servants. By directly engaging with them, we’re able to build a better understanding of their needs and how we can meet them. The full Report can be found on [Dalhousie’s website](https://bit.ly/30I14wC).

--- a/content/en/blog/posts/attracting-and-recruiting-top-talent-with-a-little-help-from-our-friends.md
+++ b/content/en/blog/posts/attracting-and-recruiting-top-talent-with-a-little-help-from-our-friends.md
@@ -10,7 +10,7 @@ date: 2019-03-18T15:00:00.000Z
 image: /img/cds/beetletoy.jpg
 image-alt: A yellow Volkswagen beetle toy on wooden shelf filled with books.
 translationKey: help-from-friends-HR
-thumb: /img/cds/thumbnails/beetletoy.jpg
+thumb: /img/cds/beetletoy.jpg
 processed: 1554413469898
 ---
 *[We get by with a little help from our friends](https://digital.canada.ca/2019/01/31/we-get-by-with-a-little-help-from-our-friends/) is a blog series profiling the amazing public servants who enable us and our partners to design and deliver better services.*

--- a/content/en/blog/posts/automated-testing-blog.md
+++ b/content/en/blog/posts/automated-testing-blog.md
@@ -13,7 +13,7 @@ image-alt: >-
   Three people are sitting around a table working on laptops. One person is
   pointing at the screen of a person across the table, who gives a thumbs-up.
 translationKey: automated-testing-blog
-thumb: /img/cds/thumbnails/blog-automated-testing.jpg
+thumb: /img/cds/blog-automated-testing.jpg
 processed: 1550672961659
 ---
 

--- a/content/en/blog/posts/b-colocating-with-NRCan.md
+++ b/content/en/blog/posts/b-colocating-with-NRCan.md
@@ -9,7 +9,7 @@ date: '2018-02-15 09:00:00 -0400'
 image: /img/cds/blog-colocating-with-NRCAN.jpg
 image-alt: Jason and Dave standing in front of the building of Natural Resources Canada
 translationKey: colocating-with-NRCan
-thumb: /img/cds/thumbnails/blog-colocating-with-NRCAN.jpg
+thumb: /img/cds/blog-colocating-with-NRCAN.jpg
 processed: 1550672961662
 ---
 

--- a/content/en/blog/posts/building-a-community-of-practice-by-offering-assessments-as-a-service.md
+++ b/content/en/blog/posts/building-a-community-of-practice-by-offering-assessments-as-a-service.md
@@ -14,7 +14,7 @@ image-alt: >-
   A hand holding a pen and writing a checklist of empty black squares on a
   notebook.
 translationKey: service-assessments
-thumb: /img/cds/thumbnails/checklist.jpg
+thumb: /img/cds/checklist.jpg
 processed: 1565980652710
 ---
 It takes a community of practice to transform government services. Last year, the Government of Canada introduced its [Digital Standards](https://www.canada.ca/en/government/system/digital-government/government-canada-digital-standards.html). These are a set of principles to help teams deliver better quality digital services for Canadians. Since their release, CDS has been exploring how departments can assess themselves against the Standards.

--- a/content/en/blog/posts/building-a-multidisciplinary-team-at-esdc-to-serve-people-better.md
+++ b/content/en/blog/posts/building-a-multidisciplinary-team-at-esdc-to-serve-people-better.md
@@ -14,7 +14,7 @@ date: 2019-06-19T13:00:00.000Z
 image: /img/cds/mic.jpg
 image-alt: condenser microphone with black background
 translationKey: building-a-multidisciplinary-team-at-ESDC-to-serve-people-better
-thumb: /img/cds/thumbnails/mic.jpg
+thumb: /img/cds/mic.jpg
 processed: 1561556657860
 ---
 As a manager under the Canada Pension Plan Service Improvement Strategy at Employment and Social Development Canada (ESDC) I helped create the multidisciplinary team at the Canadian Digital Service (CDS) working on improving the Canada Pension Plan (CPP) for people applying for disability benefits. 

--- a/content/en/blog/posts/building-a-research-plan.md
+++ b/content/en/blog/posts/building-a-research-plan.md
@@ -11,7 +11,7 @@ image-alt: >-
   Female hands unwrap brown paper with coffee to the left and purple flowers to
   the right.
 translationKey: building-a-research-plan
-thumb: /img/cds/thumbnails/blog-building-a-research-plan.jpg
+thumb: /img/cds/blog-building-a-research-plan.jpg
 processed: 1550672961664
 ---
 

--- a/content/en/blog/posts/building-inclusive-services-is-not-about-perfection.md
+++ b/content/en/blog/posts/building-inclusive-services-is-not-about-perfection.md
@@ -9,7 +9,7 @@ date: 2019-02-13T14:00:00.000Z
 image: /img/cds/_mg_9837-2.jpg
 image-alt: A man uses a split keyboard and other technologies to help use his computer.
 translationKey: not-perfect
-thumb: /img/cds/thumbnails/_mg_9837-2.jpg
+thumb: /img/cds/_mg_9837-2.jpg
 processed: 1550672961666
 ---
 Accessibility has a reputation for being hard and sometimes even unobtainable. But building inclusive services that work better for everyone isn’t about perfection. It’s about making an effort and seeing progress. When we bring that type of effort every day, transformation happens. On the flip side, when we don’t, the people who may need our services most can’t access them.

--- a/content/en/blog/posts/challenging-our-assumption.md
+++ b/content/en/blog/posts/challenging-our-assumption.md
@@ -6,7 +6,7 @@ date: '2018-01-16 09:00:00 -0400'
 image: /img/cds/blog-accessibility-2018.jpg
 image-alt: Keyboard with keys representing accessibility features
 translationKey: challenging-our-assumption
-thumb: /img/cds/thumbnails/blog-accessibility-2018.jpg
+thumb: /img/cds/blog-accessibility-2018.jpg
 processed: 1550672961668
 ---
 

--- a/content/en/blog/posts/civic-leave-embedding-private-sector-talent-in-government-tech.md
+++ b/content/en/blog/posts/civic-leave-embedding-private-sector-talent-in-government-tech.md
@@ -9,7 +9,7 @@ date: 2019-07-26T13:00:00.000Z
 image: /img/cds/small-maple-leafs.jpg
 image-alt: 'Photo of people side by side, each holding a maple leaf in their hand.'
 translationKey: civic-leave
-thumb: /img/cds/thumbnails/small-maple-leafs.jpg
+thumb: /img/cds/small-maple-leafs.jpg
 processed: 1564408446303
 ---
 It takes a variety of skilled people to create and deliver quality government digital services. Here at CDS, we use multi-disciplinary teams to build simple and effective services for Canadians. This requires a team with diverse skills and backgrounds and expertise from different sectors or even  countries. 

--- a/content/en/blog/posts/co-location-leave-no-team-member-behind.md
+++ b/content/en/blog/posts/co-location-leave-no-team-member-behind.md
@@ -9,7 +9,7 @@ date: 2019-04-10T13:45:10.709Z
 image: /img/cds/colourful-umbrellas.jpg
 image-alt: 'Colourful umbrellas floating side by side in the sky. '
 translationKey: cra-colocation
-thumb: /img/cds/thumbnails/colourful-umbrellas.jpg
+thumb: /img/cds/colourful-umbrellas.jpg
 processed: 1555070084840
 ---
 I can’t believe I’m writing a blog post! As a service owner for this project for the Canada Revenue Agency, it’s one of the things in a long list of “firsts” I’ve encountered since co-locating with our partners at the Canadian Digital Service just over a month ago. 

--- a/content/en/blog/posts/coding-is-a-team-activity.md
+++ b/content/en/blog/posts/coding-is-a-team-activity.md
@@ -9,7 +9,7 @@ date: '2018-04-24 09:00:00 -0400'
 image: /img/cds/blog-team-coding.jpg
 image-alt: A computer screen displays 200 lines of JavaScript code in Sublime Text.
 translationKey: coding-is-a-team-activity
-thumb: /img/cds/thumbnails/blog-team-coding.jpg
+thumb: /img/cds/blog-team-coding.jpg
 processed: 1550672961670
 ---
 

--- a/content/en/blog/posts/community-driven-coding.md
+++ b/content/en/blog/posts/community-driven-coding.md
@@ -10,7 +10,7 @@ date: '2018-07-17 09:00:00 -0400'
 image: /img/cds/blog-david-https-header.jpg
 image-alt: 'Illustration of two people painting a giant, physical web page.'
 translationKey: community-driven-coding
-thumb: /img/cds/thumbnails/blog-david-https-header.jpg
+thumb: /img/cds/blog-david-https-header.jpg
 processed: 1550672961671
 ---
 

--- a/content/en/blog/posts/dear-colleagues-what-digital-training-do-you-need.md
+++ b/content/en/blog/posts/dear-colleagues-what-digital-training-do-you-need.md
@@ -11,7 +11,7 @@ date: 2018-11-01T19:30:00.000Z
 image: /img/cds/screen-shot-2018-11-01-at-3.42.39-pm.jpg
 image-alt: A collection of work tools.
 translationKey: digital-training-needs
-thumb: /img/cds/thumbnails/screen-shot-2018-11-01-at-3.42.39-pm.jpg
+thumb: /img/cds/screen-shot-2018-11-01-at-3.42.39-pm.jpg
 processed: 1550672961672
 ---
 **Update:** *Building Digital Capacity: Report on the Training Needs Analysis is now available on Dalhousie University's website! [Read about what we heard here](/2019/08/30/assessing-government-training-needs-for-the-future-of-digital-service-delivery/). Thank you to all the public servants who took the survey. Your responses will help shape learning on emerging digital disciplines.* 

--- a/content/en/blog/posts/designing-for-canada.md
+++ b/content/en/blog/posts/designing-for-canada.md
@@ -9,7 +9,7 @@ date: '2017-09-21 09:00:00 -0400'
 image: /img/cds/blog-designing-for-canada-2017.jpg
 image-alt: 'Chris Govias, Chief of Design at CDS'
 translationKey: designing-for-canada
-thumb: /img/cds/thumbnails/blog-designing-for-canada-2017.jpg
+thumb: /img/cds/blog-designing-for-canada-2017.jpg
 processed: 1550672961674
 ---
 After a short sabbatical and a decade in the U.K., I'm delighted to announce that I'm going to be the first Chief of Design with the Canadian Digital Service, a new initiative by the Government of Canada.

--- a/content/en/blog/posts/developing-an-evaluation-framework-for-product-and-service-delivery.md
+++ b/content/en/blog/posts/developing-an-evaluation-framework-for-product-and-service-delivery.md
@@ -12,7 +12,7 @@ date: 2019-06-13T17:20:00.000Z
 image: /img/cds/four-frames.jpg
 image-alt: Four black empty picture frames hanging side by side on a white wall.
 translationKey: evaluation-framework
-thumb: /img/cds/thumbnails/four-frames.jpg
+thumb: /img/cds/four-frames.jpg
 processed: 1560520010223
 
 ---

--- a/content/en/blog/posts/discovery-phase-understanding-the-problem.md
+++ b/content/en/blog/posts/discovery-phase-understanding-the-problem.md
@@ -15,7 +15,7 @@ image-alt: >-
   Two people sit at a table with papers, using hand gestures as though
   discussing their work.
 translationKey: discovery-phase-understanding-the-problem
-thumb: /img/cds/thumbnails/blog-discovery.jpg
+thumb: /img/cds/blog-discovery.jpg
 processed: 1550672961676
 ---
 

--- a/content/en/blog/posts/discussing-digital-in-french.md
+++ b/content/en/blog/posts/discussing-digital-in-french.md
@@ -13,7 +13,7 @@ date: '2017-09-29 09:00:00 -0400'
 image: /img/cds/blog-discussing-digital-in-french-2017.jpg
 image-alt: Computer keyboard with the flag of France on a key
 translationKey: discussing-digital-in-french
-thumb: /img/cds/thumbnails/blog-discussing-digital-in-french-2017.jpg
+thumb: /img/cds/blog-discussing-digital-in-french-2017.jpg
 processed: 1550672961678
 ---
 Tomorrow, September 30, is International Translation Day. For me, talking about digital in French is a challenge: properly naming new technologies and *especially* - especially - not losing sight of the fact that we are addressing "real people". **Thinking of users first, making them central to our work - that also comes into play with the words that we choose**.

--- a/content/en/blog/posts/distance-makes-the-team-grow-stronger.md
+++ b/content/en/blog/posts/distance-makes-the-team-grow-stronger.md
@@ -12,7 +12,7 @@ image-alt: >-
   Five members of a team communicating to each other using different devices,
   and in different locations.
 translationKey: distributed-pm
-thumb: /img/cds/thumbnails/distributed-pm-blog.jpg
+thumb: /img/cds/distributed-pm-blog.jpg
 processed: 1575304320615
 ---
 It was a cold January day when I first started at The Canadian Digital Service (CDS). I went to the Ottawa office for a two-week onboarding session, after which I’d go back home to a *slightly warmer* Kitchener-Waterloo, to work full-time. 

--- a/content/en/blog/posts/ear-to-the-ground-using-the-words-people-use.md
+++ b/content/en/blog/posts/ear-to-the-ground-using-the-words-people-use.md
@@ -14,7 +14,7 @@ image-alt: >-
   beside her. The other has a tablet in front of him, with a glass of water to
   his right. 
 translationKey: using-words-people-use
-thumb: /img/cds/thumbnails/bag-and-hands.jpg
+thumb: /img/cds/bag-and-hands.jpg
 processed: 1560358863721
 
 ---

--- a/content/en/blog/posts/eva’s-exit-interview-take-a-walk-on-the-private-side.md
+++ b/content/en/blog/posts/eva’s-exit-interview-take-a-walk-on-the-private-side.md
@@ -12,7 +12,7 @@ image-alt: >-
   more silly, including a portrait of her mascot, Mr. Pinchey, an orange stuffed
   animal crab wearing a shark hat.
 translationKey: take-a-walk-on-the-private-side
-thumb: /img/cds/thumbnails/eva-blog.jpg
+thumb: /img/cds/eva-blog.jpg
 processed: 1559833506993
 ---
 One of our beloved developers and OG team member Eva Demers-Brett is leaving us this month to embark on an exciting opportunity in the private sector 😢. It’ll be her first time working outside the public service during her career as a developer, so we wanted to capture her insights and find out what lessons she’ll bring with her as she takes a walk on the private side.

--- a/content/en/blog/posts/framing-a-design-problem.md
+++ b/content/en/blog/posts/framing-a-design-problem.md
@@ -13,7 +13,7 @@ date: '2017-10-24 09:00:00 -0400'
 image: /img/cds/blog-framing-a-design-problem-2017.jpg
 image-alt: A room full of empty chairs at a citizenship ceremony
 translationKey: framing-a-design-problem
-thumb: /img/cds/thumbnails/blog-framing-a-design-problem-2017.jpg
+thumb: /img/cds/blog-framing-a-design-problem-2017.jpg
 processed: 1550672961688
 ---
 It’s an exciting time at the Canadian Digital Service (CDS) as we start rolling up our sleeves and digging into our first service delivery projects, while we are working hard on [choosing our next partnership opportunities](/2017/08/24/picking-our-projects/). One of our partners in these early projects is Immigration, Refugees and Citizenship Canada (IRCC).

--- a/content/en/blog/posts/from-build-first-to-users-first.md
+++ b/content/en/blog/posts/from-build-first-to-users-first.md
@@ -14,7 +14,7 @@ image-alt: >-
   stacked blocks with a ladder and two people on top, beside three stacked
   blocks with a ladder and a group of people on top.
 translationKey: from-build-first-to-users-first
-thumb: /img/cds/thumbnails/fullsizeoutput_55.jpg
+thumb: /img/cds/fullsizeoutput_55.jpg
 processed: 1550672961690
 ---
 At the Canadian Digital Service (CDS), we are excited to be working with government departments to build better [services](https://digital.canada.ca/products/). We are also keen to share lessons we learn from these experiences to hopefully help folks with their own work.

--- a/content/en/blog/posts/from-design-to-development-working-across-disciplines-at-cds.md
+++ b/content/en/blog/posts/from-design-to-development-working-across-disciplines-at-cds.md
@@ -11,7 +11,7 @@ image-alt: >-
   An aerial view of an intersection where cars are stopped and people are
   waiting to cross the street.
 translationKey: working-across-disciplines
-thumb: /img/cds/thumbnails/yoel-j-gonzalez-304137-unsplash.jpg
+thumb: /img/cds/yoel-j-gonzalez-304137-unsplash.jpg
 processed: 1550672961692
 ---
 I took Interactive Multimedia and Design in school, where I learned a solid foundation in both design and development. Professors said we’d likely end up working between these two disciplines, as a bridge. Towards the end of my program, I chose to focus primarily on design. I didn’t realize that, some short years later, I’d be learning how to code again.

--- a/content/en/blog/posts/getting-external-wi-fi-in-government-offices.md
+++ b/content/en/blog/posts/getting-external-wi-fi-in-government-offices.md
@@ -10,7 +10,7 @@ date: 2019-02-06T14:00:31.390Z
 image: /img/cds/img_20190206_121320.jpg
 image-alt: A person connecting their MacBook to a handheld MiFi device.
 translationKey: external-wifi
-thumb: /img/cds/thumbnails/img_20190206_121320.jpg
+thumb: /img/cds/img_20190206_121320.jpg
 processed: 1550672961697
 ---
 Having access to modern tools is a prerequisite for delivering modern digital services. We’ve written previously about [the importance of modern tools](https://digital.canada.ca/2018/06/27/tools-to-do-good-work/), like MacBooks and Linux-based laptops, for design and software development work.

--- a/content/en/blog/posts/getting-prototypes-out-the-door.md
+++ b/content/en/blog/posts/getting-prototypes-out-the-door.md
@@ -12,7 +12,7 @@ image-alt: >-
   The initial CDS delivery team finalizing and testing the first version of the
   e-briefing app.
 translationKey: getting-prototypes-out-the-door
-thumb: /img/cds/thumbnails/blog-ebriefing-2018.jpg
+thumb: /img/cds/blog-ebriefing-2018.jpg
 processed: 1550672961702
 ---
 

--- a/content/en/blog/posts/getting-up-to-speed-on-an-agile-team.md
+++ b/content/en/blog/posts/getting-up-to-speed-on-an-agile-team.md
@@ -9,7 +9,7 @@ date: '2018-10-16 09:00:00 -0400'
 image: /img/cds/blog-up-to-speed.jpg
 image-alt: Car dashboard showing speedometer.
 translationKey: getting-up-to-speed
-thumb: /img/cds/thumbnails/blog-up-to-speed.jpg
+thumb: /img/cds/blog-up-to-speed.jpg
 processed: 1550672961704
 ---
 

--- a/content/en/blog/posts/global-skills-strategy.md
+++ b/content/en/blog/posts/global-skills-strategy.md
@@ -15,7 +15,7 @@ date: '2018-10-12 09:00:00 -0400'
 image: /img/cds/blog-global-skills-strategy.jpg
 image-alt: A woman in silver shoes standing on a subway platform.
 translationKey: global-skills-strategy
-thumb: /img/cds/thumbnails/blog-global-skills-strategy.jpg
+thumb: /img/cds/blog-global-skills-strategy.jpg
 processed: 1550672961706
 ---
 

--- a/content/en/blog/posts/growing-service-design-and-design-research-at-pspc.md
+++ b/content/en/blog/posts/growing-service-design-and-design-research-at-pspc.md
@@ -9,7 +9,7 @@ date: 2019-07-30T13:00:00.000Z
 image: /img/cds/pspc-team-1.jpg
 image-alt: A photo of PSPC’s Design Research team.
 translationKey: emilio-pspc
-thumb: /img/cds/thumbnails/pspc-team-1.jpg
+thumb: /img/cds/pspc-team-1.jpg
 processed: 1564604599900
 ---
 When we talk about service design in government, the conversation is focused on creating amazing citizen-facing services. This is true to our core purpose - we work to serve citizens and therefore need to create services that put citizens at their core.

--- a/content/en/blog/posts/hello-world-canada.md
+++ b/content/en/blog/posts/hello-world-canada.md
@@ -10,7 +10,7 @@ date: '2018-10-19 09:00:00 -0400'
 image: /img/cds/blog-hello-world-canada.jpg
 image-alt: Red maple leaves.
 translationKey: hello-world-canada
-thumb: /img/cds/thumbnails/blog-hello-world-canada.jpg
+thumb: /img/cds/blog-hello-world-canada.jpg
 processed: 1550672961708
 ---
 

--- a/content/en/blog/posts/helping-low-income-canadians-complete-their-taxes.md
+++ b/content/en/blog/posts/helping-low-income-canadians-complete-their-taxes.md
@@ -12,7 +12,7 @@ date: 2018-11-07T16:00:00.000Z
 image: /img/cds/img_0880.jpg
 image-alt: Someone filling out taxes on paper and holding a mug.
 translationKey: Canadians-complete-taxes
-thumb: /img/cds/thumbnails/img_0880.jpg
+thumb: /img/cds/img_0880.jpg
 processed: 1550672961711
 ---
 Every day, Canadians use government services. As public servants, we exist to design and deliver those services. Many of those services are mission critical to people who need them. What this means is that when people need government services, they are often facing significant hardship.  

--- a/content/en/blog/posts/hiring-at-cds.md
+++ b/content/en/blog/posts/hiring-at-cds.md
@@ -10,7 +10,7 @@ date: '2018-01-09 09:00:00 -0400'
 image: /img/cds/blog-hiring-2018.jpg
 image-alt: Team members of CDS
 translationKey: hiring-at-cds
-thumb: /img/cds/thumbnails/blog-hiring-2018.jpg
+thumb: /img/cds/blog-hiring-2018.jpg
 processed: 1550672961713
 ---
 There’s a lot of interest on how we are recruiting and staffing up a digital services team that can hit the ground running and help solve service challenges across the Government. This is why I am super excited to be writing a blog post about our hiring practices at CDS.

--- a/content/en/blog/posts/how-communications-and-data-can-live-happily-ever-after.md
+++ b/content/en/blog/posts/how-communications-and-data-can-live-happily-ever-after.md
@@ -9,7 +9,7 @@ date: 2019-11-28T13:46:22.820Z
 image: /img/cds/dreaming-of-words.jpg
 image-alt: Illustration of a girl daydreaming about writing and books.
 translationKey: Data-driven-comms
-thumb: /img/cds/thumbnails/dreaming-of-words.jpg
+thumb: /img/cds/dreaming-of-words.jpg
 processed: 1575304320638
 ---
 ## Once upon a time...

--- a/content/en/blog/posts/how-meeting-face-to-face-builds-team-trust.md
+++ b/content/en/blog/posts/how-meeting-face-to-face-builds-team-trust.md
@@ -9,7 +9,7 @@ date: 2019-01-10T14:00:00.000Z
 image: /img/cds/groupvac_cds.jpg
 image-alt: The team members all stand together and smile for a photo.
 translationKey: VAC-CDS-visit
-thumb: /img/cds/thumbnails/groupvac_cds.jpg
+thumb: /img/cds/groupvac_cds.jpg
 processed: 1550672961717
 ---
 As a business analyst consulting at Veterans Affairs Canada (VAC) in Charlottetown partnered with the Canadian Digital Service, it’s been challenging to join an in-progress project when teams are located in different cities. Even with a daily remote standup, you don’t get to know who everybody is, and it’s hard to match a voice to a name when you’ve never met.

--- a/content/en/blog/posts/how-running-an-ama-in-government-was-like-running-a-relay-race.md
+++ b/content/en/blog/posts/how-running-an-ama-in-government-was-like-running-a-relay-race.md
@@ -11,7 +11,7 @@ date: 2019-08-20T14:12:38.386Z
 image: /img/cds/ama-banner.jpg
 image-alt: A bird’s-eye view of 4 relay racers running on a track in 4 parallel lanes.
 translationKey: relay-race-ama
-thumb: /img/cds/thumbnails/ama-banner.jpg
+thumb: /img/cds/ama-banner.jpg
 processed: 1566597193076
 ---
 Imagine this: you’re the starting runner in a 400m relay race. You get into the starting position, the gun goes off, and you sprint as hard as you can. As you reach that first 100m mark, you notice there’s no one to pass the baton to. Oh no. Now you have to sprint the whole relay race and keep the momentum going by yourself. 

--- a/content/en/blog/posts/how-we-measured-our-delivery-with-vac-and-why-its-useful.md
+++ b/content/en/blog/posts/how-we-measured-our-delivery-with-vac-and-why-its-useful.md
@@ -10,7 +10,7 @@ date: 2019-04-24T13:00:00.000Z
 image: /img/cds/VACBenchmarkBlogENG.jpg
 image-alt: A screenshot of the tool *Find Benefits and services’* landing page.
 translationKey: by-the-numbers
-thumb: /img/cds/thumbnails/VACBenchmarkBlogENG.jpg
+thumb: /img/cds/VACBenchmarkBlogENG.jpg
 processed: 1555597567075
 ---
 If you measure it, you know if you're making it better. That's why at the Canadian Digital Service we like to have a measure of where we are before we start iterating. That way, we know how far we've come after improving a product or service.

--- a/content/en/blog/posts/human-story-behind-citizenship.md
+++ b/content/en/blog/posts/human-story-behind-citizenship.md
@@ -12,7 +12,7 @@ image-alt: >-
   People stand to take an oath of Canadian Citizenship at a ceremony in
   Vancouver.
 translationKey: human-story-behind-citizenship
-thumb: /img/cds/thumbnails/blog-human-story-citizenship1.jpg
+thumb: /img/cds/blog-human-story-citizenship1.jpg
 processed: 1550672961718
 ---
 

--- a/content/en/blog/posts/in-this-together.md
+++ b/content/en/blog/posts/in-this-together.md
@@ -9,7 +9,7 @@ date: '2017-11-20 09:00:00 -0400'
 image: /img/cds/blog-in-this-together-2017.jpg
 image-alt: The Ontario Digital Service team
 translationKey: in-this-together
-thumb: /img/cds/thumbnails/blog-in-this-together-2017.jpg
+thumb: /img/cds/blog-in-this-together-2017.jpg
 processed: 1550672961719
 ---
 A few weeks ago, I had the chance to participate in the [Connected150 conference](http://www.connected150.ca) and spend some time with our colleagues in the Canadian Digital Service (CDS). 

--- a/content/en/blog/posts/innovating-from-the-inside-out-at-esdc.md
+++ b/content/en/blog/posts/innovating-from-the-inside-out-at-esdc.md
@@ -14,7 +14,7 @@ image-alt: >-
   A quote that reads “But all of a sudden we were thrown into a world of Trello,
   Slack and FunRetro” on a light blue background over a photo of the woods
 translationKey: innovating-esdc
-thumb: /img/cds/thumbnails/esdc-innovation-en.jpg
+thumb: /img/cds/esdc-innovation-en.jpg
 processed: 1563891109787
 ---
 At Employment and Social Development Canada (ESDC), we’ve really started to embrace the idea of being innovative in how we provide services and information to our clients. What seems to be much harder, at times, is opening our doors internally to new and innovative ways of doing our day-to-day work.

--- a/content/en/blog/posts/introducing-notify.md
+++ b/content/en/blog/posts/introducing-notify.md
@@ -12,7 +12,7 @@ image-alt: >-
   A phone and laptop on a white desk, with both screens featuring the Notify
   service homepage in English and French. 
 translationKey: introducing-notify
-thumb: /img/cds/thumbnails/introducing-notify.jpg
+thumb: /img/cds/introducing-notify.jpg
 processed: 1575304320646
 ---
 Imagine a scenario where every time you use a government service, all necessary information gets to where it’s going, when it needs to, and all along, you’re confident that it will. We’ve spent the past few months working to create a service that can help the Government of Canada meet this goal. 

--- a/content/en/blog/posts/ircc-to-cds.md
+++ b/content/en/blog/posts/ircc-to-cds.md
@@ -12,7 +12,7 @@ date: '2018-09-11 09:00:00 -0400'
 image: /img/cds/blog-amir.jpg
 image-alt: Amir in the CDS workspace.
 translationKey: ircc-to-cds
-thumb: /img/cds/thumbnails/blog-amir.jpg
+thumb: /img/cds/blog-amir.jpg
 processed: 1550672961720
 ---
 

--- a/content/en/blog/posts/its-about-people.md
+++ b/content/en/blog/posts/its-about-people.md
@@ -9,7 +9,7 @@ date: '2017-07-25 10:00:00 -0400'
 image: /img/cds/blog-its-about-people-2017.jpg
 image-alt: Anatole Papadopoulos speaking to some CDS staff
 translationKey: its-about-people
-thumb: /img/cds/thumbnails/blog-its-about-people-2017.jpg
+thumb: /img/cds/blog-its-about-people-2017.jpg
 processed: 1550672961722
 ---
 Putting users first. That’s what CDS is all about. When we talk about “digital government,” it often conjures up websites, APIs, and apps. They’re part of the toolkit. But digital government is about people: their needs, their experiences, their frustrations, even their hopes.

--- a/content/en/blog/posts/language-gap.md
+++ b/content/en/blog/posts/language-gap.md
@@ -10,7 +10,7 @@ date: '2018-10-03 09:00:00 -0400'
 image: /img/cds/blog-language-gap.jpg
 image-alt: A French Poodle and an English Bulldog sitting in front of laptops.
 translationKey: language-gap
-thumb: /img/cds/thumbnails/blog-language-gap.jpg
+thumb: /img/cds/blog-language-gap.jpg
 processed: 1550672961723
 ---
 

--- a/content/en/blog/posts/launch-of-the-canadian-digital-service.md
+++ b/content/en/blog/posts/launch-of-the-canadian-digital-service.md
@@ -12,7 +12,7 @@ date: '2017-07-18 09:00:00 -0400'
 image: /img/cds/launch-post-2017.jpg
 image-alt: 'The Honourable Scott Brison, President of the Treasury Board'
 translationKey: launch-of-the-canadian-digital-service
-thumb: /img/cds/thumbnails/launch-post-2017.jpg
+thumb: /img/cds/launch-post-2017.jpg
 processed: 1550672961728
 ---
 Canadians deserve government services that are easy to access and to use. They expect their government to be focused on service to citizens. In the connected world of the 21st century, good service means digital delivery, whether you are ordering take-out, rearranging your mortgage, managing your prescriptions -- or accessing government programs and services.

--- a/content/en/blog/posts/learning-from-the-people-who-want-to-use-our-reporting-service-but-might-not-use-it-now.md
+++ b/content/en/blog/posts/learning-from-the-people-who-want-to-use-our-reporting-service-but-might-not-use-it-now.md
@@ -15,7 +15,7 @@ image-alt: >-
   tool prototype pulled displayed. The title reads, “Report a scam or an online
   crime”.
 translationKey: reporting-service-checklist
-thumb: /img/cds/thumbnails/rcmp-prototype-en.jpg
+thumb: /img/cds/rcmp-prototype-en.jpg
 processed: 1567091591113
 
 ---

--- a/content/en/blog/posts/lets-talk-user-experience.md
+++ b/content/en/blog/posts/lets-talk-user-experience.md
@@ -13,7 +13,7 @@ image-alt: >-
   They are writing ideas on post-it notes and placing those on quadrants posted
   on the wall.
 translationKey: lets-talk-user-experience
-thumb: /img/cds/thumbnails/blog-user-experience.jpg
+thumb: /img/cds/blog-user-experience.jpg
 processed: 1550672961729
 ---
 

--- a/content/en/blog/posts/lexicon.md
+++ b/content/en/blog/posts/lexicon.md
@@ -11,7 +11,7 @@ date: '2018-08-17 09:00:00 -0400'
 image: /img/cds/blog-lexicon.jpg
 image-alt: Illustration a front-loading washer-dryer combo.
 translationKey: lexicon
-thumb: /img/cds/thumbnails/blog-lexicon.jpg
+thumb: /img/cds/blog-lexicon.jpg
 processed: 1550672961730
 ---
 

--- a/content/en/blog/posts/making-a-great-first-impression-onboarding-matters.md
+++ b/content/en/blog/posts/making-a-great-first-impression-onboarding-matters.md
@@ -14,7 +14,7 @@ image-alt: >-
   A photo of Eman's desk on her first day that says "Bienvenue Eman" in sticky
   notes. The desk is covered in stickers, chocolates and confetti.
 translationKey: onboarding-matters
-thumb: /img/cds/thumbnails/onboarding-banner-fitted.jpg
+thumb: /img/cds/onboarding-banner-fitted.jpg
 processed: 1564420750507
 ---
 As a growing organization, we onboard new employees almost every week. While this is something we do regularly, it’s a once in a lifetime experience for the employee starting. A new job can be stressful, and the decision to stick with a job or move on is often made within the first few days. It’s vital that we create a great onboarding experience. We never want to lose sight of the fact that people are at the heart of what we do.

--- a/content/en/blog/posts/moving-content-from-code-to-cloud.md
+++ b/content/en/blog/posts/moving-content-from-code-to-cloud.md
@@ -9,7 +9,7 @@ date: 2018-12-04T14:30:00.000Z
 image: /img/cds/magnificent-cloud.jpg
 image-alt: A magnificent cloud rises above the trees.
 translationKey: from-code-to-cloud
-thumb: /img/cds/thumbnails/magnificent-cloud.jpg
+thumb: /img/cds/magnificent-cloud.jpg
 processed: 1550672961732
 ---
 At CDS, we’re currently working on a [web app](https://github.com/cds-snc/vac-benefits-directory) with Veterans Affairs Canada (VAC). The app will help Veterans and their families find benefits and programs that are relevant to them. That means it needs to keep track of a lot of content: the user interface (UI) text, titles and one-line descriptions of the benefits, multiple choice questions, tags associated with the benefits, VAC office addresses, and more, none of which was personal data or information. And, of course, all this text is in English and French.

--- a/content/en/blog/posts/our-partnership-with-code-for-canada.md
+++ b/content/en/blog/posts/our-partnership-with-code-for-canada.md
@@ -11,7 +11,7 @@ image-alt: >-
   The six members of the first cohort of Code for Canada fellows outside the
   provincial parliament building in Toronto.
 translationKey: our-partnership-with-code-for-canada
-thumb: /img/cds/thumbnails/blog-c4c.jpg
+thumb: /img/cds/blog-c4c.jpg
 processed: 1550672961733
 ---
 

--- a/content/en/blog/posts/picking-our-projects.md
+++ b/content/en/blog/posts/picking-our-projects.md
@@ -13,7 +13,7 @@ date: '2017-08-24 10:00:00 -0400'
 image: /img/cds/picking-our-projects-2017.jpg
 image-alt: Posters in the CDS office
 translationKey: picking-our-projects
-thumb: /img/cds/thumbnails/picking-our-projects-2017.jpg
+thumb: /img/cds/picking-our-projects-2017.jpg
 processed: 1550672961739
 ---
 I grew up on a farm. It was a childhood marked by the feeling of gravel beneath my feet, dirt on my hands, and the joy of picking produce right from the field. I wish I could tell you that picking projects is the same but I have yet to encounter gravel, dirt or produce during a partnership chat (bonus points if you make this happen!)

--- a/content/en/blog/posts/policy.md
+++ b/content/en/blog/posts/policy.md
@@ -14,7 +14,7 @@ date: '2018-09-07 09:00:00 -0400'
 image: /img/cds/blog-puzzle.jpg
 image-alt: Puzzle pieces of different colours connected together.
 translationKey: policy
-thumb: /img/cds/thumbnails/blog-puzzle.jpg
+thumb: /img/cds/blog-puzzle.jpg
 processed: 1550672961740
 ---
 Here at the Canadian Digital Service, we've been lucky to have great role models to learn from, in the U.K., the U.S., Italy, Australia, Ontario, and many other places, as we work with our partners to improve digital services for Canadians. We use a well-established play to help drive this mission: bringing together multidisciplinary talent into teams that tackle a service challenge together. Our product teams include designers, researchers, developers and product managers, but we've also embedded policy and communications people into those teams. 

--- a/content/en/blog/posts/product-teams-brainstorming-during-ideation-week-this-might-be-a-terrible-idea-but-….md
+++ b/content/en/blog/posts/product-teams-brainstorming-during-ideation-week-this-might-be-a-terrible-idea-but-….md
@@ -12,7 +12,7 @@ date: 2019-08-26T14:05:22.645Z
 image: /img/cds/ideas.jpg
 image-alt: CPP-D product team members looking up at lightbulbs drawn above their heads.
 translationKey: brainstorming-ideation-week
-thumb: /img/cds/thumbnails/ideas.jpg
+thumb: /img/cds/ideas.jpg
 processed: 1566844000614
 ---
 Imagine standing up in front of your team at work and saying the worst possible idea you’ve ever had. Did that make you feel uncomfortable? We’ve been conditioned to bring only our very best ideas forward, but voicing the worst possible ideas is exactly what I asked my team to do during our recent Ideation week. Let me explain why this “outlandish” exercise was actually a very good idea. 

--- a/content/en/blog/posts/productive-collaboration.md
+++ b/content/en/blog/posts/productive-collaboration.md
@@ -17,7 +17,7 @@ date: '2018-08-21 09:00:00 -0400'
 image: /img/cds/blog-productive-collaboration.jpg
 image-alt: The product team gathers around the sprint board at a daily standup meeting.
 translationKey: productive-collaboration
-thumb: /img/cds/thumbnails/blog-productive-collaboration.jpg
+thumb: /img/cds/blog-productive-collaboration.jpg
 processed: 1550672961741
 ---
 

--- a/content/en/blog/posts/putting-your-trust-in-humans…-and-robots.md
+++ b/content/en/blog/posts/putting-your-trust-in-humans…-and-robots.md
@@ -9,7 +9,7 @@ date: 2019-03-14T13:00:00.000Z
 image: /img/cds/grass-lawn-robot.jpg
 image-alt: 'A small wooden robot stands in a grassy green lawn. '
 translationKey: trust-humans-and-robots
-thumb: /img/cds/thumbnails/grass-lawn-robot.jpg
+thumb: /img/cds/grass-lawn-robot.jpg
 processed: 1552576946487
 ---
 Effective product development and service delivery is nothing without trust. As a delivery team at CDS, we often speak to our partners about extending us the trust to help them leave their comfort zones and try new approaches. 

--- a/content/en/blog/posts/qualitative-data-uncomfortable-but-worth-it.md
+++ b/content/en/blog/posts/qualitative-data-uncomfortable-but-worth-it.md
@@ -11,7 +11,7 @@ image-alt: >-
   Photo of six members of the RCMP team around a table. They are smiling and
   reviewing a service diagram made up of different coloured sticky notes.
 translationKey: data-driven-service
-thumb: /img/cds/thumbnails/rcmp-data-blog.jpg
+thumb: /img/cds/rcmp-data-blog.jpg
 processed: 1563384025336
 ---
 

--- a/content/en/blog/posts/recruiting-our-ceo.md
+++ b/content/en/blog/posts/recruiting-our-ceo.md
@@ -9,7 +9,7 @@ date: '2018-04-09 09:00:00 -0400'
 image: /img/cds/blog-ceo-recruitment.jpg
 image-alt: Chief Executive Officer Aaron Snow chatting with two other team members.
 translationKey: recruiting-our-ceo
-thumb: /img/cds/thumbnails/blog-ceo-recruitment.jpg
+thumb: /img/cds/blog-ceo-recruitment.jpg
 processed: 1550672961742
 ---
 

--- a/content/en/blog/posts/reducing-risk-through-continuous-deployment.md
+++ b/content/en/blog/posts/reducing-risk-through-continuous-deployment.md
@@ -8,7 +8,7 @@ date: '2018-05-16 09:00:00 -0400'
 image: /img/cds/blog-continuous-deployment.jpg
 image-alt: A man works at his desk working on code.
 translationKey: reducing-risk-through-continuous-deployment
-thumb: /img/cds/thumbnails/blog-continuous-deployment.jpg
+thumb: /img/cds/blog-continuous-deployment.jpg
 processed: 1550672961744
 ---
 

--- a/content/en/blog/posts/reschedule-a-citizenship-appointment.md
+++ b/content/en/blog/posts/reschedule-a-citizenship-appointment.md
@@ -14,7 +14,7 @@ image-alt: >-
   The waiting area at an IRCC client support centre with nine stations at the
   service counter.
 translationKey: reschedule-a-citizenship-appointment
-thumb: /img/cds/thumbnails/blog-ircc-april.jpg
+thumb: /img/cds/blog-ircc-april.jpg
 processed: 1550672961748
 ---
 

--- a/content/en/blog/posts/retrospective-on-energuide-api.md
+++ b/content/en/blog/posts/retrospective-on-energuide-api.md
@@ -12,7 +12,7 @@ image-alt: >-
   people standing at the front of the room grouping post-it notes on on the
   whiteboard.
 translationKey: retrospective-on-energuide-api
-thumb: /img/cds/thumbnails/blog-energuide-retro.jpg
+thumb: /img/cds/blog-energuide-retro.jpg
 processed: 1550672961750
 ---
 

--- a/content/en/blog/posts/rfp.md
+++ b/content/en/blog/posts/rfp.md
@@ -10,7 +10,7 @@ date: '2018-08-31 09:00:00 -0400'
 image: /img/cds/rfp_eng.jpg
 image-alt: 'A maple leaf sticker with the words, Strong and Free.'
 translationKey: rfp
-thumb: /img/cds/thumbnails/rfp_eng.jpg
+thumb: /img/cds/rfp_eng.jpg
 processed: 1550672961754
 ---
 

--- a/content/en/blog/posts/scaling-design-research-in-the-government-of-canada.md
+++ b/content/en/blog/posts/scaling-design-research-in-the-government-of-canada.md
@@ -14,7 +14,7 @@ image-alt: >-
   A photo showing a table covered by white puzzle pieces, with a focus on an
   individual’s hand holding a unique red puzzle piece.
 translationKey: design-research
-thumb: /img/cds/thumbnails/puzzle.jpg
+thumb: /img/cds/puzzle.jpg
 processed: 1562852147851
 ---
 Design research (or user research) helps us understand the people who use our services. If we understand them, we can better meet their needs. We’ve seen how important design research is to delivering people-centered digital services in our work with partners. We’ve also seen how easily it can become mistaken for public opinion research (POR.) 

--- a/content/en/blog/posts/security-is-hard-it’s-also-necessary-and-manageable.md
+++ b/content/en/blog/posts/security-is-hard-it’s-also-necessary-and-manageable.md
@@ -7,7 +7,7 @@ date: 2019-06-20T13:00:00.000Z
 image: /img/cds/airplane.jpg
 image-alt: An airplane taking off on a runway at dusk.
 translationKey: security-hard
-thumb: /img/cds/thumbnails/airplane.jpg
+thumb: /img/cds/airplane.jpg
 processed: 1561556657992
 ---
 Digital security is hard. Even the best engineering and IT teams are prone to make mistakes at some point. But like airport security, steps and processes along the way keep you safe and secure.

--- a/content/en/blog/posts/service-design-thats-our-jam.md
+++ b/content/en/blog/posts/service-design-thats-our-jam.md
@@ -13,7 +13,7 @@ image-alt: >-
   Four people talk in front of a black board while coloured clouds swirl above
   their heads.
 translationKey: service-design-thats-our-jam
-thumb: /img/cds/thumbnails/blog-jam-header.jpg
+thumb: /img/cds/blog-jam-header.jpg
 processed: 1550672961756
 ---
 

--- a/content/en/blog/posts/setting-users-up for-success-with-content-design.md
+++ b/content/en/blog/posts/setting-users-up for-success-with-content-design.md
@@ -13,7 +13,7 @@ description: >-
   appointment as convenient and stress-free as possible for applicants, while
   empowering office staff.
 translationKey: setting-users-up-for-success-with-content-design
-thumb: /img/cds/thumbnails/blog-setting-up-users-for-success.jpg
+thumb: /img/cds/blog-setting-up-users-for-success.jpg
 processed: 1550672961760
 ---
 

--- a/content/en/blog/posts/showing-the-whole-iceberg.md
+++ b/content/en/blog/posts/showing-the-whole-iceberg.md
@@ -12,7 +12,7 @@ image-alt: >-
   A person standing behind a podium gestures towards an iceberg floating in an
   aquarium while a small dog watches.
 translationKey: showing-the-whole-iceberg
-thumb: /img/cds/thumbnails/blog-iceberg-header.jpg
+thumb: /img/cds/blog-iceberg-header.jpg
 processed: 1550672961762
 ---
 

--- a/content/en/blog/posts/small-acts-big-impacts.md
+++ b/content/en/blog/posts/small-acts-big-impacts.md
@@ -11,7 +11,7 @@ image-alt: >-
   A panel of moderators speaking with sign language interpreters behind them, in
   front of event attendees. 
 translationKey: small-acts-big-impact
-thumb: /img/cds/thumbnails/diversity-day-banner-image-2.jpg
+thumb: /img/cds/diversity-day-banner-image-2.jpg
 processed: 1554413470049
 ---
 Diverse and inclusive teams deliver diverse and inclusive services. That’s why on Friday, February 8, The Canadian Digital Service hosted [Diversity in Digital Services](https://www.eventbrite.ca/e/diversity-in-digital-services-diversite-au-sein-des-services-numeriques-registration-51465629082), a day to brainstorm ideas around team diversity, inclusion, and their impact on delivering better services. 

--- a/content/en/blog/posts/so-what-exactly-is-a-product-manager-anyway.md
+++ b/content/en/blog/posts/so-what-exactly-is-a-product-manager-anyway.md
@@ -14,7 +14,7 @@ image-alt: >-
   connect with distributed product management team members working from
   Montreal, Waterloo, Toronto, and Ottawa.
 translationKey: product-manager-QA
-thumb: /img/cds/thumbnails/pm-banner-fix.jpg
+thumb: /img/cds/pm-banner-fix.jpg
 processed: 1563904136175
 ---
 If you find yourself speaking to someone who is highly organized, curious, adaptive, communicative, empathetic, and passionate about removing barriers in order to get stuff done, chances are you’re either talking to a superhuman or a product manager.

--- a/content/en/blog/posts/striving-for-diversity.md
+++ b/content/en/blog/posts/striving-for-diversity.md
@@ -8,7 +8,7 @@ date: '2018-10-30 09:00:00 -0400'
 image: /img/cds/blog-striving-for-diversity.jpg
 image-alt: A blue ribbon banner with the words “a mari usque ad mare” in yellow.
 translationKey: striving-for-diversity
-thumb: /img/cds/thumbnails/blog-striving-for-diversity.jpg
+thumb: /img/cds/blog-striving-for-diversity.jpg
 processed: 1550672961764
 ---
 

--- a/content/en/blog/posts/supporting-users-gracefully-degrading-react.md
+++ b/content/en/blog/posts/supporting-users-gracefully-degrading-react.md
@@ -14,7 +14,7 @@ image-alt: >-
   A person navigating through a range of devices, including a rotary dial phone,
   a flip phone, a laptop and a computer tower.
 translationKey: supporting-users-gracefully-degrading-react
-thumb: /img/cds/thumbnails/blog-noJS.jpg
+thumb: /img/cds/blog-noJS.jpg
 processed: 1550672961766
 ---
 

--- a/content/en/blog/posts/teaming-up-to-deliver-better-outcomes-for-veterans.md
+++ b/content/en/blog/posts/teaming-up-to-deliver-better-outcomes-for-veterans.md
@@ -10,7 +10,7 @@ date: 2018-07-24T13:00:00.000Z
 image: /img/cds/blog-pei-banner.jpg
 image-alt: A red sanded clif overlooking the sea in Prince Edward Island.
 translationKey: teaming-up-to-deliver-better-outcomes-for-veterans
-thumb: /img/cds/thumbnails/blog-pei-banner.jpg
+thumb: /img/cds/blog-pei-banner.jpg
 processed: 1550672961767
 ---
 

--- a/content/en/blog/posts/technology-choices-at-cds.md
+++ b/content/en/blog/posts/technology-choices-at-cds.md
@@ -15,7 +15,7 @@ date: '2017-11-06 09:00:00 -0400'
 image: /img/cds/blog-technology-choices-at-cds-2017.jpg
 image-alt: A computer screen showing results from a test suite
 translationKey: technology-choices-at-cds
-thumb: /img/cds/thumbnails/blog-technology-choices-at-cds-2017.jpg
+thumb: /img/cds/blog-technology-choices-at-cds-2017.jpg
 processed: 1550672961768
 ---
 A few weeks ago, we opened our [public recruitment campaign](/join-our-team/), looking for designers, developers, data scientists, product managers, and engagement experts. On the developer stream, a number of people have reached out to ask which technology platforms and programming languages we work in. It’s a great question! One of the exciting parts of joining CDS at such an early stage in our existence is that you’ll have a chance to shape how our technology choices evolve. With that in mind – none of these are set in stone – I thought I’d share the current thinking of our developer team, and the two (competing) goals that influence the technologies we choose.

--- a/content/en/blog/posts/the-best-panic-attack-i-ever-had.md
+++ b/content/en/blog/posts/the-best-panic-attack-i-ever-had.md
@@ -12,7 +12,7 @@ image-alt: >-
   An image of book stacks inside the Montreal library where I had my panic
   attack.
 translationKey: best-panic-attack
-thumb: /img/cds/thumbnails/montreal-library.jpg
+thumb: /img/cds/montreal-library.jpg
 processed: 1575304320698
 ---
 Exactly one year ago, I was having a panic attack in the restroom of a public library in Montreal.

--- a/content/en/blog/posts/the-good-the-bad-and-the-struggle-a-recap-of-cds-distributed-week.md
+++ b/content/en/blog/posts/the-good-the-bad-and-the-struggle-a-recap-of-cds-distributed-week.md
@@ -11,7 +11,7 @@ image-alt: >-
   Picture of Lynn on GoogleHangouts from the perspective of Charlotte’s office
   at home.
 translationKey: CDS-distributed
-thumb: /img/cds/thumbnails/google-hangout.jpg
+thumb: /img/cds/google-hangout.jpg
 processed: 1555352343007
 ---
 Over the past year, the Canadian Digital Service (CDS) has grown considerably with colleagues in Ottawa, Toronto, Montreal, and Kitchener-Waterloo. Though our Ottawa office has the most amount of people, we’re a distributed organization. That means we work in an environment where everyone, regardless of geographic location, is able to fully contribute to team goals the same way that a team all working out of the same office can.

--- a/content/en/blog/posts/the-policy-pieces-for-conducting-research-with-vac.md
+++ b/content/en/blog/posts/the-policy-pieces-for-conducting-research-with-vac.md
@@ -9,7 +9,7 @@ date: 2019-02-27T16:13:50.918Z
 image: /img/cds/tim-swaan-45717-unsplash.jpg
 image-alt: footbridge-leading-towards-forest
 translationKey: user-interview-policy
-thumb: /img/cds/thumbnails/tim-swaan-45717-unsplash.jpg
+thumb: /img/cds/tim-swaan-45717-unsplash.jpg
 processed: 1552050695046
 ---
 Public servants who want to conduct interviews with the people that use your service, this post is for you. Recruiting people for service design research can be difficult in any sector, but government has some additional requirements. Though many are warranted due to the government’s position of authority, [others may be due to culture or habit](https://digital.canada.ca/2018/09/07/policy). In this post, we’ll talk about how we recruited Veterans and conducted research.

--- a/content/en/blog/posts/the-security-in-digital-is-silent.md
+++ b/content/en/blog/posts/the-security-in-digital-is-silent.md
@@ -10,7 +10,7 @@ date: '2018-07-11 09:00:00 -0400'
 image: /img/cds/the-security-in-digital-is-silent.jpg
 image-alt: An open lock
 translationKey: the-security-in-digital-is-silent
-thumb: /img/cds/thumbnails/the-security-in-digital-is-silent.jpg
+thumb: /img/cds/the-security-in-digital-is-silent.jpg
 processed: 1550672961769
 ---
 

--- a/content/en/blog/posts/think-big-start-small.md
+++ b/content/en/blog/posts/think-big-start-small.md
@@ -10,7 +10,7 @@ date: '2017-07-28 10:00:00 -0400'
 image: /img/cds/blog-think-big-start-small-2017.jpg
 image-alt: Some members of the CDS team celebrating the website launch with a thumbs up
 translationKey: think-big-start-small
-thumb: /img/cds/thumbnails/blog-think-big-start-small-2017.jpg
+thumb: /img/cds/blog-think-big-start-small-2017.jpg
 processed: 1550672961771
 ---
 The UK’s Government Digital Service has a brilliant list of [ten design principles](https://www.gov.uk/design-principles). I still remember the first time I saw it. “Start with user needs”, it read, “not government needs.” Oh my goodness, I thought: this is a real UK government website! That’s …amazing!

--- a/content/en/blog/posts/tools-to-do-good-work.md
+++ b/content/en/blog/posts/tools-to-do-good-work.md
@@ -8,7 +8,7 @@ date: '2018-06-27 09:00:00 -0400'
 image: /img/cds/blog-tools-for-work-2018.jpg
 image-alt: Several MacBook computers covered in stickers laid out on a table.
 translationKey: tools-to-do-good-work
-thumb: /img/cds/thumbnails/blog-tools-for-work-2018.jpg
+thumb: /img/cds/blog-tools-for-work-2018.jpg
 processed: 1550672961772
 ---
 

--- a/content/en/blog/posts/unleash-talent-and-four-other-tips-for-changing-government.md
+++ b/content/en/blog/posts/unleash-talent-and-four-other-tips-for-changing-government.md
@@ -9,7 +9,7 @@ date: 2019-01-03T14:00:04.407Z
 image: /img/cds/nordwood-themes-1066398-unsplash.jpg
 image-alt: '2019 written in fireworks, Photo: NordWood Themes/Unsplash'
 translationKey: unleash-talent
-thumb: /img/cds/thumbnails/nordwood-themes-1066398-unsplash.jpg
+thumb: /img/cds/nordwood-themes-1066398-unsplash.jpg
 processed: 1550672961778
 ---
 After two years building CDS, I wanted to share a few thoughts on what I’ve learned. With our partners, we’re changing how government designs and delivers services, but there’s a long way to go. Here’s how we can get there:

--- a/content/en/blog/posts/update-on-our-request-for-proposals.md
+++ b/content/en/blog/posts/update-on-our-request-for-proposals.md
@@ -7,7 +7,7 @@ date: 2019-01-22T14:00:00.000Z
 image: /img/cds/rfp_eng.jpg
 image-alt: 'A maple leaf sticker with the words, Strong and Free.'
 translationKey: update-rfp
-thumb: /img/cds/thumbnails/rfp_eng.jpg
+thumb: /img/cds/rfp_eng.jpg
 processed: 1550672961783
 ---
 Thank you to all of the bidders that took the time and effort to respond to our [Request for Proposals](https://buyandsell.gc.ca/procurement-data/tender-notice/PW-18-00841347). Since bidding closed we have been working hard to evaluate the bids, but it’s taking us longer than we would have liked. We know you and your teams need to make plans so here’s an update with our best estimates on timelines and a few reminders. 

--- a/content/en/blog/posts/validation-testing-a-way-to-challenge-your-assumptions.md
+++ b/content/en/blog/posts/validation-testing-a-way-to-challenge-your-assumptions.md
@@ -12,7 +12,7 @@ image-alt: >-
   Five different-coloured cactuses (orange, red, green, pink and yellow)
   arranged side by side in white pots, in front of a white background.
 translationKey: validation-testing-cra
-thumb: /img/cds/thumbnails/colourful-cactuses.jpg
+thumb: /img/cds/colourful-cactuses.jpg
 processed: 1564689903407
 ---
 Putting people at the centre of our work means trusting that they’re the experts of their own contexts and needs. 

--- a/content/en/blog/posts/wanted-ceo-cds.md
+++ b/content/en/blog/posts/wanted-ceo-cds.md
@@ -11,7 +11,7 @@ date: '2017-09-12 09:00:00 -0400'
 image: /img/cds/wanted-ceo-cds-2017.jpg
 image-alt: 'Yaprak Baltacıoğlu, Secretary of the Treasury Board'
 translationKey: wanted-ceo-cds
-thumb: /img/cds/thumbnails/wanted-ceo-cds-2017.jpg
+thumb: /img/cds/wanted-ceo-cds-2017.jpg
 processed: 1550672961786
 ---
 The services our government provides play an important role in the lives of millions of people. 

--- a/content/en/blog/posts/we-get-by-with-a-little-help-from-our-friends.md
+++ b/content/en/blog/posts/we-get-by-with-a-little-help-from-our-friends.md
@@ -12,7 +12,7 @@ image-alt: >-
   Two vintage Volkswagen Beetles face each other in a green grass field with a
   blue sky.
 translationKey: help-from-friends
-thumb: /img/cds/thumbnails/katka-pavlickova-131100-unsplash-min.jpg
+thumb: /img/cds/katka-pavlickova-131100-unsplash-min.jpg
 processed: 1550672961787
 ---
 I often get asked by fellow public servants “What authorities did the Canadian Digital Service (CDS) get to operate the way it does?” So I thought I would share the authorities we received from government when CDS was established in 2017:

--- a/content/en/blog/posts/we-love-a-good-challenge.md
+++ b/content/en/blog/posts/we-love-a-good-challenge.md
@@ -11,7 +11,7 @@ image-alt: >-
   Aaron Snow speaks at a podium in front of a colourful “FWD50” sign, with a
   screen in the background labelled “Challenge accepted.”
 translationKey: we-love-a-good-challenge
-thumb: /img/cds/thumbnails/aaron-fwd50-challenge-accepted-en.jpg
+thumb: /img/cds/aaron-fwd50-challenge-accepted-en.jpg
 processed: 1557832757137
 ---
 Last summer, the federal government brought together Canadian industry leaders to help guide [economic strategies for Canada](https://www.ic.gc.ca/eic/site/098.nsf/eng/home). One of these, the Digital Industries table – chaired by Shopify CEO [Tobi Lütke](https://twitter.com/tobi) – examined how Canada could become a digital leader. Their report was published in September 2018, and [presents a bold vision](https://www.ic.gc.ca/eic/site/098.nsf/vwapj/ISEDC_Digital_Industries.pdf/$FILE/ISEDC_Digital_Industries.pdf) for Canada as a digital society.

--- a/content/en/blog/posts/we-take-security-seriously-why-everyone-at-cds-has-security-keys.md
+++ b/content/en/blog/posts/we-take-security-seriously-why-everyone-at-cds-has-security-keys.md
@@ -10,7 +10,7 @@ date: 2019-08-15T13:00:00.000Z
 image: /img/cds/yubikey-3.jpg
 image-alt: A hand pushing their yubikey.
 translationKey: yubikey-post
-thumb: /img/cds/thumbnails/yubikey-3.jpg
+thumb: /img/cds/yubikey-3.jpg
 processed: 1565980652891
 ---
 I have fears; big, big fears. Fears of waking up in the morning and seeing the Canadian Digital Service’s cloud assets vandalized or destroyed because some bad actor got a hold of someone's credentials and decided to muck around. Hey, this fear is real and even the most conscientious of us are vulnerable.

--- a/content/en/blog/posts/we’re-launching-an-accelerator-to-test-incremental-investment.md
+++ b/content/en/blog/posts/we’re-launching-an-accelerator-to-test-incremental-investment.md
@@ -9,7 +9,7 @@ date: 2019-05-02T20:00:00.000Z
 image: /img/cds/blog-up-to-speed.jpg
 image-alt: Car speedometer
 translationKey: accelerator-launch
-thumb: /img/cds/thumbnails/blog-up-to-speed.jpg
+thumb: /img/cds/blog-up-to-speed.jpg
 processed: 1556885855943
 ---
 In countries making significant progress with digital government, work with the private sector is an important part of the puzzle. Government can’t do it alone. Contracting helps scale modern technology and design methods across the public sector. Businesses bring specialized expertise, flexible surge capacity, scale, and experience with the cutting edge of technology and practice.

--- a/content/en/blog/posts/what’s-it-like-to-work-on-a-distributed-team.md
+++ b/content/en/blog/posts/what’s-it-like-to-work-on-a-distributed-team.md
@@ -11,7 +11,7 @@ image-alt: >-
   Phil and Emily having a coffee chat with a colleague who is in a Google
   Hangout
 translationKey: VAC-distributed-interview
-thumb: /img/cds/thumbnails/google-hangout2.jpg
+thumb: /img/cds/google-hangout2.jpg
 processed: 1555352343026
 ---
 Meet Phil and Emily, distributed team members from Veterans Affairs Canada (VAC) who have been working on the Benefits Finder partnership with us. 

--- a/content/en/blog/posts/why-canada-needs-a-digital-service.md
+++ b/content/en/blog/posts/why-canada-needs-a-digital-service.md
@@ -12,7 +12,7 @@ image-alt: >-
   Ryan Androsoff, Lena Trudeau, Anatole Papadopoulos, Olivia Neal, and Pascale
   Elvas
 translationKey: why-canada-needs-a-digital-service
-thumb: /img/cds/thumbnails/why-canada-needs-a-digital-service-2017.jpg
+thumb: /img/cds/why-canada-needs-a-digital-service-2017.jpg
 processed: 1550672961788
 ---
 For months, I’ve been working behind the scenes to stand up the Canadian Digital Service. Through this process, I’ve done a lot of thinking about why Canada needs a digital service organization and the potential it has to change how we design government services.

--- a/content/fr/blog/posts/Le-SNC-accueille-son-premier-dirigeant-principal.md
+++ b/content/fr/blog/posts/Le-SNC-accueille-son-premier-dirigeant-principal.md
@@ -9,7 +9,7 @@ date: '2018-03-09 09:00:00 -0400'
 image: /img/cds/blog-aaron-snow.jpg
 image-alt: Aaron Snow
 translationKey: CDS-gets-its-first-CEO
-thumb: /img/cds/thumbnails/blog-aaron-snow.jpg
+thumb: /img/cds/blog-aaron-snow.jpg
 processed: 1550672961791
 ---
 

--- a/content/fr/blog/posts/a-la-recherche-utilisateur-avec-RNCan.md
+++ b/content/fr/blog/posts/a-la-recherche-utilisateur-avec-RNCan.md
@@ -8,7 +8,7 @@ date: '2018-02-15 09:00:00 -0400'
 image: /img/cds/blog-conducting-user-research-with-NRCAN.jpg
 image-alt: Eman et Jennifer regardent le canevas de proposition de valeur
 translationKey: conducting-user-research-with-NRCan
-thumb: /img/cds/thumbnails/blog-conducting-user-research-with-NRCAN.jpg
+thumb: /img/cds/blog-conducting-user-research-with-NRCAN.jpg
 processed: 1550672961792
 ---
 

--- a/content/fr/blog/posts/a-la-rescherche-de-la-diversity.md
+++ b/content/fr/blog/posts/a-la-rescherche-de-la-diversity.md
@@ -8,7 +8,7 @@ date: '2018-10-30 09:00:00 -0400'
 image: /img/cds/blog-striving-for-diversity.jpg
 image-alt: Une bannière de ruban bleu avec les mots « a mari usque ad mare » en jaune.
 translationKey: striving-for-diversity
-thumb: /img/cds/thumbnails/blog-striving-for-diversity.jpg
+thumb: /img/cds/blog-striving-for-diversity.jpg
 processed: 1550672961794
 ---
 

--- a/content/fr/blog/posts/aidons-les-canadiens-à-faible-revenu-à-produire-leur-déclaration-de-revenus.md
+++ b/content/fr/blog/posts/aidons-les-canadiens-à-faible-revenu-à-produire-leur-déclaration-de-revenus.md
@@ -15,7 +15,7 @@ image-alt: >-
   Quelqu'un produit sa déclaration de revenus sur papier avec une tasse en
   main. 
 translationKey: Canadians-complete-taxes
-thumb: /img/cds/thumbnails/img_0880.jpg
+thumb: /img/cds/img_0880.jpg
 processed: 1550672961798
 ---
 Tous les jours, les Canadiens utilisent les services gouvernementaux. En tant que fonctionnaires, nous assurons la conception et la prestation de ces services. Bon nombre de ces services sont cruciaux pour les gens qui en ont besoin. Cela veut dire que lorsque les gens ont besoin de services gouvernementaux, ils sont souvent confrontés à de sérieuses difficultés. 

--- a/content/fr/blog/posts/attirer-et-recruter-les-meilleurs-talents-avec-un-petit-coup-de-main-de-nos-amis.md
+++ b/content/fr/blog/posts/attirer-et-recruter-les-meilleurs-talents-avec-un-petit-coup-de-main-de-nos-amis.md
@@ -15,7 +15,7 @@ image-alt: >-
   Un jouet de voiture Volkswagen jaune sur une étagère en bois remplie de
   livres.
 translationKey: help-from-friends-HR
-thumb: /img/cds/thumbnails/beetletoy.jpg
+thumb: /img/cds/beetletoy.jpg
 processed: 1554413470134
 ---
 *[On s’en sort avec l’aide de nos amis] (https://numerique.canada.ca/2019/01/31/on-sen-sort-avec-laide-de-nos-amis/) est une série de billets de blogues mettant en vedette les fonctionnaires extraordinaires qui nous permettent, à nous et à nos partenaires, de concevoir et d’offrir de meilleurs services.*

--- a/content/fr/blog/posts/b-travailler-dans-les-locaux-de-RNCan.md
+++ b/content/fr/blog/posts/b-travailler-dans-les-locaux-de-RNCan.md
@@ -9,7 +9,7 @@ date: '2018-02-15 09:00:00 -0400'
 image: /img/cds/blog-colocating-with-NRCAN.jpg
 image-alt: Jason et Dave debouts devant l'édifice de Ressources naturelles Canada
 translationKey: colocating-with-NRCan
-thumb: /img/cds/thumbnails/blog-colocating-with-NRCAN.jpg
+thumb: /img/cds/blog-colocating-with-NRCAN.jpg
 processed: 1550672961800
 ---
 

--- a/content/fr/blog/posts/bonjour-le-monde-canada.md
+++ b/content/fr/blog/posts/bonjour-le-monde-canada.md
@@ -11,7 +11,7 @@ date: '2018-10-19 09:00:00 -0400'
 image: /img/cds/blog-hello-world-canada.jpg
 image-alt: Des feuilles d’érable rouge.
 translationKey: hello-world-canada
-thumb: /img/cds/thumbnails/blog-hello-world-canada.jpg
+thumb: /img/cds/blog-hello-world-canada.jpg
 processed: 1550672961801
 ---
 

--- a/content/fr/blog/posts/bâtir-une-communauté-de-pratique-en-offrant-des-évaluations-comme-service.md
+++ b/content/fr/blog/posts/bâtir-une-communauté-de-pratique-en-offrant-des-évaluations-comme-service.md
@@ -15,7 +15,7 @@ image-alt: >-
   Photo d’une main tenant un crayon et écrivant une liste avec des cases à
   cocher dans un calepin.
 translationKey: service-assessments
-thumb: /img/cds/thumbnails/checklist.jpg
+thumb: /img/cds/checklist.jpg
 processed: 1565980652928
 ---
 Il faut une communauté de pratique pour transformer les services gouvernementaux. L’an dernier, le gouvernement du Canada a présenté ses [normes numériques](https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/normes-numeriques-gouvernement-canada.html). Il s’agit d’un ensemble de principes visant à aider les équipes à offrir des services numériques de meilleure qualité aux Canadiens. Depuis leur publication, le Service numérique canadien (SNC) examine comment les ministères peuvent s’évaluer en fonction des normes.

--- a/content/fr/blog/posts/ce-sont-les-gens-qui-comptent.md
+++ b/content/fr/blog/posts/ce-sont-les-gens-qui-comptent.md
@@ -10,7 +10,7 @@ date: '2017-07-25 10:00:00 -0400'
 image: /img/cds/blog-its-about-people-2017.jpg
 image-alt: Anatole Papadopoulos parle avec le personnel du SNC.
 translationKey: its-about-people
-thumb: /img/cds/thumbnails/blog-its-about-people-2017.jpg
+thumb: /img/cds/blog-its-about-people-2017.jpg
 processed: 1550672961802
 ---
 Privilégier les utilisateurs. Voilà la raison d’être du Service numérique canadien. Lorsqu’on parle du «&nbsp;gouvernement numérique&nbsp;», on pense habituellement aux sites Web, aux API et aux applications. Tout cela fait partie du coffre à outils. Pourtant, ce sont les gens – leurs besoins, leurs expériences, leurs frustrations, même leurs espoirs – qui devraient être au cœur des efforts vers un gouvernement numérique.

--- a/content/fr/blog/posts/chers-collègues-quelle-est-la-formation-numérique-dont-vous-avez-besoin.md
+++ b/content/fr/blog/posts/chers-collègues-quelle-est-la-formation-numérique-dont-vous-avez-besoin.md
@@ -12,7 +12,7 @@ date: 2018-11-01T19:50:46.952Z
 image: /img/cds/screen-shot-2018-11-01-at-3.42.39-pm.jpg
 image-alt: Une collection d'outils de travail
 translationKey: digital-training-needs
-thumb: /img/cds/thumbnails/screen-shot-2018-11-01-at-3.42.39-pm.jpg
+thumb: /img/cds/screen-shot-2018-11-01-at-3.42.39-pm.jpg
 processed: 1550672961805
 ---
 **Mise à jour :** *Renforcement de la capacité numérique : le rapport sur l’analyse des besoins en formation est maintenant disponible sur le site Web de l’Université Dalhousie! [Lisez ici ce que nous avons découvert](/2019/08/30/%C3%A9valuer-les-besoins-en-formation-du-gouvernement-pour-lavenir-de-la-prestation-de-services-num%C3%A9riques/). Merci à tous les fonctionnaires qui ont participé au sondage. Vos réponses contribueront à orienter l’apprentissage sur les disciplines numériques émergentes.*

--- a/content/fr/blog/posts/choisir-nos-projets.md
+++ b/content/fr/blog/posts/choisir-nos-projets.md
@@ -15,7 +15,7 @@ date: '2017-08-24 10:00:00 -0400'
 image: /img/cds/picking-our-projects-2017.jpg
 image-alt: Affiches dans les locaux du SNC.
 translationKey: picking-our-projects/
-thumb: /img/cds/thumbnails/picking-our-projects-2017.jpg
+thumb: /img/cds/picking-our-projects-2017.jpg
 processed: 1550672961807
 ---
 J’ai grandi sur une ferme. Mon enfance a été marquée par la sensation du gravier sous mes pieds, la terre sur mes mains et le bonheur de choisir des fruits et des légumes directement du champ. J’aimerais pouvoir vous dire que choisir des projets est semblable, mais je n’ai toujours pas vu de gravier, de terre, de fruits ou de légumes pendant une discussion portant sur un partenariat (points bonis si vous y arrivez!)

--- a/content/fr/blog/posts/circonscrire-un-probleme-de-conception.md
+++ b/content/fr/blog/posts/circonscrire-un-probleme-de-conception.md
@@ -8,7 +8,7 @@ date: '2017-10-24 09:00:00 -0400'
 image: /img/cds/blog-framing-a-design-problem-2017.jpg
 image-alt: Une salle remplie de chaises inoccupées lors d’une cérémonie de citoyenneté.
 translationKey: framing-a-design-problem
-thumb: /img/cds/thumbnails/blog-framing-a-design-problem-2017.jpg
+thumb: /img/cds/blog-framing-a-design-problem-2017.jpg
 processed: 1550672961807
 ---
 C’est une période emballante au Service numérique canadien (SNC) : nous avons retroussé nos manches et nous nous sommes lancés dans nos premiers projets de prestation de services, tout en travaillant fort pour [choisir nos prochains partenariats](/2017/08/24/choisir-nos-projets/). L’un de nos partenaires pour ces tout premiers projets est Immigration, Réfugiés et Citoyenneté Canada (IRCC).

--- a/content/fr/blog/posts/codage-collectif.md
+++ b/content/fr/blog/posts/codage-collectif.md
@@ -13,7 +13,7 @@ image-alt: >-
   Une illustration de deux personnes qui peinturent une maquette géante de page
   web.
 translationKey: community-driven-coding
-thumb: /img/cds/thumbnails/blog-david-https-header.jpg
+thumb: /img/cds/blog-david-https-header.jpg
 processed: 1550672961814
 ---
 

--- a/content/fr/blog/posts/coder-une-activite-dequipe.md
+++ b/content/fr/blog/posts/coder-une-activite-dequipe.md
@@ -10,7 +10,7 @@ date: '2018-04-24 09:00:00 -0400'
 image: /img/cds/blog-team-coding.jpg
 image-alt: Un écran d'ordinateur affiche 200 lignes de code JavaScript dans Sublime Text.
 translationKey: coding-is-a-team-activity
-thumb: /img/cds/thumbnails/blog-team-coding.jpg
+thumb: /img/cds/blog-team-coding.jpg
 processed: 1550672961815
 ---
 

--- a/content/fr/blog/posts/collaboration-productive.md
+++ b/content/fr/blog/posts/collaboration-productive.md
@@ -22,7 +22,7 @@ image-alt: >-
   L'équipe de produit se réunit autour du tableau de print lors d'une réunion
   quotidienne.
 translationKey: productive-collaboration
-thumb: /img/cds/thumbnails/blog-productive-collaboration.jpg
+thumb: /img/cds/blog-productive-collaboration.jpg
 processed: 1550672961816
 ---
 

--- a/content/fr/blog/posts/colocalisation-ne-laisser-aucun-membre-de-l’équipe-derrière.md
+++ b/content/fr/blog/posts/colocalisation-ne-laisser-aucun-membre-de-l’équipe-derrière.md
@@ -9,7 +9,7 @@ date: 2019-04-10T13:57:43.293Z
 image: /img/cds/colourful-umbrellas.jpg
 image-alt: Des parapluies colorés flottant côte à côte dans le ciel.
 translationKey: cra-colocation
-thumb: /img/cds/thumbnails/colourful-umbrellas.jpg
+thumb: /img/cds/colourful-umbrellas.jpg
 processed: 1555070084965
 
 ---

--- a/content/fr/blog/posts/comment-nous-avons-mesuré-notre-prestation-avec-acc-et-pourquoi-c’est-utile.md
+++ b/content/fr/blog/posts/comment-nous-avons-mesuré-notre-prestation-avec-acc-et-pourquoi-c’est-utile.md
@@ -13,7 +13,7 @@ image-alt: >-
   Une capture d’écran de la page d’accueil de l’outil Rechercher des avantages
   et des services.
 translationKey: by-the-numbers
-thumb: /img/cds/thumbnails/VACBenchmarkBlogFRgood.jpg
+thumb: /img/cds/VACBenchmarkBlogFRgood.jpg
 processed: 1556121236018
 ---
 Si nous mesurons une prestation, nous pouvons savoir si nous l’améliorons. C’est pourquoi au Service numérique canadien, nous aimons savoir où nous en sommes avant de commencer à itérer. De cette façon, nous pouvons constater tout le chemin parcouru après avoir perfectionné un produit ou un service.

--- a/content/fr/blog/posts/communications-et-données-elles-vécurent-heureuses-jusqu’à-la-fin-des-temps.md
+++ b/content/fr/blog/posts/communications-et-données-elles-vécurent-heureuses-jusqu’à-la-fin-des-temps.md
@@ -10,7 +10,7 @@ date: 2019-11-28T14:09:20.985Z
 image: /img/cds/dreaming-of-words.jpg
 image-alt: 'Illustration d''une fille rêvant d''écriture et de livres. '
 translationKey: Data-driven-comms
-thumb: /img/cds/thumbnails/dreaming-of-words.jpg
+thumb: /img/cds/dreaming-of-words.jpg
 processed: 1575304320725
 ---
 ## Il était une fois...

--- a/content/fr/blog/posts/conception-de-services-a-nos-idees.md
+++ b/content/fr/blog/posts/conception-de-services-a-nos-idees.md
@@ -13,7 +13,7 @@ image-alt: >-
   Quatre personnes parlent devant un tableau noir alors que des nuages ​​colorés
   tourbillonnent au-dessus de leurs têtes.
 translationKey: service-design-thats-our-jam
-thumb: /img/cds/thumbnails/blog-jam-header.jpg
+thumb: /img/cds/blog-jam-header.jpg
 processed: 1550672961818
 ---
 

--- a/content/fr/blog/posts/concevoir-pour-le-canada.md
+++ b/content/fr/blog/posts/concevoir-pour-le-canada.md
@@ -9,7 +9,7 @@ date: '2017-09-21 09:00:00 -0400'
 image: /img/cds/blog-designing-for-canada-2017.jpg
 image-alt: 'Chris Govias, Design'
 translationKey: designing-for-canada/
-thumb: /img/cds/thumbnails/blog-designing-for-canada-2017.jpg
+thumb: /img/cds/blog-designing-for-canada-2017.jpg
 processed: 1550672961819
 ---
 Après un bref congé sabbatique et une décennie passée au Royaume-Uni, je suis fier d’annoncer que je serai le premier chef de la conception au Service numérique canadien (SNC), une nouvelle initiative du gouvernement du Canada.

--- a/content/fr/blog/posts/congé-civique-intégrer-les-talents-du-privé-dans-le-secteur-technologique-public.md
+++ b/content/fr/blog/posts/congé-civique-intégrer-les-talents-du-privé-dans-le-secteur-technologique-public.md
@@ -14,7 +14,7 @@ image-alt: >-
   Photo de personnes côte à côte, chacune tenant une feuille d'érable dans sa
   main.
 translationKey: civic-leave
-thumb: /img/cds/thumbnails/small-maple-leafs.jpg
+thumb: /img/cds/small-maple-leafs.jpg
 processed: 1564408446497
 ---
 Il faut une variété de personnes qualifiées pour créer et offrir des services numériques gouvernementaux de qualité. Ici, au Service numérique canadien (SNC), nous avons recours à des équipes multidisciplinaires pour concevoir des services simples et efficaces pour les Canadiens. Ces équipes possèdent des compétences et des expériences variées, ainsi qu’une expertise provenant de divers secteurs et même de différents pays. 

--- a/content/fr/blog/posts/cote-humain-de-la-citoyennete.md
+++ b/content/fr/blog/posts/cote-humain-de-la-citoyennete.md
@@ -13,7 +13,7 @@ image-alt: >-
   Des personnes sont debouts et prononcent le serment de citoyenneté canadienne
   à une cérémonie à Vancouver
 translationKey: human-story-behind-citizenship
-thumb: /img/cds/thumbnails/blog-human-story-citizenship1.jpg
+thumb: /img/cds/blog-human-story-citizenship1.jpg
 processed: 1550672961820
 ---
 

--- a/content/fr/blog/posts/créer-des-services-inclusifs-n’est-pas-une-question-de-perfection.md
+++ b/content/fr/blog/posts/créer-des-services-inclusifs-n’est-pas-une-question-de-perfection.md
@@ -11,7 +11,7 @@ image-alt: >-
   Un homme utilise un clavier ajustable et d’autres technologies qui l’aident à
   utiliser son ordinateur.
 translationKey: not-perfect
-thumb: /img/cds/thumbnails/_mg_9837-2.jpg
+thumb: /img/cds/_mg_9837-2.jpg
 processed: 1550672961824
 ---
 L'accessibilité a la réputation d'être difficile, et même parfois impossible à réaliser. Pourtant, l’élaboration de services inclusifs qui conviennent à tous n’est pas une question de perfection. C’est une question d’efforts et de progrès. Et lorsqu’on déploie ce genre d’efforts chaque jour, la transformation s’opère. À l’opposé, si l’on ne fait rien, les gens qui ont le plus besoin de nos services ne pourront pas y accéder. 

--- a/content/fr/blog/posts/c’est-comment-travailler-dans-une-équipe-géographiquement-dispersée.md
+++ b/content/fr/blog/posts/c’est-comment-travailler-dans-une-équipe-géographiquement-dispersée.md
@@ -11,7 +11,7 @@ date: 2019-04-15T15:06:03.334Z
 image: /img/cds/google-hangout2.jpg
 image-alt: 'Phil et Emily partagent un café avec un collègue utilisant Google Hangout. '
 translationKey: VAC-distributed-interview
-thumb: /img/cds/thumbnails/google-hangout2.jpg
+thumb: /img/cds/google-hangout2.jpg
 processed: 1555352342776
 ---
 Rencontrez Phil et Emily, des membres d’équipe géographiquement dispersés d’Anciens Combattants Canada (ACC) qui ont travaillé avec nous au sein du partenariat de recherche d’avantages et de services.

--- a/content/fr/blog/posts/c’est-quoi-au-juste-un-gestionnaire-de-produits.md
+++ b/content/fr/blog/posts/c’est-quoi-au-juste-un-gestionnaire-de-produits.md
@@ -16,7 +16,7 @@ image-alt: >-
   dispersés de l’équipe de gestion de produits qui travaillent de Montréal,
   Waterloo, Toronto et Ottawa.
 translationKey: product-manager-QA
-thumb: /img/cds/thumbnails/pm-banner-fix.jpg
+thumb: /img/cds/pm-banner-fix.jpg
 processed: 1563904136241
 ---
 

--- a/content/fr/blog/posts/dans-le-monde-numerique-la-securite-se-cache.md
+++ b/content/fr/blog/posts/dans-le-monde-numerique-la-securite-se-cache.md
@@ -11,7 +11,7 @@ date: '2018-07-11 09:00:00 -0400'
 image: /img/cds/the-security-in-digital-is-silent.jpg
 image-alt: Un cadenas ouvert
 translationKey: the-security-in-digital-is-silent
-thumb: /img/cds/thumbnails/the-security-in-digital-is-silent.jpg
+thumb: /img/cds/the-security-in-digital-is-silent.jpg
 processed: 1550672961825
 ---
 

--- a/content/fr/blog/posts/ddp.md
+++ b/content/fr/blog/posts/ddp.md
@@ -11,7 +11,7 @@ date: '2018-08-31 09:00:00 -0400'
 image: /img/cds/rfp_fr.jpg
 image-alt: 'Des autocollants en forme de feuilles d''érables avec les mots, fort et libre.'
 translationKey: rfp
-thumb: /img/cds/thumbnails/rfp_fr.jpg
+thumb: /img/cds/rfp_fr.jpg
 processed: 1550672961826
 ---
 Aujourd'hui, nous (le Service numérique canadien) avons lancé une [demande de propositions](https://achatsetventes.gc.ca/donnees-sur-l-approvisionnement/appels-d-offres/PW-18-00841347). 

--- a/content/fr/blog/posts/de-la-conception-au-développement-la-pluridisciplinarité-au-snc.md
+++ b/content/fr/blog/posts/de-la-conception-au-développement-la-pluridisciplinarité-au-snc.md
@@ -11,7 +11,7 @@ image-alt: >-
   Vue en plan d’une intersection où des voitures sont arrêtées et où des
   personnes attendent pour traverser la rue.
 translationKey: working-across-disciplines
-thumb: /img/cds/thumbnails/yoel-j-gonzalez-304137-unsplash.jpg
+thumb: /img/cds/yoel-j-gonzalez-304137-unsplash.jpg
 processed: 1550672961828
 ---
 J’ai suivi le programme Interactive Multimedia and Design (Conception et multimédias interactifs) à l’université, et j’y ai acquis une solide base à la fois en conception et en développement. Les professeurs nous disaient qu’on travaillerait probablement à la croisée de ces deux disciplines, assurant le lien entre elles. Vers la fin de mon programme, j’ai décidé de me concentrer sur la conception. J’étais loin de savoir que, quelques années plus tard, j’apprendrais à nouveau à coder.

--- a/content/fr/blog/posts/de-la-conception-d’abord-aux-utilisateurs-d’abord.md
+++ b/content/fr/blog/posts/de-la-conception-d’abord-aux-utilisateurs-d’abord.md
@@ -16,7 +16,7 @@ image-alt: >-
   personnes au sommet, à côté de trois blocs empilés avec une échelle et un
   groupe de personnes en-haut.
 translationKey: from-build-first-to-users-first
-thumb: /img/cds/thumbnails/fullsizeoutput_55.jpg
+thumb: /img/cds/fullsizeoutput_55.jpg
 processed: 1550672961830
 ---
 Au Service numérique canadien (SNC), nous sommes heureux de collaborer avec les ministères afin de concevoir de meilleurs [services](https://numerique.canada.ca/produits/). Nous sommes également impatients de partager les leçons apprises de ces expériences pour tenter d’aider les autres dans leur propre travail.

--- a/content/fr/blog/posts/de-petits-gestes-ayant-des-retombées-significatives.md
+++ b/content/fr/blog/posts/de-petits-gestes-ayant-des-retombées-significatives.md
@@ -11,7 +11,7 @@ image-alt: >-
   Un groupe d’intervenants discute devant les participants de l’événement alors
   que des interprètes gestuels se trouvent derrière eux.
 translationKey: small-acts-big-impact
-thumb: /img/cds/thumbnails/diversity-day-banner-image.jpg
+thumb: /img/cds/diversity-day-banner-image.jpg
 processed: 1554413470255
 ---
 Des équipes diversifiées et inclusives offrent des services qui le sont tout autant. C’est pourquoi le vendredi 8 février, le Service numérique canadien a tenu l’événement [Diversité au sein des services numériques](https://www.eventbrite.ca/e/diversity-in-digital-services-diversite-au-sein-des-services-numeriques-registration-51465629082), une journée destinée à échanger des idées à propos de la diversité et de l’inclusion des équipes, ainsi que de leur incidence sur la prestation de meilleurs services.

--- a/content/fr/blog/posts/dircc-au-snc.md
+++ b/content/fr/blog/posts/dircc-au-snc.md
@@ -13,7 +13,7 @@ date: '2018-09-11 09:00:00 -0400'
 image: /img/cds/blog-amir.jpg
 image-alt: Amir dans l'espace de travail du SNC.
 translationKey: ircc-to-cds
-thumb: /img/cds/thumbnails/blog-amir.jpg
+thumb: /img/cds/blog-amir.jpg
 processed: 1550672961831
 ---
 

--- a/content/fr/blog/posts/donner-aux-utilisateurs-les-moyens-de-réussir.md
+++ b/content/fr/blog/posts/donner-aux-utilisateurs-les-moyens-de-réussir.md
@@ -15,7 +15,7 @@ description: >-
   demandeurs, tout en facilitant la vie du personnel administratif.
 image-translation: null
 translationKey: setting-users-up-for-success-with-content-design
-thumb: /img/cds/thumbnails/blog-setting-up-users-for-success.jpg
+thumb: /img/cds/blog-setting-up-users-for-success.jpg
 processed: 1550672961832
 ---
 

--- a/content/fr/blog/posts/données-qualitatives-inconfortables-oui-mais-elles-valent-le-coup.md
+++ b/content/fr/blog/posts/données-qualitatives-inconfortables-oui-mais-elles-valent-le-coup.md
@@ -13,7 +13,7 @@ image-alt: >-
   d’une table. Ils sourient et examinent un diagramme de service composé de
   papillons adhésifs de différentes couleurs.
 translationKey: data-driven-service
-thumb: /img/cds/thumbnails/rcmp-data-blog.jpg
+thumb: /img/cds/rcmp-data-blog.jpg
 processed: 1563384025449
 ---
 Je suis un grand lecteur. J’adore les livres. Mais j’ai parfois du mal à en choisir un. 

--- a/content/fr/blog/posts/déplacer-le-contenu-du-code-vers-le-nuage.md
+++ b/content/fr/blog/posts/déplacer-le-contenu-du-code-vers-le-nuage.md
@@ -10,7 +10,7 @@ date: 2018-12-04T14:30:00.000Z
 image: /img/cds/magnificent-cloud.jpg
 image-alt: Un nuage magnifique s’élève au-dessus des arbres.
 translationKey: from-code-to-cloud
-thumb: /img/cds/thumbnails/magnificent-cloud.jpg
+thumb: /img/cds/magnificent-cloud.jpg
 processed: 1550672961835
 ---
 Au Service numérique canadien (SNC), nous travaillons actuellement sur une [application Web] (https://github.com/cds-snc/vac-benefits-directory) avec Anciens Combattants Canada (ACC). L’application aidera les vétérans et leurs familles à trouver des avantages et des programmes qui leur conviennent. Cela signifie que cette application doit surveiller beaucoup de contenu, soit le texte d’interface, les titres et les descriptions en une ligne des avantages, les questions à choix multiples, les étiquettes associées aux prestations, l’adresse des bureaux d’ACC et d’autres informations, dont aucune ne contenait des données ou des renseignements personnels. Bien sûr, tout ce texte est en anglais et en français.

--- a/content/fr/blog/posts/développer-la-recherche-en-conception-au-gouvernement-du-canada.md
+++ b/content/fr/blog/posts/développer-la-recherche-en-conception-au-gouvernement-du-canada.md
@@ -19,7 +19,7 @@ image-alt: >-
   étant mis sur la main d'un individu tenant une unique pièce de casse-tête
   rouge.
 translationKey: design-research
-thumb: /img/cds/thumbnails/puzzle.jpg
+thumb: /img/cds/puzzle.jpg
 processed: 1562852147949
 ---
 La recherche en conception (ou la recherche sur les utilisateurs) nous aide à comprendre les gens qui utilisent nos services. Si nous les comprenons, nous pouvons mieux répondre à leurs besoins. Nous avons vu à quel point la recherche en conception est importante pour assurer la prestation de services numériques axés sur les personnes dans le cadre de notre travail avec nos partenaires. Nous avons également vu à quel point elle peut facilement être confondue avec la recherche sur l’opinion publique (ROP). 

--- a/content/fr/blog/posts/elaborer-un-plan-de-researche.md
+++ b/content/fr/blog/posts/elaborer-un-plan-de-researche.md
@@ -11,7 +11,7 @@ image-alt: >-
   Les mains d’une femme déballent du papier brun. Il y a un café à la gauche et
   des fleurs violettes à la droite.
 translationKey: building-a-research-plan
-thumb: /img/cds/thumbnails/blog-building-a-research-plan.jpg
+thumb: /img/cds/blog-building-a-research-plan.jpg
 processed: 1550672961836
 ---
 

--- a/content/fr/blog/posts/embauche-au-snc.md
+++ b/content/fr/blog/posts/embauche-au-snc.md
@@ -11,7 +11,7 @@ date: '2018-01-09 09:00:00 -0400'
 image: /img/cds/blog-hiring-2018.jpg
 image-alt: Membres de l’équipe du SNC
 translationKey: hiring-at-cds
-thumb: /img/cds/thumbnails/blog-hiring-2018.jpg
+thumb: /img/cds/blog-hiring-2018.jpg
 processed: 1550672961837
 ---
 Notre manière de faire du recrutement et de renforcer l’effectif d’une équipe de services numériques qui se met immédiatement au travail et qui aide à relever les défis liés aux services dans l’ensemble du gouvernement suscite beaucoup d’intérêt. Voilà pourquoi je suis ravie de bloguer sur les pratiques d’embauche au SNC.

--- a/content/fr/blog/posts/en-pleine-croissance-à-spac-conception-de-services-et-recherche-en-conception.md
+++ b/content/fr/blog/posts/en-pleine-croissance-à-spac-conception-de-services-et-recherche-en-conception.md
@@ -13,7 +13,7 @@ date: 2019-07-30T13:00:00.000Z
 image: /img/cds/pspc-team-1.jpg
 image-alt: Photo de l’équipe de recherche en conception à SPAC.
 translationKey: emilio-pspc
-thumb: /img/cds/thumbnails/pspc-team-1.jpg
+thumb: /img/cds/pspc-team-1.jpg
 processed: 1564604600053
 ---
 Lorsqu’on parle de la conception de services au gouvernement, il est surtout question de la création de services hors pair offerts aux citoyens. Cela est conforme à notre but principal : nous travaillons pour servir les citoyens. Nous devons par conséquent faire en sorte que les citoyens soient placés au cœur des services.

--- a/content/fr/blog/posts/entrevue-de-départ-d’eva-une-petite-promenade-du-côté-privé.md
+++ b/content/fr/blog/posts/entrevue-de-départ-d’eva-une-petite-promenade-du-côté-privé.md
@@ -13,7 +13,7 @@ image-alt: >-
   loufoques, ainsi qu’un portrait de sa mascotte, M. Pinchey, un crabe en
   peluche orange portant un chapeau de requin.
 translationKey: take-a-walk-on-the-private-side
-thumb: /img/cds/thumbnails/eva-blog.jpg
+thumb: /img/cds/eva-blog.jpg
 processed: 1559833507130
 ---
 L’une de nos développeuses bien-aimées, Eva Demers-Brett, membre de l’équipe du gouvernement ouvert (GO), nous quitte ce mois-ci pour entreprendre une aventure passionnante dans le secteur privé 😢. Ce sera la première fois de sa carrière de développeuse qu’elle travaillera à l’extérieur de la fonction publique; c’est pourquoi nous voulions connaître ses réflexions et les leçons qu’elle gardera en tête tandis qu’elle découvre le secteur privé.

--- a/content/fr/blog/posts/faire-confiance-aux-humains-et-aux-robots.md
+++ b/content/fr/blog/posts/faire-confiance-aux-humains-et-aux-robots.md
@@ -10,7 +10,7 @@ date: 2019-03-14T13:00:00.000Z
 image: /img/cds/grass-lawn-robot.jpg
 image-alt: 'Un petit robot en bois se tient debout dans une pelouse verdoyante. '
 translationKey: trust-humans-and-robots
-thumb: /img/cds/thumbnails/grass-lawn-robot.jpg
+thumb: /img/cds/grass-lawn-robot.jpg
 processed: 1552576946528
 ---
 Le développement de produits et la prestation de services efficaces ne sont rien sans la confiance. En tant qu’équipe de prestation au SNC, nous parlons souvent à nos partenaires de nous accorder la confiance pour les aider à quitter leurs zones de confort et à essayer de nouvelles approches. 

--- a/content/fr/blog/posts/faire-equipe-pour-mieux-servir-les-anciens-combattants.md
+++ b/content/fr/blog/posts/faire-equipe-pour-mieux-servir-les-anciens-combattants.md
@@ -11,7 +11,7 @@ date: 2018-07-24T13:00:00.000Z
 image: /img/cds/blog-pei-banner.jpg
 image-alt: Falaise rouge bordée d’herbe surplombant la mer.
 translationKey: teaming-up-to-deliver-better-outcomes-for-veterans
-thumb: /img/cds/thumbnails/blog-pei-banner.jpg
+thumb: /img/cds/blog-pei-banner.jpg
 processed: 1550672961838
 ---
 

--- a/content/fr/blog/posts/faire-une-bonne-première-impression-l’intégration-c’est-important.md
+++ b/content/fr/blog/posts/faire-une-bonne-première-impression-l’intégration-c’est-important.md
@@ -15,7 +15,7 @@ image-alt: >-
   étant collés sur les moniteurs de façon à écrire «Bienvenue Eman», et le
   bureau étant recouvert d'autocollants, de chocolats et de confettis.
 translationKey: onboarding-matters
-thumb: /img/cds/thumbnails/onboarding-banner-fitted.jpg
+thumb: /img/cds/onboarding-banner-fitted.jpg
 processed: 1564420750598
 ---
 En tant qu’organisme en pleine expansion, nous accueillons de nouveaux employés quasiment toutes les semaines. S’il s’agit de routine pour nous, c’est un événement unique pour les employés qui commencent. Un nouvel emploi peut être stressant, et la décision de garder son poste ou de passer à autre chose se prend souvent lors des premiers jours. Il est donc essentiel que nous créions une excellente expérience d’intégration. Après tout, les personnes sont au cœur de notre travail — il ne faut pas l’oublier. 

--- a/content/fr/blog/posts/former-une-équipe-multidisciplinaire-à-edsc-pour-mieux-servir-les-gens.md
+++ b/content/fr/blog/posts/former-une-équipe-multidisciplinaire-à-edsc-pour-mieux-servir-les-gens.md
@@ -15,7 +15,7 @@ date: 2019-06-19T13:00:00.000Z
 image: /img/cds/mic.jpg
 image-alt: microphone à condensateur sur fond noir
 translationKey: building-a-multidisciplinary-team-at-ESDC-to-serve-people-better
-thumb: /img/cds/thumbnails/mic.jpg
+thumb: /img/cds/mic.jpg
 processed: 1561556658181
 ---
 À titre de gestionnaire de la Stratégie d’amélioration des services du Régime de pensions du Canada à Emploi et Développement social Canada (EDSC), j’ai contribué à la constitution de l’équipe multidisciplinaire au Service numérique canadien (SNC) qui travaille à l’amélioration du Régime de pensions du Canada (RPC) pour les personnes qui demandent des prestations d’invalidité. 

--- a/content/fr/blog/posts/innover-à-la-fois-à-l’interne-et-à-l’externe-chez-edsc.md
+++ b/content/fr/blog/posts/innover-à-la-fois-à-l’interne-et-à-l’externe-chez-edsc.md
@@ -15,7 +15,7 @@ image-alt: >-
   monde de Trello, Slack et FunRetro » sur un fond bleu clair sur une photo des
   bois.
 translationKey: innovating-esdc
-thumb: /img/cds/thumbnails/esdc-innovation-fr.jpg
+thumb: /img/cds/esdc-innovation-fr.jpg
 processed: 1563891110033
 ---
 À Emploi et Développement social Canada, nous avons vraiment commencé à embrasser l’idée d’être novateurs dans la façon dont nous fournissons des services et des informations à nos clients. Ce qui parfois nous semble plus difficile, c’est de nous ouvrir à de nouvelles façons de faire notre travail quotidien *à l’interne*.

--- a/content/fr/blog/posts/la-fois-où-la-tenue-d’un-ama-a-ressemblé-à-une-course-à-relais.md
+++ b/content/fr/blog/posts/la-fois-où-la-tenue-d’un-ama-a-ressemblé-à-une-course-à-relais.md
@@ -15,7 +15,7 @@ image-alt: >-
   Vue aérienne de 4 coureurs à relais parcourant une piste dotée de 4 voies
   parallèles.
 translationKey: relay-race-ama
-thumb: /img/cds/thumbnails/ama-banner.jpg
+thumb: /img/cds/ama-banner.jpg
 processed: 1566597193279
 ---
 Imaginez que vous êtes le premier coureur d’une course à relais de 400 m. Vous vous placez en position de départ. On donne le signal, et vous vous lancez aussitôt dans un sprint en ne ménageant aucun effort. En vous approchant de la marque des 100 m, vous vous apercevez que personne n’est prêt à prendre le relais. Oh non! Vous devez maintenant continuer sur la même lancée et poursuivre ce sprint jusqu’à la fin de la course. 

--- a/content/fr/blog/posts/la-meilleure-attaque-de-panique-que-j’ai-jamais-eue.md
+++ b/content/fr/blog/posts/la-meilleure-attaque-de-panique-que-j’ai-jamais-eue.md
@@ -12,7 +12,7 @@ image-alt: >-
   Une image des rayons de la bibliothèque de Montréal où j’ai eu une crise de
   panique.
 translationKey: best-panic-attack
-thumb: /img/cds/thumbnails/montreal-library.jpg
+thumb: /img/cds/montreal-library.jpg
 processed: 1575304320916
 ---
 Il y a exactement un an, j’ai eu une crise de panique dans les toilettes de la Grande Bibliothèque à Montréal.

--- a/content/fr/blog/posts/la-phase-de-decouverte-comprendre-le-probleme.md
+++ b/content/fr/blog/posts/la-phase-de-decouverte-comprendre-le-probleme.md
@@ -16,7 +16,7 @@ image-alt: >-
   Deux personnes sont assises à une table et utilisent des gestes de la main en
   discutant de leur travail.
 translationKey: discovery-phase-understanding-the-problem
-thumb: /img/cds/thumbnails/blog-discovery.jpg
+thumb: /img/cds/blog-discovery.jpg
 processed: 1550672961839
 ---
 

--- a/content/fr/blog/posts/la-sécurité-c’est-difficile-mais-c’est-aussi-nécessaire-et-gérable.md
+++ b/content/fr/blog/posts/la-sécurité-c’est-difficile-mais-c’est-aussi-nécessaire-et-gérable.md
@@ -9,7 +9,7 @@ image-alt: >-
   L’application utilise un fichier ESLint pour faire une analyse statique de
   programmes.
 translationKey: security-hard
-thumb: /img/cds/thumbnails/airplane.jpg
+thumb: /img/cds/airplane.jpg
 processed: 1561556658198
 ---
 La sécurité numérique, c’est difficile. Même les meilleures équipes d’ingénieurs et de spécialistes des TI sont susceptibles de faire des erreurs à un moment donné. Mais tout comme la sécurité dans les aéroports, les étapes et les processus en place sont là pour votre sûreté.

--- a/content/fr/blog/posts/la-sécurité-c’est-sérieux-nous-avons-tous-des-clés-de-sécurité-au-snc.md
+++ b/content/fr/blog/posts/la-sécurité-c’est-sérieux-nous-avons-tous-des-clés-de-sécurité-au-snc.md
@@ -10,7 +10,7 @@ date: 2019-08-15T13:00:00.000Z
 image: /img/cds/yubikey-3.jpg
 image-alt: Une main qui appuie sur sa clé yubikey.
 translationKey: yubikey-post
-thumb: /img/cds/thumbnails/yubikey-3.jpg
+thumb: /img/cds/yubikey-3.jpg
 processed: 1565980653077
 ---
 J’ai peur, très peur! J’ai peur de me réveiller le matin et de constater que les ressources infonuagiques du Service numérique canadien (SNC) ont été vandalisées ou détruites parce qu’une personne mal intentionnée a mis la main sur les justificatifs d’identité de quelqu’un et a décidé de tout bousiller. Cette peur est réelle, et même les plus consciencieux d’entre nous sont vulnérables.

--- a/content/fr/blog/posts/lacunes-linguistiques.md
+++ b/content/fr/blog/posts/lacunes-linguistiques.md
@@ -13,7 +13,7 @@ image-alt: >-
   Un caniche français et un bouledogue anglais assis devant des ordinateurs
   portables.
 translationKey: language-gap
-thumb: /img/cds/thumbnails/blog-language-gap.jpg
+thumb: /img/cds/blog-language-gap.jpg
 processed: 1550672961841
 ---
 

--- a/content/fr/blog/posts/lancement-du-service-numerique-canadien.md
+++ b/content/fr/blog/posts/lancement-du-service-numerique-canadien.md
@@ -13,7 +13,7 @@ date: '2017-07-18 09:00:00 -0400'
 image: /img/cds/launch-post-2017.jpg
 image-alt: 'L''honorable Scott Brison, Président du Conseil du Trésor'
 translationKey: launch-of-the-canadian-digital-service
-thumb: /img/cds/thumbnails/launch-post-2017.jpg
+thumb: /img/cds/launch-post-2017.jpg
 processed: 1550672961842
 ---
 Les Canadiens méritent des services gouvernementaux accessibles et faciles à utiliser. Ils s’attendent à ce que leur gouvernement fournisse des services axés sur les citoyens. Dans ce monde hyper connecté du 21<sup>e</sup> siècle, un service de qualité entend la prestation numérique, qu’il s’agisse de commander un mets à emporter, de renouveler son hypothèque, de gérer ses ordonnances ou d’accéder à des programmes et services gouvernementaux.

--- a/content/fr/blog/posts/le-bon-le-méchant-et-la-lutte-récapitulation-de-la-semaine-de-la-décentralisation-du-snc.md
+++ b/content/fr/blog/posts/le-bon-le-méchant-et-la-lutte-récapitulation-de-la-semaine-de-la-décentralisation-du-snc.md
@@ -13,7 +13,7 @@ image-alt: >-
   Photo de Lynn dans Google Hangouts du point de vue du bureau à domicile de
   Charlotte.
 translationKey: CDS-distributed
-thumb: /img/cds/thumbnails/google-hangout.jpg
+thumb: /img/cds/google-hangout.jpg
 processed: 1555352899385
 ---
 Au cours de la dernière année, le Service numérique canadien (SNC) a pris une expansion considérable. Il compte maintenant des collègues à Ottawa, à Toronto, à Montréal et à Kitchener-Waterloo. Bien que notre bureau à Ottawa compte le plus grand nombre d’employés, nous sommes un organisme géographiquement dispersé. Nous travaillons dans un environnement où tout le monde, peu importe leur emplacement géographique, est en mesure de contribuer aux objectifs de l’équipe de la même façon que le fait une équipe dont les membres travaillent tous dans le même bureau.

--- a/content/fr/blog/posts/le-point-sur-notre-demande-de-propositions.md
+++ b/content/fr/blog/posts/le-point-sur-notre-demande-de-propositions.md
@@ -7,7 +7,7 @@ date: 2019-01-22T14:00:00.000Z
 image: /img/cds/rfp_fr.jpg
 image-alt: 'Des autocollants en forme de feuilles d''érables avec les mots, fort et libre.'
 translationKey: update-rfp
-thumb: /img/cds/thumbnails/rfp_fr.jpg
+thumb: /img/cds/rfp_fr.jpg
 processed: 1550858572535
 ---
 Nous tenons à remercier tous les soumissionnaires qui ont consacré le temps et les efforts nécessaires pour répondre à notre [demande de propositions](https://achatsetventes.gc.ca/donnees-sur-l-approvisionnement/appels-d-offres/PW-18-00841347). Depuis que le processus de demande de propositions a pris fin, nous travaillons sans relâche à l’évaluation des soumissions, mais cela prend plus de temps que nous l’aurions souhaité. Nous savons que vous et vos équipes devez établir des plans. Cela dit, voici une mise à jour sur le calendrier le plus plausible et quelques rappels :

--- a/content/fr/blog/posts/le-recrutement-de-notre-dirigeant-principal.md
+++ b/content/fr/blog/posts/le-recrutement-de-notre-dirigeant-principal.md
@@ -8,7 +8,7 @@ image-alt: >-
   Le dirigeant principal Aaron Snow discute avec deux autres membres de
   l’équipe.
 translationKey: recruiting-our-ceo
-thumb: /img/cds/thumbnails/blog-ceo-recruitment.jpg
+thumb: /img/cds/blog-ceo-recruitment.jpg
 processed: 1550672962164
 ---
 

--- a/content/fr/blog/posts/les-choix-technologiques-du-snc.md
+++ b/content/fr/blog/posts/les-choix-technologiques-du-snc.md
@@ -18,7 +18,7 @@ date: '2017-11-06 09:00:00 -0400'
 image: /img/cds/blog-technology-choices-at-cds-2017.jpg
 image-alt: Un écran d'ordinateur montrant les résultats d'une série de tests.
 translationKey: technology-choices-at-cds
-thumb: /img/cds/thumbnails/blog-technology-choices-at-cds-2017.jpg
+thumb: /img/cds/blog-technology-choices-at-cds-2017.jpg
 processed: 1550672962165
 ---
 Il y a quelques semaines, nous avons lancé notre [campagne de recrutement publique](/rejoindre-notre-equipe/) dans le but d’embaucher des concepteurs, des développeurs, des scientifiques de données, des gestionnaires de produits et des experts en mobilisation. S’informant au sujet du volet des développeurs, certains nous ont demandé avec quelles plateformes technologiques et quels langages de programmation nous travaillons. Excellente question! L’un des aspects excitants de vous joindre au Service numérique canadien (SNC) si tôt dans notre existence est que vous aurez la chance de modeler la façon dont nos choix technologiques évoluent. Dans cet esprit, c’est-à-dire qu’aucune de ces technologies n’est définitive, j’ai pensé faire le point sur le raisonnement de notre équipe de développement à ce jour ainsi que sur les deux objectifs (en opposition) qui influencent nos choix technologiques.

--- a/content/fr/blog/posts/les-tests-automatises.md
+++ b/content/fr/blog/posts/les-tests-automatises.md
@@ -17,7 +17,7 @@ image-alt: >-
   ordinateurs portables. Une personne montre du doigt l’écran de la personne en
   face d’elle qui montre un signe d’accord.
 translationKey: automated-testing-blog
-thumb: /img/cds/thumbnails/blog-automated-testing.jpg
+thumb: /img/cds/blog-automated-testing.jpg
 processed: 1550672962167
 ---
 

--- a/content/fr/blog/posts/lexique.md
+++ b/content/fr/blog/posts/lexique.md
@@ -12,7 +12,7 @@ date: '2018-08-17 09:00:00 -0400'
 image: /img/cds/blog-lexicon.jpg
 image-alt: Une illustration d’un combo laveuse-sécheuse.
 translationKey: lexicon
-thumb: /img/cds/thumbnails/blog-lexicon.jpg
+thumb: /img/cds/blog-lexicon.jpg
 processed: 1550672962167
 ---
 

--- a/content/fr/blog/posts/libérer-le-talent et-4-autres-conseils-pour-changer-le-gouvernement.md
+++ b/content/fr/blog/posts/libérer-le-talent et-4-autres-conseils-pour-changer-le-gouvernement.md
@@ -9,7 +9,7 @@ date: 2019-01-03T14:00:35.062Z
 image: /img/cds/nordwood-themes-1066398-unsplash.jpg
 image-alt: '2019 écrit en feux d''artifices, Photo : NordWood Themes/Unsplash'
 translationKey: unleash-talent
-thumb: /img/cds/thumbnails/nordwood-themes-1066398-unsplash.jpg
+thumb: /img/cds/nordwood-themes-1066398-unsplash.jpg
 processed: 1550672962169
 ---
 Après deux ans à bâtir le SNC, j’ai voulu partager quelques réflexions sur ce que j’ai appris. Avec l’aide de nos partenaires, nous changeons la façon dont le gouvernement conçoit et livre ses services. Néanmoins, le chemin à parcourir est long. Voici ce qui nous permettra d’y arriver :

--- a/content/fr/blog/posts/l’accord-parfait-quand-les-politiques-renforcent-la-recherche-en-conception.md
+++ b/content/fr/blog/posts/l’accord-parfait-quand-les-politiques-renforcent-la-recherche-en-conception.md
@@ -9,7 +9,7 @@ date: 2019-02-27T14:00:00.000Z
 image: /img/cds/tim-swaan-45717-unsplash.jpg
 image-alt: Une passerelle qui mène vers une forêt.
 translationKey: user-interview-policy
-thumb: /img/cds/thumbnails/tim-swaan-45717-unsplash.jpg
+thumb: /img/cds/tim-swaan-45717-unsplash.jpg
 processed: 1552050695071
 ---
 Si vous êtes un fonctionnaire et que vous souhaitez mener des entrevues auprès des gens qui utilisent votre service, ce billet est pour vous. Dans tout secteur, il peut déjà être difficile de recruter des personnes à des fins de recherche en conception de services. Le gouvernement, toutefois, a des exigences supplémentaires. Bien que certaines d’entre elles soient justifiées par sa position en tant qu’autorité, [d’autres peuvent découler d’une culture ou d’habitudes](https://numerique.canada.ca/2018/09/07/politiques/). Dans ce billet, nous vous montrons comment nous avons fait pour recruter des anciens combattants et mener notre recherche.

--- a/content/fr/blog/posts/montrer-liceberg-en-entier.md
+++ b/content/fr/blog/posts/montrer-liceberg-en-entier.md
@@ -13,7 +13,7 @@ image-alt: >-
   Une personne debout derrière un podium fait signe vers un iceberg qui flotte
   dans un aquarium, alors qu’un petit chien observe.
 translationKey: showing-the-whole-iceberg
-thumb: /img/cds/thumbnails/blog-iceberg-header.jpg
+thumb: /img/cds/blog-iceberg-header.jpg
 processed: 1550672962171
 ---
 

--- a/content/fr/blog/posts/notre-partenariat-avec-code-for-canada.md
+++ b/content/fr/blog/posts/notre-partenariat-avec-code-for-canada.md
@@ -12,7 +12,7 @@ image-alt: >-
   Les six membres de la première cohorte d’associés de Code for Canada à
   l’extérieur de l’édifice du parlement provincial à Toronto.
 translationKey: our-partnership-with-code-for-canada
-thumb: /img/cds/thumbnails/blog-c4c.jpg
+thumb: /img/cds/blog-c4c.jpg
 processed: 1550672962173
 ---
 

--- a/content/fr/blog/posts/nous-aimons-les-bons-défis.md
+++ b/content/fr/blog/posts/nous-aimons-les-bons-défis.md
@@ -12,7 +12,7 @@ image-alt: >-
   Aaron est en train de parler sur un podium, devant une bannière colorée
   affichant « FWD50 », et un écran à l’avant indique « Défi accepté ».
 translationKey: we-love-a-good-challenge
-thumb: /img/cds/thumbnails/aaron-fwd50-challenge-accepted-fr.jpg
+thumb: /img/cds/aaron-fwd50-challenge-accepted-fr.jpg
 processed: 1557832757239
 ---
 L’été dernier, le gouvernement fédéral a réuni des chefs de file de l’industrie canadienne pour aider à orienter les [stratégies économiques du Canada](https://www.ic.gc.ca/eic/site/098.nsf/fra/accueil). L’un de ces groupes, soit la Table sur les industries numériques qui était présidée par le président-directeur général de Shopify, [Tobi Lütke](https://twitter.com/tobi), a examiné la façon dont le Canada pourrait devenir un chef de file du numérique. Son rapport, publié en septembre 2018, [présente une vision audacieuse](https://www.ic.gc.ca/eic/site/098.nsf/vwapj/ISEDC_IndustriesNumeriques.pdf/%24file/ISEDC_IndustriesNumeriques.pdf) du Canada en tant que société numérique.

--- a/content/fr/blog/posts/nous-lançons-un-accélérateur-pour-tester-l’investissement-progressif.md
+++ b/content/fr/blog/posts/nous-lançons-un-accélérateur-pour-tester-l’investissement-progressif.md
@@ -10,7 +10,7 @@ date: 2019-05-02T20:00:00.000Z
 image: /img/cds/blog-up-to-speed.jpg
 image-alt: Indicateur de vitesse
 translationKey: accelerator-launch
-thumb: /img/cds/thumbnails/blog-up-to-speed.jpg
+thumb: /img/cds/blog-up-to-speed.jpg
 processed: 1556885855972
 ---
 La collaboration avec le secteur privé joue un rôle important dans les pays qui font de grands progrès en matière de gouvernement numérique. Le gouvernement ne peut pas y arriver seul. La passation de marchés contribue à l’expansion des technologies modernes et des méthodes de conception dans le secteur public. Les entreprises apportent une expertise spécialisée, une capacité d’intensification flexible, une envergure et une expérience à la fine pointe de la technologie et de la pratique.

--- a/content/fr/blog/posts/nous-sommes-tous-concernes.md
+++ b/content/fr/blog/posts/nous-sommes-tous-concernes.md
@@ -6,7 +6,7 @@ date: '2017-11-20 09:00:00 -0400'
 image: /img/cds/blog-in-this-together-2017.jpg
 image-alt: L’équipe des Services numériques de l’Ontario.
 translationKey: n-this-together
-thumb: /img/cds/thumbnails/blog-in-this-together-2017.jpg
+thumb: /img/cds/blog-in-this-together-2017.jpg
 processed: 1550672962174
 ---
 Il y a environ un mois, j’ai eu la chance de participer à la [conférence Connected150](http://www.connected150.ca) et de passer un peu de temps avec nos collègues du Service numérique canadien (SNC). 

--- a/content/fr/blog/posts/obtenir-un-wi-fi-externe-dans-les-bureaux-du-gouvernement.md
+++ b/content/fr/blog/posts/obtenir-un-wi-fi-externe-dans-les-bureaux-du-gouvernement.md
@@ -11,7 +11,7 @@ date: 2019-02-06T14:00:58.492Z
 image: /img/cds/img_20190206_121320.jpg
 image-alt: Une personne raccorde son Macbook à un appareil MiFi portatif.
 translationKey: external-wifi
-thumb: /img/cds/thumbnails/img_20190206_121320.jpg
+thumb: /img/cds/img_20190206_121320.jpg
 processed: 1550672962184
 ---
 Le fait d’avoir accès à des outils modernes est une condition préalable pour la prestation de services numériques modernes. Nous avons écrit auparavant au sujet de [l’importance des outils modernes](https://numerique.canada.ca/2018/06/27/outils-pour-faire-du-bon-travail/), tels que des MacBook et des ordinateurs portables basés sur Linux, pour la conception et le développement de logiciels.

--- a/content/fr/blog/posts/on-s’en-sort-avec-l’aide-de-nos-amis.md
+++ b/content/fr/blog/posts/on-s’en-sort-avec-l’aide-de-nos-amis.md
@@ -11,7 +11,7 @@ date: 2019-01-31T14:00:00.000Z
 image: /img/cds/katka-pavlickova-131100-unsplash-min.jpg
 image-alt: Deux vieux Volkswagen Beetles se font face dans un champ sous un ciel bleu.
 translationKey: help-from-friends
-thumb: /img/cds/thumbnails/katka-pavlickova-131100-unsplash-min.jpg
+thumb: /img/cds/katka-pavlickova-131100-unsplash-min.jpg
 processed: 1550672962186
 ---
 Des collègues fonctionnaires me demandent souvent « Quelles autorisations le Service numérique canadien (SNC) a-t-il obtenues pour fonctionner comme il le fait ? » J’ai donc pensé vous faire part des autorisations que nous avons reçues du gouvernement quand le SNC a été fondé en 2017:

--- a/content/fr/blog/posts/on-vous-présente-notification.md
+++ b/content/fr/blog/posts/on-vous-présente-notification.md
@@ -13,7 +13,7 @@ image-alt: >-
   des écrans affiche la page d’accueil du service Notification, l’un en anglais,
   l’autre en français. 
 translationKey: introducing-notify
-thumb: /img/cds/thumbnails/introducing-notify.jpg
+thumb: /img/cds/introducing-notify.jpg
 processed: 1575304320958
 ---
 Imaginez un scénario où chaque fois que vous utilisez un service gouvernemental, toute l’information nécessaire est acheminée au bon destinataire, au bon moment, et vous en avez l’assurance du début à la fin. Ces derniers mois, nous avons consacré notre temps à élaborer une solution qui aiderait le gouvernement du Canada à atteindre cet objectif.

--- a/content/fr/blog/posts/outils-pour-faire-du-bon-travail.md
+++ b/content/fr/blog/posts/outils-pour-faire-du-bon-travail.md
@@ -9,7 +9,7 @@ date: '2018-06-27 09:00:00 -0400'
 image: /img/cds/blog-tools-for-work-2018.jpg
 image-alt: Plusieurs ordinateurs MacBook couverts d'autocollants sur une table.
 translationKey: tools-to-do-good-work
-thumb: /img/cds/thumbnails/blog-tools-for-work-2018.jpg
+thumb: /img/cds/blog-tools-for-work-2018.jpg
 processed: 1550672962188
 ---
 

--- a/content/fr/blog/posts/parler-numerique-en-francais.md
+++ b/content/fr/blog/posts/parler-numerique-en-francais.md
@@ -13,7 +13,7 @@ author: 'Annie Leblond, communications'
 image: /img/cds/blog-discussing-digital-in-french-2017.jpg
 image-alt: Clavier d’ordinateur avec une touche illustrant le drapeau de la France.
 translationKey: discussing-digital-in-french/
-thumb: /img/cds/thumbnails/blog-discussing-digital-in-french-2017.jpg
+thumb: /img/cds/blog-discussing-digital-in-french-2017.jpg
 processed: 1550672962190
 ---
 Demain, le 30 septembre, ce sera la Journée mondiale de la traduction. Pour moi, parler du numérique en français, c’est un défi&nbsp;: Nommer correctement les nouveautés technologiques et *surtout* – surtout – ne pas perdre de vue que nous nous adressons à «&nbsp;du vrai monde&nbsp;». **Penser à l’utilisateur d’abord, le placer au cœur de notre travail, c’est aussi dans les mots que nous choisissons**.

--- a/content/fr/blog/posts/politiques.md
+++ b/content/fr/blog/posts/politiques.md
@@ -6,7 +6,7 @@ date: '2018-09-07 09:00:00 -0400'
 image: /img/cds/blog-puzzle.jpg
 image-alt: Morceaux de casse-tête de couleurs différentes connectés ensemble.
 translationKey: policy
-thumb: /img/cds/thumbnails/blog-puzzle.jpg
+thumb: /img/cds/blog-puzzle.jpg
 processed: 1550672962191
 ---
 Au sein du Service numérique canadien, nous avons eu la chance d'apprendre de plusieurs grands modèles du Royaume-Uni, des États-Unis, de l'Italie, de l'Australie, de l'Ontario et de bien d'autres endroits, alors que nous travaillons avec nos partenaires pour améliorer les services numériques offerts aux Canadiens et aux Canadiennes. Nous utilisons des techniques bien établies pour diriger cette mission : regrouper des talents multidisciplinaires en équipes qui s'attaquent ensemble aux questions de service. Nos équipes de produits sont composées de concepteurs, de chercheurs, de développeurs et de gestionnaires de produit, puis nous avons également intégré des spécialistes en politiques et communications. 

--- a/content/fr/blog/posts/pourquoi-canada-a-besoin-service-numerique.md
+++ b/content/fr/blog/posts/pourquoi-canada-a-besoin-service-numerique.md
@@ -14,7 +14,7 @@ image-alt: >-
   Ryan Androsoff, Lena Trudeau, Anatole Papadopoulos, Olivia Neal et Pascale
   Elvas
 translationKey: why-canada-needs-a-digital-service/
-thumb: /img/cds/thumbnails/why-canada-needs-a-digital-service-2017.jpg
+thumb: /img/cds/why-canada-needs-a-digital-service-2017.jpg
 processed: 1550672962193
 ---
 Pendant plusieurs mois, j’ai travaillé en coulisses pour défendre cette cause qu’est le Service numérique canadien (SNC). J’ai beaucoup réfléchi à la raison d’être d’une organisation dédiée aux services numériques au Canada, ainsi qu’au potentiel de cette organisation de changer la façon de concevoir les services gouvernementaux. 

--- a/content/fr/blog/posts/recherche-dirigeant-principal-du-service-numerique-canadien.md
+++ b/content/fr/blog/posts/recherche-dirigeant-principal-du-service-numerique-canadien.md
@@ -13,7 +13,7 @@ date: '2017-09-12 09:00:00 -0400'
 image: /img/cds/wanted-ceo-cds-2017.jpg
 image-alt: 'Yaprak Baltacıoğlu, Secrétaire du Conseil du Trésor'
 translationKey: wanted-ceo-cds/
-thumb: /img/cds/thumbnails/wanted-ceo-cds-2017.jpg
+thumb: /img/cds/wanted-ceo-cds-2017.jpg
 processed: 1550672962199
 ---
  Les services fournis par notre gouvernement jouent un rôle important dans la vie de millions de gens. 

--- a/content/fr/blog/posts/reduire-le-risque-grace-au-deploiement-continu.md
+++ b/content/fr/blog/posts/reduire-le-risque-grace-au-deploiement-continu.md
@@ -8,7 +8,7 @@ date: '2018-05-16 09:00:00 -0400'
 image: /img/cds/blog-continuous-deployment.jpg
 image-alt: Un homme travaille à un bureau sur le code.
 translationKey: reducing-risk-through-continuous-deployment
-thumb: /img/cds/thumbnails/blog-continuous-deployment.jpg
+thumb: /img/cds/blog-continuous-deployment.jpg
 processed: 1550672962200
 ---
 La plupart des ministères avec qui nous travaillons déploient de nouvelles versions de leur code tous les 4, 6 ou 12 mois. Cette façon de faire cadre bien avec le processus de [développement de logiciel en cascade](https://cyclededeveloppementdunlogiciel.wordpress.com/le-modele-en-cascade/), souvent accompagné de sérieux risques. 

--- a/content/fr/blog/posts/remettre-en-question.md
+++ b/content/fr/blog/posts/remettre-en-question.md
@@ -11,7 +11,7 @@ date: '2018-01-16 09:00:00 -0400'
 image: /img/cds/blog-accessibility-2018.jpg
 image-alt: Clavier avec des touches représentant des fonctionnalités d'accessibilité
 translationKey: challenging-our-assumption
-thumb: /img/cds/thumbnails/blog-accessibility-2018.jpg
+thumb: /img/cds/blog-accessibility-2018.jpg
 processed: 1550672962201
 ---
 

--- a/content/fr/blog/posts/remue-méninges-en-équipe-durant-la-semaine-d’idéation-c’est-peut-être-une-idée-terrible-mais….md
+++ b/content/fr/blog/posts/remue-méninges-en-équipe-durant-la-semaine-d’idéation-c’est-peut-être-une-idée-terrible-mais….md
@@ -14,7 +14,7 @@ image-alt: >-
   Les membres de l'équipe de produits du RPC regardent des ampoules électriques
   tirées au-dessus de leur tête.
 translationKey: brainstorming-ideation-week
-thumb: /img/cds/thumbnails/ideas.jpg
+thumb: /img/cds/ideas.jpg
 processed: 1566844000861
 ---
 Imaginez-vous au travail, debout devant votre équipe, en train de dire la pire idée que vous ayez jamais eue. Cela vous rend-il mal à l’aise? Nous avons été conditionnés à ne présenter que nos meilleures idées. Mais dire les pires idées possible est exactement ce que j’ai demandé à mon équipe au cours de notre dernière Semaine d’idéation. Permettez-moi d’expliquer pourquoi cet exercice « farfelu » était en fait une très bonne idée.

--- a/content/fr/blog/posts/reporter-un-rendez-vous-dexamen.md
+++ b/content/fr/blog/posts/reporter-un-rendez-vous-dexamen.md
@@ -12,7 +12,7 @@ image-alt: >-
   La salle d'attente du centre de soutien à la clientèle d'IRCC avec neuf places
   au comptoir de service.
 translationKey: reschedule-a-citizenship-appointment
-thumb: /img/cds/thumbnails/blog-ircc-april.jpg
+thumb: /img/cds/blog-ircc-april.jpg
 processed: 1550672962203
 ---
 

--- a/content/fr/blog/posts/retrospective-sur-lapi-denerguide.md
+++ b/content/fr/blog/posts/retrospective-sur-lapi-denerguide.md
@@ -14,7 +14,7 @@ image-alt: >-
   personnes debouts devant eux qui regroupent des papiers autocollants («
   post-it ») sur le tableau blanc.
 translationKey: retrospective-on-EnerGuide-api
-thumb: /img/cds/thumbnails/blog-energuide-retro.jpg
+thumb: /img/cds/blog-energuide-retro.jpg
 processed: 1550672962208
 ---
 

--- a/content/fr/blog/posts/se-mettre-a-niveau-au-sien-dune-equipe-agile.md
+++ b/content/fr/blog/posts/se-mettre-a-niveau-au-sien-dune-equipe-agile.md
@@ -9,7 +9,7 @@ date: '2018-10-16 09:00:00 -0400'
 image: /img/cds/blog-up-to-speed.jpg
 image-alt: Le tableau de bord d’une voiture avec l’indicateur de vitesse.
 translationKey: getting-up-to-speed
-thumb: /img/cds/thumbnails/blog-up-to-speed.jpg
+thumb: /img/cds/blog-up-to-speed.jpg
 processed: 1550672962210
 ---
 

--- a/content/fr/blog/posts/se-rencontrer-en-vrai-bâtit-la-confiance-d’une-équipe.md
+++ b/content/fr/blog/posts/se-rencontrer-en-vrai-bâtit-la-confiance-d’une-équipe.md
@@ -9,7 +9,7 @@ date: 2019-01-10T14:00:00.000Z
 image: /img/cds/groupvac_cds.jpg
 image-alt: Les membres de l’équipe sont rassemblés et sourient pour une photo.
 translationKey: VAC-CDS-visit
-thumb: /img/cds/thumbnails/groupvac_cds.jpg
+thumb: /img/cds/groupvac_cds.jpg
 processed: 1550672962212
 ---
 En tant qu’analyste d’entreprise consultante à Anciens Combattants Canada (ACC) à Charlottetown, en partenariat avec le Service numérique canadien (SNC), il est difficile de participer à un projet en cours alors que les équipes sont situées dans différentes villes. Malgré nos mêlées quotidiennes à distance, nous ne faisons pas connaissance avec tout le monde, et il est difficile d’associer une voix à un nom sans s’être jamais rencontrés. 

--- a/content/fr/blog/posts/sortir-les-prototypes.md
+++ b/content/fr/blog/posts/sortir-les-prototypes.md
@@ -12,7 +12,7 @@ image-alt: >-
   La première équipe de prestation du SNC en train de finaliser et de tester la
   première version de l'application de breffage électronique.
 translationKey: getting-prototypes-out-the-door
-thumb: /img/cds/thumbnails/blog-ebriefing-2018.jpg
+thumb: /img/cds/blog-ebriefing-2018.jpg
 processed: 1550672962220
 ---
 

--- a/content/fr/blog/posts/strategie-en-matiere-de-competences-mondiales.md
+++ b/content/fr/blog/posts/strategie-en-matiere-de-competences-mondiales.md
@@ -16,7 +16,7 @@ date: '2018-10-12 09:00:00 -0400'
 image: /img/cds/blog-global-skills-strategy.jpg
 image-alt: Une femme porte des chaussures argentées sur une plate-forme de métro.
 translationKey: global-skills-strategy
-thumb: /img/cds/thumbnails/blog-global-skills-strategy.jpg
+thumb: /img/cds/blog-global-skills-strategy.jpg
 processed: 1550672962324
 ---
 

--- a/content/fr/blog/posts/supporter-utilisateurs-degradation-progressive-react.md
+++ b/content/fr/blog/posts/supporter-utilisateurs-degradation-progressive-react.md
@@ -9,7 +9,7 @@ image-alt: >-
   électroniques, y compris un téléphone à cadran, un téléphone à clapet, un
   ordinateur portable et une tour d’ordinateur de bureau.
 translationKey: supporting-users-gracefully-degrading-react
-thumb: /img/cds/thumbnails/blog-noJS.jpg
+thumb: /img/cds/blog-noJS.jpg
 processed: 1550672962326
 ---
 

--- a/content/fr/blog/posts/tests-de-validation-une-façon-de-remettre-en-question-ses-hypothèses.md
+++ b/content/fr/blog/posts/tests-de-validation-une-façon-de-remettre-en-question-ses-hypothèses.md
@@ -14,7 +14,7 @@ image-alt: >-
   Cinq cactus de couleur différente (orange, rouge, vert, rose et jaune) placés
   côte à côte dans des pots blancs et devant un fond blanc.
 translationKey: validation-testing-cra
-thumb: /img/cds/thumbnails/colourful-cactuses.jpg
+thumb: /img/cds/colourful-cactuses.jpg
 processed: 1564689903502
 ---
 Placer les gens au centre de notre travail, c’est aussi avoir confiance qu’ils sont les experts de leur contexte et de leurs besoins. 

--- a/content/fr/blog/posts/toujours-un-defi.md
+++ b/content/fr/blog/posts/toujours-un-defi.md
@@ -10,7 +10,7 @@ date: '2017-12-07 09:00:00 -0400'
 image: /img/cds/blog-toujours-un-defi-2017.jpg
 image-alt: La page d’accueil de la plateforme de défis Impact Canada.
 translationKey: always-a-challenge
-thumb: /img/cds/thumbnails/blog-toujours-un-defi-2017.jpg
+thumb: /img/cds/blog-toujours-un-defi-2017.jpg
 processed: 1550672962330
 ---
 Au cours de nos [séances de mobilisation](/commencement-de-la-conversation/rapport-complet/), les gens nous ont dit que le gouvernement devait trouver des façons de permettre aux joueurs non traditionnels de s’impliquer et de co-créer des solutions avec le gouvernement.

--- a/content/fr/blog/posts/une-équipe-renforcée-par-la-distance.md
+++ b/content/fr/blog/posts/une-équipe-renforcée-par-la-distance.md
@@ -13,7 +13,7 @@ image-alt: >-
   Cinq membres d’équipe communiquent entre eux à l’aide de différents appareils
   et à partir de lieux différents.
 translationKey: distributed-pm
-thumb: /img/cds/thumbnails/distributed-pm-blog.jpg
+thumb: /img/cds/distributed-pm-blog.jpg
 processed: 1575304320971
 ---
 Je suis arrivé au Service numérique canadien (SNC) par une froide journée de janvier. Je me suis rendu au bureau d’Ottawa pour une période d’intégration de deux semaines, après quoi je devais retourner chez moi, à Kitchener-Waterloo, où il fait *un peu moins* froid, pour travailler à temps plein. 

--- a/content/fr/blog/posts/voir-grand-commencer-modestement.md
+++ b/content/fr/blog/posts/voir-grand-commencer-modestement.md
@@ -13,7 +13,7 @@ image-alt: >-
   Des membres de l'équipe du SNC célèbrent le lancement du site web avec le
   pouce vers le haut.
 translationKey: think-big-start-small
-thumb: /img/cds/thumbnails/blog-think-big-start-small-2017.jpg
+thumb: /img/cds/blog-think-big-start-small-2017.jpg
 processed: 1550672962344
 ---
 Le Government Digital Service (GDS) du Royaume-Uni a une remarquable liste de [dix principes de conception](https://www.gov.uk/design-principles). Je me souviens encore de la première fois où je l’ai vue. On peut y lire «&nbsp;Commencez par les besoins des utilisateurs, pas par les besoins du gouvernement&nbsp;». Oh mon dieu, me suis-je dit : il s’agit d’un vrai site Web du gouvernement du Royaume-Uni. C’est incroyable!

--- a/content/fr/blog/posts/élaborer-un-cadre-d’évaluation-pour-la-prestation-des-produits-et-services.md
+++ b/content/fr/blog/posts/élaborer-un-cadre-d’évaluation-pour-la-prestation-des-produits-et-services.md
@@ -13,7 +13,7 @@ date: 2019-06-13T17:20:00.000Z
 image: /img/cds/four-frames.jpg
 image-alt: Quatre cadres noirs et sans photo sont accrochés côte à côte sur un mur blanc.
 translationKey: evaluation-framework
-thumb: /img/cds/thumbnails/four-frames.jpg
+thumb: /img/cds/four-frames.jpg
 processed: 1560520010502
 
 ---

--- a/content/fr/blog/posts/évaluer-les-besoins-en-formation-du-gouvernement-pour-l’avenir-de-la-prestation-de-services-numériques.md
+++ b/content/fr/blog/posts/évaluer-les-besoins-en-formation-du-gouvernement-pour-l’avenir-de-la-prestation-de-services-numériques.md
@@ -20,7 +20,7 @@ image-alt: >-
   numériques » sont assis autour de grandes tables rondes, avec des ordinateurs
   portables et des papillons adhésifs, à l’occasion d’un atelier.
 translationKey: assessing-training-needs
-thumb: /img/cds/thumbnails/tna-image.jpg
+thumb: /img/cds/tna-image.jpg
 processed: 1567559156581
 ---
 Alors que le gouvernement du Canada (GC) s’efforce d’améliorer sa façon de concevoir et d’offrir des services, il est possible d’envisager de nouveaux outils, méthodes et pratiques pour renforcer notre capacité à y parvenir. Mais les gens — les fonctionnaires — demeurent au cœur de ces efforts. Ainsi, lorsque nous avons [fait équipe](/2018/11/01/chers-collègues-quelle-est-la-formation-numérique-dont-vous-avez-besoin/) avec la Faculté de gestion de l’Université Dalhousie, à la fin de l’année dernière, pour mieux comprendre et évaluer les besoins actuels en formation dans les disciplines numériques à l’échelle du GC, nous avons commencé par consulter les fonctionnaires. Communiquer directement avec eux nous a permis de mieux comprendre leurs besoins et la façon dont nous pouvons y répondre. Le rapport complet se trouve sur [le site Web de l’Université Dalhousie](https://bit.ly/2NHBVyG).

--- a/content/fr/blog/posts/être-tout-oreilles-pour-utiliser-les-mêmes-mots-que-les-gens.md
+++ b/content/fr/blog/posts/être-tout-oreilles-pour-utiliser-les-mêmes-mots-que-les-gens.md
@@ -15,7 +15,7 @@ image-alt: >-
   des notes dans un petit carnet, avec une tasse de café et un téléphone à côté
   d’elle. L’autre a une tablette devant elle et un verre d’eau à sa droite.
 translationKey: using-words-people-use
-thumb: /img/cds/thumbnails/bag-and-hands.jpg
+thumb: /img/cds/bag-and-hands.jpg
 processed: 1560358863965
 
 ---


### PR DESCRIPTION
Currently, on our Blog List page ((https://digital.canada.ca/blog/), when an image is added as a banner on the website, it gets stretched on the blog post's page and cropped on the thumbnail page. The goal of this PR is to provide a standard ratio for both thumbnail and header images, so that images chosen as a banner/thumbnail for a blog post can dynamically fit in both the banner and thumbnail area of the blog.

Trello card: https://trello.com/c/Mng4nV4G/23-fixing-the-blog-post-banner-image-ratio

This PR includes a redesign to our Blog List page, including:
- Styling individual blog posts as individual tiles
- Using flexbox to style them responsively in columns and rows
- Changing font sizes to be more readable
- Removing the "/thumbnails/" path from banner images, as they have a square ratio