### PR TITLE
Update images to point to new cloudfront url instead of s3 bucket directly

### DIFF
--- a/assets/sass/cds/_variables.scss
+++ b/assets/sass/cds/_variables.scss
@@ -20,4 +20,4 @@ $action-orange: #E87722;
 
 
 // Image hosting
-$image-base-url: "https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com";
+$image-base-url: "https://de2an9clyit2x.cloudfront.net";

--- a/assets/sass/engagement/_settings.scss
+++ b/assets/sass/engagement/_settings.scss
@@ -11,4 +11,4 @@ $foundations-color  : $primary-color !global !default;
 $yourthoughts-color : $primary-color !global !default;
 
 // Image hosting
-$image-base-url: "https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com";
+$image-base-url: "https://de2an9clyit2x.cloudfront.net";

--- a/layouts/section/meet-the-team.html
+++ b/layouts/section/meet-the-team.html
@@ -2,6 +2,8 @@
 
 {{ .Content }}
 
+{{ $baseURL := "https://de2an9clyit2x.cloudfront.net/" }}
+
 <section class="section our-team--listing">
   <h2 class="section--title">{{ i18n "key-contacts" }}</h2>
 
@@ -10,13 +12,11 @@
       {{ range $member := getJSON "http://cms-load-balancer-986685684.ca-central-1.elb.amazonaws.com/team-members?KeyContact=true&_sort=name:ASC" }}
       {{ $v1 := not (isset $member "archived") }}
       {{ if or ($v1) (eq $member.archived false) }}
-      {{$imgurl := index $member.Photo.url }}
-      {{ if isset $member.Photo.formats "small" }}{{ $imgurl := index $member.Photo.formats.small}}{{ end }}
 
       <div class="col-xs-12 col-sm-6 col-md-4">
         <div class="team-member">
           <div class="photo-container">
-              <img class="lazy" src="/img/cds/placeholder.gif" data-src="{{ if isset $member.Photo.formats "small" }}{{ $member.Photo.formats.small.url }}{{ else }}{{ index $member.Photo.url }}{{ end }}" data-srcset="{{ if isset $member.Photo.formats "small" }}{{ $member.Photo.formats.small.url }}{{ else }}{{ index $member.Photo.url }}{{ end }}" alt="{{ index $member "name" }}">   
+              <img class="lazy" src="/img/cds/placeholder.gif" data-src="{{ if isset $member.Photo.formats "small" }}{{ $baseURL}}small_{{ $member.Photo.hash }}.jpg{{ else }}{{$baseURL}}{{ index $member.Photo.hash }}.jpg{{ end }}" data-srcset="{{ if isset $member.Photo.formats "small" }}{{ $baseURL}}small_{{ $member.Photo.hash }}.jpg{{ else }}{{$baseURL}}{{ index $member.Photo.hash }}.jpg{{ end }}" alt="{{ index $member "name" }}">   
           </div>
 
           <div class="text">
@@ -75,7 +75,7 @@
         <div class="team-member">
 
           <div class="photo-container">
-            <img class="lazy" src="/img/cds/placeholder.gif" data-src="{{ if isset $member.Photo.formats "small" }}{{ $member.Photo.formats.small.url }}{{ else }}{{ index $member.Photo.url }}{{ end }}" data-srcset="{{ if isset $member.Photo.formats "small" }}{{ $member.Photo.formats.small.url }}{{ else }}{{ index $member.Photo.url }}{{ end }}" alt="{{ index $member "name" }}">   
+            <img class="lazy" src="/img/cds/placeholder.gif" data-src="{{ if isset $member.Photo.formats "small" }}{{ $baseURL}}small_{{ $member.Photo.hash }}.jpg{{ else }}{{$baseURL}}{{ index $member.Photo.hash }}.jpg{{ end }}" data-srcset="{{ if isset $member.Photo.formats "small" }}{{ $baseURL}}small_{{ $member.Photo.hash }}.jpg{{ else }}{{$baseURL}}{{ index $member.Photo.hash }}.jpg{{ end }}" alt="{{ index $member "name" }}">
           </div>
 
           <div class="text">


### PR DESCRIPTION
This affects images that have already been ported to the s3 bucket, so far:
- Team images
- Beginning the conversation page

This is needed so we can make the s3 bucket private, as per https://github.com/cds-snc/site-reliability-engineering-internal/issues/91