### PR TITLE
A11y fixes

### DIFF
--- a/assets/sass/cds/_layout.scss
+++ b/assets/sass/cds/_layout.scss
@@ -335,6 +335,7 @@ td {
   justify-content: flex-start;
   border: none;
   padding-top: 15px;
+  color: $black;
   
   h2 {
     font-size: 1.85em;

--- a/content/en/tools-and-resources/digital-reading-list.html
+++ b/content/en/tools-and-resources/digital-reading-list.html
@@ -56,7 +56,7 @@ aliases: [/liste-lecture-concernant/]
                 <li><a href="https://policyoptions.irpp.org/magazines/february-2019/outdated-procurement-rules-hindering-digital-government/">Outdated procurement rules hindering digital government</a>, by Luke DeCoste</li>
                 <li><a href="https://18f.gsa.gov/2019/02/28/prerequisites-for-modular-contracting/">Prerequisites for modular contracting</a>, by Waldo Jaquith</li>
                 <li><a href="https://github.com/18F/technology-budgeting/blob/master/handbook.md">De-risking custom technology projects</a>, by Robin Carnahan, Randy Hart, and Waldo Jaquith</li>
-                <li><a href="http://www.gencat.cat/eapc/epum/N2/pdf/EPuM2Schneider.pdf">Modernising the state through State Startups, by Matti Schneider</li>
+                <li><a href="http://www.gencat.cat/eapc/epum/N2/pdf/EPuM2Schneider.pdf">Modernising the state through State Startups, by Matti Schneider</a></li>
                 <li><a href="https://www.cigionline.org/articles/governance-vacuums-and-how-code-becoming-law">Governance Vacuums and How Code Is Becoming Law</a>, by Bianca Wiley</li>
             </ul>
 

--- a/layouts/engagement/default.html
+++ b/layouts/engagement/default.html
@@ -70,7 +70,7 @@
         <div class="row">
             <div class="brand col-xs-8 col-sm-9 col-md-6">
                 <a href="https://www.canada.ca/{{ .Site.Language }}.html">
-                    <object type="image/svg+xml" tabindex="-1" data="/img/sig-blk-{{ .Site.Language }}.svg"></object><span class="wb-inv"> {{ i18n "goc" }}</span></a>
+                    <object type="image/svg+xml" tabindex="-1" data="/img/sig-blk-{{ .Site.Language }}.svg">{{ i18n "goc" }}</object><span class="wb-inv"> {{ i18n "goc" }}</span></a>
             </div>
         </div>
     </div>

--- a/layouts/section/blog.html
+++ b/layouts/section/blog.html
@@ -13,47 +13,49 @@
       {{ $upper_limit := (sub .Paginator.TotalPages $adjacent_links )}}
 
       {{ if gt .Paginator.TotalPages 1 }}
-      <ul class="blogpost-paginator">
-        {{ if ne .Paginator.PageNumber 1 }}
-          <li class="pagination">
-            <a href="{{.Paginator.First.URL }}">First</a>
-          </li>
-        {{ end }}
-        {{ range $trail := .Paginator.Pagers }}
-          {{ $.Scratch.Set "page_number_flag" false }}
-          {{ if gt $paginator.TotalPages $max_links }}
-            <!-- Complex page number logic -->
-            {{ if le $paginator.PageNumber $lower_limit }}
-              <!-- show pages from 1 to 5 -->
-              {{ if le .PageNumber $max_links }}
-                {{ $.Scratch.Set "page_number_flag" true }}
-              {{ end }}
-            {{ else if ge $paginator.PageNumber $upper_limit }}
-              <!-- show pages from end -5  to end-->
-              {{ if gt .PageNumber (sub $paginator.TotalPages $max_links) }}
-                {{ $.Scratch.Set "page_number_flag" true }}
-              {{ end }}
-            {{ else }}
-              <!-- Show middle pages -->
-              {{ if and ( ge .PageNumber (sub $paginator.PageNumber $adjacent_links) ) ( le .PageNumber (add $paginator.PageNumber $adjacent_links) ) }}
-                {{ $.Scratch.Set "page_number_flag" true }}
-              {{ end }}
-            {{ end }}
-          {{ else }}
-            {{ $.Scratch.Set "page_number_flag" true }}
-          {{ end }}
-          {{ if eq ($.Scratch.Get "page_number_flag") true }}
-            <li class = "pagination {{ if eq $paginator.PageNumber $trail.PageNumber }}active{{ end }}" >
-              <a href="{{$trail.URL }}">{{ $trail.PageNumber }}</a>
+      <li>
+        <ul class="blogpost-paginator">
+          {{ if ne .Paginator.PageNumber 1 }}
+            <li class="pagination">
+              <a href="{{.Paginator.First.URL }}">First</a>
             </li>
           {{ end }}
-        {{ end }}
-        {{ if ne .Paginator.PageNumber .Paginator.TotalPages }}
-          <li class="pagination">
-            <a href="{{.Paginator.Last.URL }}">Last</a>
-          </li>
-        {{ end }}
-      </ul>
+          {{ range $trail := .Paginator.Pagers }}
+            {{ $.Scratch.Set "page_number_flag" false }}
+            {{ if gt $paginator.TotalPages $max_links }}
+              <!-- Complex page number logic -->
+              {{ if le $paginator.PageNumber $lower_limit }}
+                <!-- show pages from 1 to 5 -->
+                {{ if le .PageNumber $max_links }}
+                  {{ $.Scratch.Set "page_number_flag" true }}
+                {{ end }}
+              {{ else if ge $paginator.PageNumber $upper_limit }}
+                <!-- show pages from end -5  to end-->
+                {{ if gt .PageNumber (sub $paginator.TotalPages $max_links) }}
+                  {{ $.Scratch.Set "page_number_flag" true }}
+                {{ end }}
+              {{ else }}
+                <!-- Show middle pages -->
+                {{ if and ( ge .PageNumber (sub $paginator.PageNumber $adjacent_links) ) ( le .PageNumber (add $paginator.PageNumber $adjacent_links) ) }}
+                  {{ $.Scratch.Set "page_number_flag" true }}
+                {{ end }}
+              {{ end }}
+            {{ else }}
+              {{ $.Scratch.Set "page_number_flag" true }}
+            {{ end }}
+            {{ if eq ($.Scratch.Get "page_number_flag") true }}
+              <li class = "pagination {{ if eq $paginator.PageNumber $trail.PageNumber }}active{{ end }}" >
+                <a href="{{$trail.URL }}">{{ $trail.PageNumber }}</a>
+              </li>
+            {{ end }}
+          {{ end }}
+          {{ if ne .Paginator.PageNumber .Paginator.TotalPages }}
+            <li class="pagination">
+              <a href="{{.Paginator.Last.URL }}">Last</a>
+            </li>
+          {{ end }}
+        </ul>
+      </li>
       {{ end }}
     </ul>
   </div>


### PR DESCRIPTION
Fix the following accessibility errors:
UL and OL must only directly contain LI, SCRIPT or TEMPLATE elements
OBJECT elements must have alternate text
Links must have discernible text
Elements must have sufficient color contrast 