### PR TITLE
Changed display number for Blog list page from 5 to 6

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -9,7 +9,7 @@ languages:
     lang: en
     languageName: English
     title: Blog
-    Paginate: 5
+    Paginate: 6
     frontmatter:
       date: [":filename", ":default"]
     permalinks:


### PR DESCRIPTION
With the new redesign of our Blog list page, there's a gap on the bottom right (since 5 posts are displayed per page).

This PR changes the display number from 5 to 6 blogs per page. 