### PR TITLE
Prep for medium image size

### DIFF
--- a/util/processBlogImages.js
+++ b/util/processBlogImages.js
@@ -1,86 +1,100 @@
 const path = require("path");
-const fmEditor = require('front-matter-editor');
-const { getFileInfo } = require('./lib/getFileInfo');
-const { timestamp } = require('./lib/timestamp');
-const { saveImage } = require('./lib/saveImage');
-const { readFileDir } = require('./lib/readFileDir');
+const fmEditor = require("front-matter-editor");
+const { getFileInfo } = require("./lib/getFileInfo");
+const { timestamp } = require("./lib/timestamp");
+const { saveImage } = require("./lib/saveImage");
+const { readFileDir } = require("./lib/readFileDir");
 
 // read + edit front matter data
-const frontMatter = (dirName, fileName, ext, paths = { large, thumb }) => {
+const frontMatter = (
+  dirName,
+  fileName,
+  ext,
+  paths = { large, medium, thumb }
+) => {
   const filePath = path.join(`${dirName}/${fileName}`);
   const destPath = path.join(dirName);
   let imageInfo;
+  //let saveFile = false;
   let saveFile = false;
 
-  fmEditor.saveFile = fmEditor.save
-  fmEditor.read(filePath)
-    .data((data, matter) => {
+  fmEditor.saveFile = fmEditor.save;
+  fmEditor.read(filePath).data((data, matter) => {
+    if (data.processed) {
+      // console.log("processed => ", data.processed)
+      imageInfo = { processed: data.processed };
+      saveFile = false;
+      return;
+    }
 
-      if (data.processed) {
-        // console.log("processed => ", data.processed)
-        imageInfo = { processed: data.processed };
-        saveFile = false
-        return;
-      }
+    saveFile = true;
+    imageInfo = getFileInfo(data.image);
 
-      saveFile = true;
-      imageInfo = getFileInfo(data.image);
+    if (!imageInfo) return;
 
-      if (!imageInfo) return;
+    const useExt = ext ? ext : imageInfo.ext;
 
-      const useExt = ext ? ext : imageInfo.ext;
-
-      // update markdown data
-      data.image = `/${paths.large}/${imageInfo.name}${useExt}`;
-      data.thumb = `/${paths.thumb}/${imageInfo.name}${useExt}`;
-      data.processed = timestamp();
-      matter.data = data;
-    });
+    // update markdown data
+    data.image = `/${paths.large}/${imageInfo.name}${useExt}`;
+    data.thumb = `/${paths.thumb}/${imageInfo.name}${useExt}`;
+    data.medium = `/${paths.medium}/${imageInfo.name}${useExt}`;
+    data.processed = timestamp();
+    matter.data = data;
+  });
 
   if (saveFile) {
-    fmEditor.save(destPath, { postfix: '' }, (err, data) => {
+    fmEditor.save(destPath, { postfix: "" }, (err, data) => {
       if (err) {
         console.log("failed to save front matter data", err);
       }
 
       console.log(`saved ${destPath}`);
-    })
+    });
   }
 
   return imageInfo;
-}
+};
 
 const start = (lang, markdownDir) => {
   const prefixPath = path.join(__dirname, `../static`);
 
-  const imagePath = 'img/cds';
+  const imagePath = "img/cds";
   const sourceImagePath = `${prefixPath}/${imagePath}`;
   const largeImagePath = `${imagePath}`;
   const thumbImagePath = `${imagePath}/thumbnails`;
+  const mediumImagePath = `${imagePath}/medium`;
 
   readFileDir(markdownDir, (dirName, fileName) => {
-
     // console.log(`read ${dirName}/${fileName}`);
 
-    const imageInfo = frontMatter(dirName, fileName, '.jpg', { large: largeImagePath, thumb: thumbImagePath });
+    const imageInfo = frontMatter(dirName, fileName, ".jpg", {
+      large: largeImagePath,
+      medium: mediumImagePath,
+      thumb: thumbImagePath
+    });
 
     if (!imageInfo) {
-      console.log(`failed to read image data ${dirName} ${fileName}`)
-      return
+      console.log(`failed to read image data ${dirName} ${fileName}`);
+      return;
     }
 
     const imagePath = `${sourceImagePath}/${imageInfo.name}${imageInfo.ext}`;
 
     // save a large version of the image
-    saveImage(imagePath, `${prefixPath}/${largeImagePath}`, '.jpg')
+    saveImage(imagePath, `${prefixPath}/${largeImagePath}`, ".jpg");
 
     // save a thumbnail version of the image
-    saveImage(imagePath, `${prefixPath}/${thumbImagePath}`, '.jpg', 300, 300)
-  })
-}
+    saveImage(imagePath, `${prefixPath}/${thumbImagePath}`, ".jpg", 300, 300);
 
-// kickoff 
-start('en', path.join(__dirname, '../content/en/blog/posts'));
-start('fr', path.join(__dirname, '../content/fr/blog/posts'));
+    // save a mediumImagePath version of the image
+
+    // adjust size as needed and uncomment the next line
+    //saveImage(imagePath, `${prefixPath}/${mediumImagePath}`, ".jpg", 600, 600);
+  });
+};
+
+// kickoff
+start("en", path.join(__dirname, "../content/en/blog/posts"));
+start("fr", path.join(__dirname, "../content/fr/blog/posts"));
 
 //process.exit()


### PR DESCRIPTION
This PR adds a medium image size to the blog image process script

I have left the line commented out to avoid generating the images / altering the blog posts with this PR

See:
https://github.com/cds-snc/digital-canada-ca/compare/add-medium-image-size?expand=1#diff-a052db16441ce3bc43762cac0640d0f3R91

Adjust the image size to whatever is a good fit (doesn't have to be square). Uncomment the line.
 
Run 

```
npm run build
```

Will generate the new images.

To update the blog posts with the new Front Matter meta comment out the `if (data.processed) {` line

https://github.com/cds-snc/digital-canada-ca/compare/add-medium-image-size?expand=1#diff-a052db16441ce3bc43762cac0640d0f3R23

<img width="515" alt="Screen Shot 2020-02-11 at 3 10 10 PM" src="https://user-images.githubusercontent.com/62242/74274945-faa93580-4ce0-11ea-8da7-14b98e4518a7.png">
