### PR TITLE
Fix gap between job posts on Join our Team page

### DIFF
--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -667,6 +667,8 @@ span.livefr {
 
 .flexbox {
   display: flex;
+  
+  
 
   .steps-icon {
     flex: 0 0 70px;
@@ -688,11 +690,10 @@ span.livefr {
 }
 
 .our-job--listing {
-  margin-left:-20px;
-  margin: 5rem 0 3rem -20px;
-
+  margin: 40px 0;
+  
   h3 {
-    margin-left: 20px;
+    margin: 0 20px;
   }
 
   .border-primary {
@@ -705,15 +706,33 @@ span.livefr {
     margin:20px;
   }
 
-  .post {
+  .row {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    @include logo_break{
+      flex-direction: column;
+    } 
+  }
+
+  .post {
     padding: 20px;
     background-color: $white;
-    margin-bottom: 2em;
     box-shadow: 5px 8px 5px $medium-grey;
-    height: 100%;
+    width: calc(50% - 20px);
     text-align: left;
+    margin: 10px;
+
+    @include logo_break{
+      width: 80%;
+      margin: 10px 0;
+    } 
+
+    @include mobile_only {
+      width: 100%;
+    }
+    
 
     p {
       margin-bottom: 0px;
@@ -725,6 +744,7 @@ span.livefr {
       font-size: 2rem;
       font-weight: 600;
       text-decoration: underline;
+      
     }
   }
 }

--- a/layouts/section/join-our-team.en.html
+++ b/layouts/section/join-our-team.en.html
@@ -18,11 +18,10 @@
                         <div class="row">
                             {{ if gt (len (where .Pages ".Params.archived" "==" false)) 0 }}
                                 {{ range $p := (where .Pages ".Params.archived" "==" false) }}
-                                <div class="col-xs-12 col-md-6">
-                                    <div class="post border-primary ">
-                                        <h3><a class="job-posting-link" href={{ .RelPermalink }}>{{ .Title }}</a></h3>
-                                    </div>
+                                <div class="post border-primary ">
+                                    <h3><a class="job-posting-link" href={{ .RelPermalink }}>{{ .Title }}</a></h3>
                                 </div>
+
                                 {{ end }}
                             {{ end }}
                         </div>

--- a/layouts/section/join-our-team.fr.html
+++ b/layouts/section/join-our-team.fr.html
@@ -19,10 +19,8 @@
                          <div class="row">
                             {{ if gt (len (where .Pages ".Params.archived" "==" false)) 0 }}
                                 {{ range $p := (where .Pages ".Params.archived" "==" false) }}
-                                <div class="col-xs-12 col-md-6">
-                                    <div class="post border-primary ">
-                                        <h3><a class ="job-posting-link" href={{ .RelPermalink }}>{{ .Title }}</a></h3>
-                                    </div>
+                                <div class="post border-primary ">
+                                    <h3><a class ="job-posting-link" href={{ .RelPermalink }}>{{ .Title }}</a></h3>
                                 </div>
                             {{ end }}
                             {{ end }}


### PR DESCRIPTION
This PR includes the following changes to the Join our Team page:
- Adding responsive width styles to individual job postings 
- Fixing gap in the first column of individual job postings of English Join our Team page 