### PR TITLE
Allow raw HTML in markdown files to be rendered

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -233,6 +233,10 @@ collections:
                 fields:
                   - {label: name, name: name, widget: string}
                   - {label: url, name: url, widget: string}
+markup:
+  goldmark:
+    renderer:
+      unsafe: true
 
 exclude:
  - admin/index.js


### PR DESCRIPTION
# Summary | Résumé

Currently, Hugo strips out raw HTML from .md files. This config change tells the renderer (Goldmark) to allow the raw HTML to stay in the file when rendered. This is necessary to view things like tables within blog posts.

