### PR TITLE
Update to Covid Health Research recruitment pages

### DIFF
--- a/assets/sass/cds/_layout.scss
+++ b/assets/sass/cds/_layout.scss
@@ -257,6 +257,7 @@ hr {
 // Research page styles
 .research-page-contact {
   margin-bottom: 23px;
+  
   p {
     margin: 0;
   }

--- a/content/en/covid-health-research.html
+++ b/content/en/covid-health-research.html
@@ -10,7 +10,7 @@ aliases: [/recherche-sante-covid/]
         <div class="col-sm-10 col-sm-offset-1 col-xs-12">
             <h2 class="section--title">Do you talk to patients about COVID-19 test results?</h2>
 
-            <p>The Canadian Digital Service (CDS) is working to help the government’s response to COVID-19. We’re looking to understand how COVID-19 testing is done and how test results are communicated across the country.</p>
+            <p>The Canadian Digital Service (CDS) is working to help the government’s response to Covid-19. We are conducting research studies in the upcoming weeks to understand how Covid-19 testing is done and how test results are communicated across the country. The studies will be conducted through phone or video-conferencing and should take about 30 minutes to an hour.</p>
 
             <hr>
 
@@ -19,7 +19,7 @@ aliases: [/recherche-sante-covid/]
             <p>If you are interested in volunteering to participate in a study:</p>
             
             <ol>
-                <li>Contact Adrianne Lee at cds-snc@tbs-sct.gc.ca to express your interest</li>
+                <li>Contact Adrianne Lee at <a href="cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a> to express your interest</li>
 <li>We will then ask you some preliminary questions to help us determine how you may qualify for our studies</li>
 <li>We may then contact you to participate in a study</li>
             </ol>

--- a/content/en/covid-health-research.html
+++ b/content/en/covid-health-research.html
@@ -10,7 +10,7 @@ aliases: [/recherche-sante-covid/]
         <div class="col-sm-10 col-sm-offset-1 col-xs-12">
             <h2 class="section--title">Do you talk to patients about COVID-19 test results?</h2>
 
-            <p>The Canadian Digital Service (CDS) is working to help the government’s response to Covid-19. We are conducting research studies in the upcoming weeks to understand how Covid-19 testing is done and how test results are communicated across the country. The studies will be conducted through phone or video-conferencing and should take about 30 minutes to an hour.</p>
+            <p>The Canadian Digital Service (CDS) is working to help the government’s response to COVID-19. We are conducting research studies in the upcoming weeks to understand how COVID-19 testing is done and how test results are communicated across the country. The studies will be conducted through phone or video-conferencing and should take about 30 minutes to an hour.</p>
 
             <hr>
 

--- a/content/en/covid-health-research.html
+++ b/content/en/covid-health-research.html
@@ -14,6 +14,16 @@ aliases: [/recherche-sante-covid/]
 
             <hr>
 
+            <h2>How to get involved</h2>
+
+            <p>If you are interested in volunteering to participate in a study:</p>
+            
+            <ol>
+                <li>Contact Adrianne Lee at cds-snc@tbs-sct.gc.ca to express your interest</li>
+<li>We will then ask you some preliminary questions to help us determine how you may qualify for our studies</li>
+<li>We may then contact you to participate in a study</li>
+            </ol>
+            
             <p>The following explains how the Government of Canada will handle your information throughout and following this research session. </p>
 
             <p>By providing your written or verbal consent, you agree to the following:</p>

--- a/content/en/covid-health-research.html
+++ b/content/en/covid-health-research.html
@@ -9,102 +9,92 @@ aliases: [/recherche-sante-covid/]
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-xs-12">
             <h2 class="section--title">Do you talk to patients about COVID-19 test results?</h2>
-        
-            <p>The Canadian Digital Service (CDS) is working to help the government’s response to Covid-19. We are conducting research studies in the upcoming weeks to understand how Covid-19 testing is done and how test results are communicated across the country. The studies will be conducted through phone or video-conferencing and should take about 30 minutes to an hour.</p>
+
+            <p>The Canadian Digital Service (CDS) is working to help the government’s response to COVID-19. We’re looking to understand how COVID-19 testing is done and how test results are communicated across the country.</p>
 
             <hr>
 
-            <h2>How to get involved</h2>
+            <p>The following explains how the Government of Canada will handle your information throughout and following this research session. </p>
 
-            <p>If you are interested in volunteering to participate in a study:</p>
-            
-            <ol>
-                <li>Contact Adrianne Lee at cds-snc@tbs-sct.gc.ca to express your interest</li>
-<li>We will then ask you some preliminary questions to help us determine how you may qualify for our studies</li>
-<li>We may then contact you to participate in a study</li>
-            </ol>
-            
-            <p>By participating in this study, you understand that:</p>
-
+            <p>By providing your written or verbal consent, you agree to the following:</p>
             <ul>
-                <li>You are volunteering to participate. You can stop at any time for any reason, without any consequences.</li>
-                <li>Your information will be anonymous. This means your responses will not be linked to you. Due to this, you will not be able to withdraw or correct your information once provided.</li>
-                <li>Please do not provide any information in your responses that would identify you.</li>
-                <li>Your participation and answers will not affect your access to Government of Canada services or benefits.</li>
-                <li>The Canadian Digital Service (CDS) may collect your personal information. For example, your employment history and experience with government services. To learn about how CDS protects your personal information, please see the privacy statement, below.</li>
+                <li>You are volunteering and can stop the session at any time for any reason, without any consequences.</li>
+                <li>The information you provide will be anonymous - which means that your responses will not be linked to you. This also means that you won’t be able to withdraw or correct your feedback once it is provided.</li>
+                <li>We may collect information like general details about your employment, your knowledge about COVID-19 testing and result notification, your experience with COVID-19 testing and result notification.</li>
+                <li>We won’t note down any information that may come up in the conversation that would identify you (e.g. names of your employer, your address, your name).</li>
+                <li>Your participation and answers <span class="bolded">won’t</span> affect your access to Government of Canada services or benefits.</li>
             </ul>
-
-            <p>For any further questions about this research, or to participate, please contact:</p>
-
-            <div class="research-page-contact">
-                <p>Adrianne Lee</p>
-                <p><a href="mailto:cds-snc@tbs-sct.gc.ca "><strong>cds-snc@tbs-sct.gc.ca</strong></a></p>
-            </div>
 
             <hr>
 
             <section>
-                <h2>Privacy statement</h2>
+                <h2>Privacy Notice</h2>
                 <p>Participation is completely voluntary.</p>
 
-                        <p>For any questions about this research, please contact:</p>
-                        
-                        <div class="research-page-contact">
-                            <p>Adrianne Lee</p>
-                            <p><a href="mailto:cds-snc@tbs-sct.gc.ca "><strong>cds-snc@tbs-sct.gc.ca</strong></a></p>
-                        </div>
-                                                
-                        <p>Thank you for volunteering to talk to us.</p>
-                        
-                        <h3>What we will collect</h3>
-                        
-                        <p>By participating in this research you consent that your employment history and experience with government services will be collected.</p>
-                        
-                        <h3>How we will use this information</h3>
-                        
-                        <p>The Canadian Digital Service (CDS) will use this information to create clear, understandable information about what help is available, eligibility criteria and estimated payments.</p>
-                        
-                        <p>This personal information will not be used for any “administrative purposes”. Your information will not be used to make a decision that affects you or your access to Government of Canada services.</p>
-                        
-                        <p>CDS may publish or share with other government institutions a summary of what we have learned from this research, including quotes or narratives. Your name will not be associated with your responses, quotes, or narratives.</p>
-                        
-                        <h3>Who we are</h3>
-                        
-                        <p>CDS is part of the <a href="https://www.canada.ca/en/treasury-board-secretariat.html">Treasury Board of Canada Secretariat</a> (TBS).</p>
-                        
-                        <ul>
-                            <li>
-                            <p>The collection and use of your personal information by TBS is authorized by the <a href="https://laws-lois.justice.gc.ca/eng/acts/f-11/">Financial Administration Act</a>.</p>
-                            </li>
-                            <li>
-                            <p>The collection, use, and disclosure of your personal information is in accordance with the federal Privacy Act. Under the <a href="http://laws-lois.justice.gc.ca/eng/acts/P-21/index.html">Privacy Act</a>, you have a right of protection, access to and correction or notation of your personal information.</p>
-                            </li>
-                        </ul>
-                        
-                        <p>The Standard Personal Information Bank entitled &ldquo;<a href="https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings/standard-personal-information-banks.html#psu938">Outreach Activities, PSU 938</a>&rdquo;, describes the personal information that may be written down.</p>
-                        
-                        <h3>Your legal rights</h3>
+                <p>For any questions about this research, please contact:</p>
 
-                        <p>Due to the anonymity of responses, CDS will have no reliable means of associating you with your information provided. This means we will not be able to access or respond to your request for correction to inaccurate information or withdrawal.</p>
-                        
-                        <p>CDS/TBS may record your personal information. If you want to access or correct that personal information, or for any questions or concerns, please contact their privacy office:</p>
-                        
-                        <div class="research-page-contact">
-                            <p>TBS Access to Information and Privacy Coordinator</p>
-                            <p><a href="mailto:ATIP.AIPRP@tbs-sct.gc.ca">ATIP.AIPRP@tbs-sct.gc.ca</a></p>
-                            <p>1-866-312-1511</p>
-                        </div>
-                        
-                        <p>You can complain to the Office of the Privacy Commissioner of Canada about the handling of your personal information:</p>
-                        
-                        <div class="reseearch-page-contact">
-                            <p>Office of the Privacy Commissioner of Canada</p>
-                            <p><a href="mailto:info@priv.gc.ca">info@priv.gc.ca</a></p>
-                            <p>1-800-282-1376</p>
-                        </div>
-    
+                <div class="research-page-contact">
+                    <p>Adrianne Lee</p>
+                    <p><a href="mailto:cds-snc@tbs-sct.gc.ca "><strong>cds-snc@tbs-sct.gc.ca</strong></a></p>
+                </div>
+
+                <p>Thank you for volunteering to talk to us.</p>
+
+                <h3>What we will collect</h3>
+
+                <p>By participating in this research, you consent that general details about your employment, your knowledge about COVID-19 testing and result notification, and your experience with COVID-19 testing and result notification may be collected.</p>
+
+                <h3>How we will use this information</h3>
+
+                <p>The Canadian Digital Service (CDS) will use this information to help the government’s response to COVID-19.</p>
+
+                <p>This personal information will not be used for any “administrative purposes”. In other words, your information will not be used to make a decision that affects you or your access to Government of Canada services.</p>
+                
+                <p>CDS may publish or share with other government institutions a summary of what we have learned from this research, including quotes or narratives. Your name will not be associated with your responses, quotes, or narratives.</p>
+
+                <h3>Who we are</h3>
+
+                <p>CDS is part of the <a href="https://www.canada.ca/en/treasury-board-secretariat.html">Treasury Board
+                        of Canada Secretariat</a> (TBS).</p>
+
+               
+                        <p>The collection and use of your personal information by TBS is authorized by the <a
+                                href="https://laws-lois.justice.gc.ca/eng/acts/f-11/">Financial Administration Act</a>.
+                        </p>
+                    
+                        <p>The collection, use, and disclosure of your personal information is in accordance with the
+                            federal Privacy Act. Under the <a
+                                href="http://laws-lois.justice.gc.ca/eng/acts/P-21/index.html">Privacy Act</a>, you have
+                            a to protection of, access to and correction or notation of your personal information.
+                        </p>
+                
+
+                <p>The Standard Personal Information Bank entitled &ldquo;<a
+                        href="https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings/standard-personal-information-banks.html#psu938">Outreach
+                        Activities, PSU 938</a>&rdquo;, describes the personal information that may be written down.</p>
+
+                <h3>Your legal rights</h3>
+
+                <p>Due to the anonymity of responses, CDS will have no reliable means of associating you with your information provided. This means we will not be able to respond to any requests to withdraw your information or correct inaccurate information.</p>
+
+                <p>CDS/TBS will avoid recording your personal information. For any questions or concerns, please contact the researcher or their privacy office:</p>
+
+                <div class="research-page-contact">
+                    <p>TBS Access to Information and Privacy Coordinator</p>
+                    <p><a href="mailto:ATIP.AIPRP@tbs-sct.gc.ca">ATIP.AIPRP@tbs-sct.gc.ca</a></p>
+                    <p>1-866-312-1511</p>
+                </div>
+
+                <p>If you have any concerns about the handling of your personal information, you can file a complaint with the Office of the Privacy Commissioner of Canada:</p>
+
+                <div class="research-page-contact">
+                    <p>Office of the Privacy Commissioner of Canada</p>
+                    <p><a href="mailto:info@priv.gc.ca">info@priv.gc.ca</a></p>
+                    <p>1-800-282-1376</p>
+                </div>
+
             </section>
-            
+
         </div>
-    </div>  
+    </div>
 </section>

--- a/content/en/covid-health-research.html
+++ b/content/en/covid-health-research.html
@@ -19,7 +19,7 @@ aliases: [/recherche-sante-covid/]
             <p>If you are interested in volunteering to participate in a study:</p>
             
             <ol>
-                <li>Contact Adrianne Lee at <a href="cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a> to express your interest</li>
+                <li>Contact Adrianne Lee at <a href="mailto:cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a> to express your interest</li>
 <li>We will then ask you some preliminary questions to help us determine how you may qualify for our studies</li>
 <li>We may then contact you to participate in a study</li>
             </ol>

--- a/content/fr/covid-health-research.html
+++ b/content/fr/covid-health-research.html
@@ -11,34 +11,23 @@ aliases: [/covid-health-research/]
             <h2 class="section--title">Parlez-vous aux patients des résultats au test de COVID-19?</h2>
             <p>Le Service numérique canadien (SNC) cherche à aider le gouvernement à intervenir contre la COVID-19. Nous menons des séances de recherche au cours des prochaines semaines pour comprendre comment les tests de diagnostic pour la COVID-19 sont réalisés et comment les résultats des tests sont communiqués à travers le Canada. Les séances auront lieu par téléphone ou par vidéoconférence et devraient durer entre 30 minutes et 1 heure.</p>
         <hr>
-            <h2>Comment participer</h2>
-            <p>Si vous souhaitez vous porter volontaire pour notre étude,</p>
-        <ol>
-            <li>Contactez Stéphane Boisvert à l’adresse <a href="mailto:cds-snc@tbs-sct.gc.ca ">cds-snc@tbs-sct.gc.ca</a> pour exprimer votre intérêt.</li>
-            <li>Nous vous poserons ensuite quelques questions préliminaires pour déterminer comment vous pourriez contribuer à notre recherche.</li>
-            <li>Nous pourrions alors vous contacter pour que vous participiez à une séance.</li>
-            </ol>
-            
-            <p>En participant à cette recherche, vous comprenez que :</p>
-            <ul>
-                <li>Votre participation est volontaire. Vous pouvez arrêter de participer en tout temps et peu importe la raison, sans aucune conséquence.</li>
-                <li>Vos renseignements seront anonymes, ce qui signifie que vos réponses ne seront pas reliées à vous.</li>
-                <li>Pour cette raison, vous ne pourrez pas retirer ou corriger vos rensegnements une fois que vous les aurez fournis.</li>
-                <li>Dans vos réponses, veuillez ne pas fournir de renseignements permettant de vous identifier.</li>
-                <li>Votre participation et vos réponses n’affecteront pas votre accès aux services ou aux prestations du gouvernement du Canada.</li>
-                <li>Le Service numérique canadien (SNC) peut recueillir des renseignements personnels comme vos antécédents professionnels et votre expérience des services publics. Pour vous renseigner sur la façon dont le SNC protège vos renseignements personnels, veuillez consulter l’avis de confidentialité ci-joint.</li>
-            </ul>
 
-            <div class="research-page-contact">
-                <p>Stéphane Boisvert</p>
-                <p><a href="mailto:cds-snc@tbs-sct.gc.ca "><strong>cds-snc@tbs-sct.gc.ca</strong></a></p>
-            </div>
+        <p>Le texte qui suit explique comment le gouvernement du Canada traitera vos renseignements personnels pendant et après la séance de recherche.</p>
+
+        <p>En nous donnant votre consentement écrit ou verbal, vous consentez aux points suivants :</p>
+        <ul>
+            <li>Votre participation est volontaire. Vous pouvez arrêter de participer en tout temps et peu importe la raison, sans aucune conséquence.</li>
+            <li>Vos renseignements seront anonymes, ce qui signifie que vos réponses ne seront pas associées à vous. Pour cette raison, vous ne pourrez pas retirer ou corriger vos renseignements une fois que vous les aurez fournis.</li>
+            <li>Nous pouvons recueillir des renseignements généraux au sujet de votre emploi et de vos connaissances ou de votre expérience en lien avec les tests de diagnostic de COVID-19 et la communication de leurs résultats.</li>
+            <li>Nous ne recueillerons aucun renseignement fourni dans notre conversation qui pourrait permettre de vous identifier (par exemple, le nom de votre employeur, votre adresse, votre nom).</li>
+            <li>Votre participation et vos réponses n’affecteront pas votre accès aux services ou aux prestations du gouvernement du Canada.</li>
+        </ul>
           
             <hr>
             <section>
                 <h2>Avis de confidentialité</h2>
                 <p> Votre participation est entièrement volontaire.</p>
-                <p>Pour toute question au sujet de cette recherche, veuillez communiquer avec :</p>
+                <p>Pour toute question au sujet de la recherche, veuillez communiquer avec :</p>
                 <div class="research-page-contact">
                     <p>Stéphane Boisvert</p>
                     <p><a href="mailto:cds-snc@tbs-sct.gc.ca ">cds-snc@tbs-sct.gc.ca </a></p>
@@ -47,21 +36,19 @@ aliases: [/covid-health-research/]
 
                 <p>Merci de vous être porté volontaire pour vous entretenir avec nous.</p>
                 <h3>Ce que nous recueillerons</h3>
-                <p>En participant à cette recherche, vous consentez à ce que vos antécédents professionnels et votre expérience des services publics soient recueillis.</p>
+
+                <p>En participant à cette recherche, vous consentez à ce que des renseignements généraux soient recueillis au sujet de votre emploi, de vos connaissances sur les tests de diagnostic de COVID-19 et la communication de leurs résultats, et de votre expérience en lien avec les tests de diagnostic de COVID-19 et la communication de leurs résultats.</p>
+                
                 <h3>Comment nous utiliserons ces renseignements</h3>
-                <p>Le Service numérique canadien (SNC) utilisera ces renseignements pour créer des informations claires et compréhensibles sur l'aide disponible, les critères d'éligibilité et les sommes disponibles.</p>
+                <p>Le Service numérique canadien (SNC) utilisera ces renseignements pour aider le gouvernement à intervenir contre la COVID-19.</p>
                 <p>Vos renseignements personnels ne seront pas utilisés à des « fins administratives ». Ils ne seront pas utilisés pour prendre une décision qui vous touche ou qui touche votre accès aux services du gouvernement du Canada.</p>
-                <p>Le SNC pourrait publier ou partager avec d’autres organismes gouvernementaux un résumé de ce qu’il a appris dans le cadre de cette recherche, y compris des citations ou récits. Votre nom ne sera pas associé à vos réponses, citations ou récits.</p>
+                <p>Le SNC pourrait publier ou partager avec d’autres organismes gouvernementaux un résumé de ce qu’il a appris dans le cadre de cette recherche, y compris des citations ou des récits. Votre nom ne sera pas associé à vos réponses, citations ou récits.</p>
+
                 <h3>Qui sommes-nous?</h3>
                 <p>Le SNC fait partie du <a href="https://www.canada.ca/fr/secretariat-conseil-tresor.html">Secrétariat du Conseil du Tr&eacute;sor</a> (SCT) du Canada.</p>
-                <ul>
-                    <li>
-                    <p>La collecte et l&rsquo;utilisation de vos renseignements personnels par le SCT sont autoris&eacute;es en vertu de la <a href="https://laws-lois.justice.gc.ca/fra/lois/f-11/">Loi sur la gestion des finances publiques</a>.</p>
-                    </li>
-                    <li>
-                    <p>La collecte, l&rsquo;utilisation et la divulgation de vos renseignements personnels sont conformes &agrave; la Loi sur la protection des renseignements personnels du gouvernement f&eacute;d&eacute;ral. Cette loi vous assure un droit de protection, de correction ou mention de vos renseignements personnels, et d&rsquo;acc&egrave;s &agrave; ceux-ci.</p>
-                    </li>
-                </ul>
+                
+                <p>La collecte, l’utilisation et la divulgation de vos renseignements personnels sont conformes à la Loi sur la protection des renseignements personnels du gouvernement fédéral. Cette loi vous assure un droit de protection, de correction ou de notation de vos renseignements personnels, et d’accès à ceux-ci.</p>
+
         <p>Les Fichiers de renseignements personnels ordinaires intitulés « <a href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/renseignements-programmes-fonds-renseignements/fichiers-renseignements-personnels-ordinaires.html#pou938">Activités de sensibilisation – POU 938</a> » décrivent les renseignements personnels qui peuvent être recueillis.</p>
         <h3>Vos droits reconnus par la loi</h3>
         <p>En raison de l’anonymisation des réponses, le SNC n’aura aucun moyen fiable de vous associer à vos réponses. Ainsi, nous ne serons pas en mesure d’accéder aux renseignements que vous avez fournis pour répondre à une demande de retrait ou de correction de renseignements inexacts.</p>

--- a/content/fr/covid-health-research.html
+++ b/content/fr/covid-health-research.html
@@ -9,14 +9,14 @@ aliases: [/covid-health-research/]
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-xs-12">
             <h2 class="section--title">Parlez-vous aux patients des résultats au test de COVID-19?</h2>
-            <p>Le Service numérique canadien (SNC) cherche à aider le gouvernement à intervenir contre la COVID-19. Nous cherchons à comprendre comment les tests de diagnostic pour la COVID-19 sont réalisés et comment les résultats des tests sont communiqués à travers le Canada.</p>
+            <p>Le Service numérique canadien (SNC) cherche à aider le gouvernement à intervenir contre la COVID-19. Nous menons des séances de recherche au cours des prochaines semaines pour comprendre comment les tests de diagnostic pour la COVID-19 sont réalisés et comment les résultats des tests sont communiqués à travers le Canada. Les séances auront lieu par téléphone ou par vidéoconférence et devraient durer entre 30 minutes et 1 heure.</p>
             
             <hr>
 
             <h2>Comment participer</h2>
             <p>Si vous souhaitez vous porter volontaire pour notre étude:</p>
             <ol>
-                <li>Contactez Stéphane Boisvert à l’adresse cds-snc@tbs-sct.gc.ca pour exprimer votre intérêt.</li>
+                <li>Contactez Stéphane Boisvert à l’adresse <a href="cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a> pour exprimer votre intérêt.</li>
                 <li>Nous vous poserons ensuite quelques questions préliminaires pour déterminer comment vous pourriez contribuer à notre recherche.</li>
                 <li>Nous pourrions alors vous contacter pour que vous participiez à une séance.</li>
             </ol>

--- a/content/fr/covid-health-research.html
+++ b/content/fr/covid-health-research.html
@@ -9,8 +9,17 @@ aliases: [/covid-health-research/]
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-xs-12">
             <h2 class="section--title">Parlez-vous aux patients des résultats au test de COVID-19?</h2>
-            <p>Le Service numérique canadien (SNC) cherche à aider le gouvernement à intervenir contre la COVID-19. Nous menons des séances de recherche au cours des prochaines semaines pour comprendre comment les tests de diagnostic pour la COVID-19 sont réalisés et comment les résultats des tests sont communiqués à travers le Canada. Les séances auront lieu par téléphone ou par vidéoconférence et devraient durer entre 30 minutes et 1 heure.</p>
-        <hr>
+            <p>Le Service numérique canadien (SNC) cherche à aider le gouvernement à intervenir contre la COVID-19. Nous cherchons à comprendre comment les tests de diagnostic pour la COVID-19 sont réalisés et comment les résultats des tests sont communiqués à travers le Canada.</p>
+            
+            <hr>
+
+            <h2>Comment participer</h2>
+            <p>Si vous souhaitez vous porter volontaire pour notre étude:</p>
+            <ol>
+                <li>Contactez Stéphane Boisvert à l’adresse cds-snc@tbs-sct.gc.ca pour exprimer votre intérêt.</li>
+                <li>Nous vous poserons ensuite quelques questions préliminaires pour déterminer comment vous pourriez contribuer à notre recherche.</li>
+                <li>Nous pourrions alors vous contacter pour que vous participiez à une séance.</li>
+            </ol>
 
         <p>Le texte qui suit explique comment le gouvernement du Canada traitera vos renseignements personnels pendant et après la séance de recherche.</p>
 
@@ -31,7 +40,6 @@ aliases: [/covid-health-research/]
                 <div class="research-page-contact">
                     <p>Stéphane Boisvert</p>
                     <p><a href="mailto:cds-snc@tbs-sct.gc.ca ">cds-snc@tbs-sct.gc.ca </a></p>
-                    <p>343-542-7841</p>
                 </div>
 
                 <p>Merci de vous être porté volontaire pour vous entretenir avec nous.</p>
@@ -44,24 +52,32 @@ aliases: [/covid-health-research/]
                 <p>Vos renseignements personnels ne seront pas utilisés à des « fins administratives ». Ils ne seront pas utilisés pour prendre une décision qui vous touche ou qui touche votre accès aux services du gouvernement du Canada.</p>
                 <p>Le SNC pourrait publier ou partager avec d’autres organismes gouvernementaux un résumé de ce qu’il a appris dans le cadre de cette recherche, y compris des citations ou des récits. Votre nom ne sera pas associé à vos réponses, citations ou récits.</p>
 
-                <h3>Qui sommes-nous?</h3>
+                <h3>Notre organisation</h3>
                 <p>Le SNC fait partie du <a href="https://www.canada.ca/fr/secretariat-conseil-tresor.html">Secrétariat du Conseil du Tr&eacute;sor</a> (SCT) du Canada.</p>
                 
+                <p>La collecte et l’utilisation de vos renseignements personnels par le SCT sont autorisées en vertu de la Loi sur la gestion des finances publiques.</p>
+
                 <p>La collecte, l’utilisation et la divulgation de vos renseignements personnels sont conformes à la Loi sur la protection des renseignements personnels du gouvernement fédéral. Cette loi vous assure un droit de protection, de correction ou de notation de vos renseignements personnels, et d’accès à ceux-ci.</p>
 
-        <p>Les Fichiers de renseignements personnels ordinaires intitulés « <a href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/renseignements-programmes-fonds-renseignements/fichiers-renseignements-personnels-ordinaires.html#pou938">Activités de sensibilisation – POU 938</a> » décrivent les renseignements personnels qui peuvent être recueillis.</p>
-        <h3>Vos droits reconnus par la loi</h3>
-        <p>En raison de l’anonymisation des réponses, le SNC n’aura aucun moyen fiable de vous associer à vos réponses. Ainsi, nous ne serons pas en mesure d’accéder aux renseignements que vous avez fournis pour répondre à une demande de retrait ou de correction de renseignements inexacts.</p>
-        <p>Le SNC/SCT peut enregistrer vos renseignements personnels. Si vous souhaitez accéder à ces renseignements personnels ou les corriger, ou si vous avez d’autres questions ou préoccupations, veuillez communiquer avec leur Bureau de l’accès à l’information et de la protection des renseignements personnels :</p>
+                <p>Les Fichiers de renseignements personnels ordinaires intitulés « <a href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/renseignements-programmes-fonds-renseignements/fichiers-renseignements-personnels-ordinaires.html#pou938">Activités de sensibilisation – POU 938</a> » décrivent les renseignements personnels qui peuvent être recueillis.</p>
         
-        <div class="research-page-contact">
+        
+                <h3>Vos droits reconnus par la loi</h3>
+     
+                <p>En raison de l’anonymisation des réponses, le SNC n’aura aucun moyen de vous associer à vos réponses. Ainsi, nous ne serons pas en mesure d’accéder aux renseignements que vous avez fournis pour répondre à une demande de retrait ou de correction de renseignements inexacts.
+                </p>
+                <p>Le SNC/SCT n’enregistrera pas vos renseignements personnels. Si vous avez des questions ou des préoccupations, veuillez communiquer avec le chercheur ou leur Bureau de l’accès à l’information et de la protection des renseignements personnels :</p>
+        
+        
+                <div class="research-page-contact">
             <p>Coordonnateur de l’accès à l’information et de la protection des renseignements personnels du SCT</p>
             <p><a href="mailto:ATIP.AIPRP@tbs-sct.gc.ca">ATIP.AIPRP@tbs-sct.gc.ca</a>&nbsp;</p>
             <p>1-866-312-1511</p>
         </div>
 
+        <p>Si vous avez des préoccupations quant à la façon dont vos renseignements personnels sont traités, vous pouvez déposer une plainte auprès du Commissariat à la protection de la vie privée du Canada :</p>
         <div class="research-page-contact">
-            <p>Vous pouvez d&eacute;poser une plainte aupr&egrave;s du Commissariat &agrave; la protection de la vie priv&eacute;e du Canada quant &agrave; la fa&ccedil;on dont vos renseignements personnels sont trait&eacute;s.</p>
+            <p>Commissariat &agrave; la protection de la vie priv&eacute;e du Canada</p>
             <p><a href="mailto:info@priv.gc.ca">info@priv.gc.ca</a></p>
             <p>1-800-282-1376</p>
         </div>

--- a/content/fr/covid-health-research.html
+++ b/content/fr/covid-health-research.html
@@ -16,7 +16,7 @@ aliases: [/covid-health-research/]
             <h2>Comment participer</h2>
             <p>Si vous souhaitez vous porter volontaire pour notre étude:</p>
             <ol>
-                <li>Contactez Stéphane Boisvert à l’adresse <a href="cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a> pour exprimer votre intérêt.</li>
+                <li>Contactez Stéphane Boisvert à l’adresse <a href="mailto:cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a> pour exprimer votre intérêt.</li>
                 <li>Nous vous poserons ensuite quelques questions préliminaires pour déterminer comment vous pourriez contribuer à notre recherche.</li>
                 <li>Nous pourrions alors vous contacter pour que vous participiez à une séance.</li>
             </ol>


### PR DESCRIPTION
This PR includes content updates to EN + FR research recruitment pages for:
- https://digital.canada.ca/covid-health-research/
- https://numerique.canada.ca/recherche-sante-covid/