### PR TITLE
Minor fix to roadmap print layout

### DIFF
--- a/assets/sass/engagement/_roadmap.scss
+++ b/assets/sass/engagement/_roadmap.scss
@@ -130,6 +130,7 @@
 
         p {
             margin: 0 0 1.2em;
+            line-height: 1.5;
         }
 
         blockquote {


### PR DESCRIPTION
Fixes the paragraph line height on the Roadmap pages (English and French) when printed or saved as PDFs. Thanks! 😄 