### PR TITLE
C19 recruitment page

### DIFF
--- a/content/en/esdc-c19-research.html
+++ b/content/en/esdc-c19-research.html
@@ -51,11 +51,7 @@ url: /esdc-c19-research/
                         <p>Adrianne Lee<br />
                         <a href="mailto:adrianne.lee@tbs-sct.gc.ca">adrianne.lee@tbs-sct.gc.ca</a><br />
                         613-222-7880</p>
-                        
-                        <p>Or:</p>
-                        
-                        <p><a href="mailto:cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a></p>
-                        
+                                                
                         <p>Thank you for volunteering to talk to us.</p>
                         
                         <h3>What we will collect</h3>

--- a/content/en/esdc-c19-research.html
+++ b/content/en/esdc-c19-research.html
@@ -7,30 +7,31 @@ url: /esdc-c19-research/
 <section class="page--outer-container-padding">
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-            <h2 class="section--title">Worried about COVID-19 financial help in Canada?</h2>
+            <h2 class="section--title"Are you or someone you know experiencing financial stress due to Covid-19?</h2>
         
-            <p>Help us solve your worries. Help us create clear, understandable information about what help is available, eligibility criteria and estimated payments.</p>
-
-            <p>If you would like to help us, or know someone else who can, please contact <a href="mailto:adrianne.lee@tbs-sct.gc.ca">adrianne.lee@tbs-sct.gc.ca</a> for more information on how to be involved.</p>
+            <p>We, at the Government of Canada, are in the process of making improvements to our Covid-19 website. We are conducting research studies in the upcoming weeks to understand how effective our website is for people who are experiencing financial stress.
+The studies will be conducted through an online video-conferencing session and should take about 30 minutes. No expertise about Covid-19 is required.</p>
 
             <hr>
 
-            <h2>How you can help</h2>
+            <h2>How to get involved</h2>
 
-            <p>We are working with Employment and Social Development Canada (ESDC) to <b>create clear, understandable information about what help is available, eligibility criteria and estimated payments</b>.</p>
+            <p>If you are interested in volunteering to participate in a study:</p>
             
-            <p>To do this we will <b>ask you to join an online Zoom video-conferencing session to describe your situation to us and then try using a draft web page to see if the content is helpful</b>. This will take <b>30 minutes</b>.</p>
-
+            <ol>
+                <li>Contact Adrianne Lee at adrianne.lee@tbs-sct.gc.ca to express your interest</li>
+<li>We will then ask you some preliminary questions to help us determine how you may qualify for our studies</li>
+<li>We may then contact you to participate in a study</li>
+            </ol>
+            
             <p>By participating in this study, you understand that:</p>
 
             <ul>
                 <li>You are volunteering to participate. You can stop at any time for any reason, without any consequences.</li>
-                <li>Your information will be anonymous. This means your responses will not be linked to you.</li>
-                <li>Due to this, you will not be able to withdraw or correct your information once provided.</li>
+                <li>Your information will be anonymous. This means your responses will not be linked to you. Due to this, you will not be able to withdraw or correct your information once provided.</li>
                 <li>Please do not provide any information in your responses that would identify you.</li>
                 <li>Your participation and answers will not affect your access to Government of Canada services or benefits.</li>
-                <li>We'll use Zoom for the session. Here’s a link to their privacy policy: https://zoom.us/privacy</li>
-                <li>CDS and ESDC may collect your personal information. For example, your employment history and experience with government services. To learn about how CDS and ESDC protect your personal information, please see the privacy statement, below.</li>
+                <li>The Canadian Digital Service (CDS) and Employment and Social Development Canada (ESDC) may collect your personal information. For example, your employment history and experience with government services. To learn about how CDS and ESDC protect your personal information, please see the privacy statement, below.</li>
             </ul>
 
             <blockquote>

--- a/content/fr/esdc-c19-research.html
+++ b/content/fr/esdc-c19-research.html
@@ -38,8 +38,6 @@ url: /recherche-edsc-c19/
                 <p>Philippe Caron<br />
                 <a href="mailto:philippe.caron@tbs-sct.gc.ca">philippe.caron@tbs-sct.gc.ca</a><br />
                 343-542-7841</p>
-                <p>Ou :</p>
-                <p><a href="mailto:cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a></p>
                 <p>Merci de vous être porté volontaire pour vous entretenir avec nous.</p>
                 <h3>Ce que nous recueillerons</h3>
                 <p>En participant à cette recherche, vous consentez à ce que vos antécédents professionnels et votre expérience des services publics soient recueillis.</p>

