### PR TITLE
add long form for acronyms

### DIFF
--- a/content/en/products/products/help-canadians-access-the-cpp-disability-benefit.md
+++ b/content/en/products/products/help-canadians-access-the-cpp-disability-benefit.md
@@ -3,7 +3,7 @@ title: Help Canadians access the CPP Disability Benefit
 translationKey: esdc-product
 description: >-
   Exploring how to improve service delivery for Canadians with disabilities and
-  their children who apply for Canada Pension Plan benefits.
+  their children who apply for Canada Pension Plan (CPP) benefits.
 phase: alpha / alpha
 contact:
   - email: courtney.claessens@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/_index.html
+++ b/content/en/tools-and-resources/_index.html
@@ -9,7 +9,7 @@ aliases: [/outils-et-ressources/]
     <div class="col-sm-10 col-sm-offset-1 col-xs-12">
       <div>
         <p>
-          Here are some of the tools we use as product teams at CDS to help build
+          Here are some of the tools we use as product teams at the Canadian Digital Service (CDS) to help build
           new solutions to service delivery in Canada. These tools are always
           being iterated on and are available to everyone inside and outside of
           government.

--- a/content/fr/_index.html
+++ b/content/fr/_index.html
@@ -7,7 +7,7 @@ type: section
   <div class="container">
     <div class="row">
       <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-        <p>Le Service numérique canadien fait équipe avec des ministères et des organismes fédéraux afin d’axer les services gouvernementaux sur les besoins des gens.</p>
+        <p>Le Service numérique canadien (SNC) fait équipe avec des ministères et des organismes fédéraux afin d’axer les services gouvernementaux sur les besoins des gens.</p>
       </div>
     </div>
   </div>

--- a/content/fr/products/products/aider-les-canadiennes-et-les-canadiens-à-recevoir-des-prestations-d’invalidité-du-rpc.md
+++ b/content/fr/products/products/aider-les-canadiennes-et-les-canadiens-à-recevoir-des-prestations-d’invalidité-du-rpc.md
@@ -6,7 +6,7 @@ translationKey: esdc-product
 description: >-
   Réflexions sur la façon d’améliorer les services offerts aux Canadiennes et
   aux Canadiens ayant une invalidité et à leurs enfants lors d’une demande de
-  prestations du Régime de pensions du Canada.
+  prestations du Régime de pensions du Canada (RPC).
 phase: alpha / alpha
 contact:
   - email: courtney.claessens@tbs-sct.gc.ca

--- a/content/fr/tools-and-resources/_index.html
+++ b/content/fr/tools-and-resources/_index.html
@@ -9,7 +9,7 @@ url: /outils-et-ressources/
     <div class="row work-in-progress--intro">
         <div class="col-sm-10 col-sm-offset-1 col-xs-12">
             <div>
-                <p>Voici certains outils que nous utilisons en tant qu’équipes de produits au SNC pour élaborer de nouvelles solutions de prestation de services au Canada. Ces outils sont mis à jour de façon constante et sont à la disposition de tous, tant à l’intérieur qu’à l’extérieur du gouvernement.</p>
+                <p>Voici certains outils que nous utilisons en tant qu’équipes de produits au Service numérique canadien (SNC) pour élaborer de nouvelles solutions de prestation de services au Canada. Ces outils sont mis à jour de façon constante et sont à la disposition de tous, tant à l’intérieur qu’à l’extérieur du gouvernement.</p>
             </div>
         </div>
     </div>

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -59,7 +59,7 @@ partnerships:
 partnerships-contact-us:
     other: "Contact us"
 partnerships-intro:
-  other: "At the Canadian Digital Service, we partner up with federal departments to design, test and build simple, easy to use services. Our goal is to improve the experience – for people who deliver government services and people who use those services."
+  other: "At the Canadian Digital Service (CDS), we partner up with federal departments to design, test and build simple, easy to use services. Our goal is to improve the experience – for people who deliver government services and people who use those services."
 partnerships-how-it-works:
   other: "How it works"
 partnerships-how-we-do-it-1st:

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -59,7 +59,7 @@ partnerships:
 partnerships-contact-us:
   other: "Communiquez avec nous"
 partnerships-intro:
-  other: "Au Service numérique canadien, nous établissons des partenariats avec les ministères fédéraux pour concevoir, tester et bâtir des services simples et faciles à utiliser. Notre objectif est d’améliorer l’expérience des personnes qui fournissent les services gouvernementaux tout comme celle des personnes qui les utilisent."
+  other: "Au Service numérique canadien (SNC), nous établissons des partenariats avec les ministères fédéraux pour concevoir, tester et bâtir des services simples et faciles à utiliser. Notre objectif est d’améliorer l’expérience des personnes qui fournissent les services gouvernementaux tout comme celle des personnes qui les utilisent."
 partnerships-how-it-works:
   other: "Fonctionnement"
 partnerships-how-we-do-it-1st:


### PR DESCRIPTION
Added long form for CDS, SNC, CPP and RPC acronyms
-Homepage
-Partnerships page
-Tools and resources page
-CPPD product card