### PR TITLE
Fix duplicate field name in datafiles

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -216,7 +216,7 @@ collections:
           - {label: email, name: email, widget: string}
           - {label: youtube, hint: "Username Only", name: youtube, widget: string}
           - {label: github, hint: "Username Only", name: github, widget: string}
-          - {label: linkedin, hint: "Username Only", name: github, widget: string}
+          - {label: linkedin, hint: "Username Only", name: linkedin, widget: string}
           - label: medium
             name: medium
             widget: object


### PR DESCRIPTION
Linkedin ended up with github for the name, which is not only incorrect, but a duplicate, causing the CMS to error