--- a/content/fr/esdc-c19-research.html
+++ b/content/fr/esdc-c19-research.html
@@ -7,13 +7,18 @@ url: /recherche-edsc-c19/
 <section class="page--outer-container-padding">
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-            <h2 class="section--title">Vous êtes inquiets de l'aide financière en lien avec la COVID-19 au Canada?</h2>
-            <p>Aidez-nous à résoudre vos inquiétudes. Aidez-nous à concevoir de l'information claire et compréhensible à props de l'aide disponible, des critères d'éligibilité et des sommes disponibles.</p>
-            <p>Si vous désirez nous aider, ou si vous connaissez quelqu'un qui pourrait nous aider, veuillez communiquer avec <a href="mailto:philippe.caron@tbs-sct.gc.ca">philippe.caron@tbs-sct.gc.ca</a> pour savoir comment participer.</p>
-            <hr>
-            <h2>Comment vous pouvez nous aider</h2>
-            <p>Nous collaborons avec Emploi et Développement social Canada (EDSC) pour concevoir de l'information claire et compréhensible à props de l'aide disponible, des critères d'éligibilité et des sommes disponibles.</p>
-            <p>Pour ce faire, nous vous demanderons de participer à une séance de vidéoconférence Zoom pour nous décrire votre situation, puis de tester une page web pour voir si le contenu est utile. Cela prendra 30 minutes.</p>
+            <h2 class="section--title">Est-ce que vous ou une personne de votre entourage vivez un stress financier en raison de la COVID-19?</h2>
+            <p>Notre équipe, au gouvernement du Canada, est actuellement en train d’améliorer notre site Web sur la COVID-19. Nous mènerons des séances de recherche au cours des prochaines semaines afin de mesurer à quel point notre site Web est utile pour les personnes vivant un stress financier.</p>
+            <p>Les séances de recherche auront lieu par vidéoconférence et dureront environ 30 minutes. Il n’est pas nécessaire d’avoir une expertise liée à la COVID-19.</p>
+        <hr>
+            <h2>Comment participer</h2>
+            <p>Si vous souhaitez vous porter volontaire pour notre étude,</p>
+        <ol>
+            <li>Contactez Philippe Caron à l’adresse <a href="mailto:philippe.caron@tbs-sct.gc.ca">philippe.caron@tbs-sct.gc.ca</a> pour exprimer votre intérêt.</li>
+            <li>Nous vous poserons ensuite quelques questions préliminaires pour déterminer comment vous pourriez contribuer à notre recherche.</li>
+            <li>Nous pourrions alors vous contacter pour que vous participiez à une séance.</li>
+            </ol>
+            
             <p>En participant à cette recherche, vous comprenez que :</p>
             <ul>
                 <li>Votre participation est volontaire. Vous pouvez arrêter de participer en tout temps et peu importe la raison, sans aucune conséquence.</li>
@@ -21,8 +26,7 @@ url: /recherche-edsc-c19/
                 <li>Pour cette raison, vous ne pourrez pas retirer ou corriger vos rensegnements une fois que vous les aurez fournis.</li>
                 <li>Dans vos réponses, veuillez ne pas fournir de renseignements permettant de vous identifier.</li>
                 <li>Votre participation et vos réponses n’affecteront pas votre accès aux services ou aux prestations du gouvernement du Canada.</li>
-                <li>Nous utiliserons Zoom pour la session. Voici un lien vers leur politique concernant les données confidentielles : <a href="https://zoom.us/fr-fr/privacy.html">https://zoom.us/fr-fr/privacy.html</a></li>
-                <li>Le SNC et EDSC peuvent recueillir des renseignements personnels comme vos antécédents professionnels et votre expérience des services publics. Pour vous renseigner sur la façon dont le SNC et EDSC protègent vos renseignements personnels, veuillez consulter l’avis de confidentialité ci-joint.</li>
+                <li>Le Service numérique canadien (SNC) et Emploi et Développement social Canada (EDSC) peuvent recueillir des renseignements personnels comme vos antécédents professionnels et votre expérience des services publics. Pour vous renseigner sur la façon dont le SNC et EDSC protègent vos renseignements personnels, veuillez consulter l’avis de confidentialité ci-joint.</li>
             </ul>
             <blockquote>
                 <p>Pour toute autre question concernant cette recherche ou si vous voulez participer, veuillez communiquer avec&nbsp;:<br>


### PR DESCRIPTION
Removed the general inbox emails from the c19 recruitment page, incase people were emailing there instead of my/Phil C's email.