### PR TITLE
Restore team.yml so PRs will work for team data

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -1,0 +1,594 @@
+exec:
+  - archived: false
+    name: Aaron Snow
+    title:
+      en: Chief Executive Officer
+      fr: Président-directeur général
+    imagehash: aaron_snow2_3d68f68391
+    email: aaron.snow@tbs-sct.gc.ca
+    github: aaronsnow
+    linkedin: aaronsnow
+    twitter: aaronsnow
+  - archived: false
+    name: Alex MacEachern
+    title:
+      en: Chief of Staff
+      fr: Chef de cabinet
+    imagehash: alex_maceachern_0d6ca2eb31
+    email: Alex.MacEachern@tbs-sct.gc.ca
+    linkedin: alexandra-maceachern-4b0209b2
+    twitter: amaceachern123
+  - archived: false
+    name: Anatole Papadopoulos
+    title:
+      en: Chief Operating Officer
+      fr: Chef des opérations
+    imagehash: anatole_papadopoulos_b4da501172
+    email: Anatole.Papadopoulos@tbs-sct.gc.ca
+    linkedin: anatole-papadopoulos-845a431
+    twitter: anatolep
+  - archived: false
+    name: Andrea Gilbrook
+    title:
+      en: Head of Talent
+      fr: Chef du talent
+    imagehash: andrea_gilbrook_6ea1e45ba5
+    email: Andrea.Gilbrook@tbs-sct.gc.ca
+    linkedin: andreagilbrook
+    twitter: andreagilbrook
+  - archived: false
+    name: Andréanne Trudeau
+    title:
+      en: Head of Product Management
+      fr: Chef de la gestion de produits
+    imagehash: andreanne_trudeau_9074cc18b5
+    email: andreanne.trudeau@tbs-sct.gc.ca
+    linkedin: andreannetrudeau
+  - archived: false
+    name: Chelsea Novak
+    title:
+      en: Head of Outreach
+      fr: Chef de liaison et diffusion
+    imagehash: chelsea_novak_05ac9ef7d7
+    email: chelsea.novak@tbs-sct.gc.ca
+    github: chelseanovak
+    linkedin: chelseanovak
+    twitter: herhighnessness
+  - archived: false
+    name: Eman El-Fayomi
+    title:
+      en: Head of Design
+      fr: Chef de la conception
+    imagehash: eman_elfayomi_f0738a4ba5
+    email: Eman.El-Fayomi@tbs-sct.gc.ca
+    linkedin: eelfayomi
+    twitter: emanelfy
+  - archived: false
+    name: John Millons
+    title:
+      en: Head of Policy
+      fr: Chef des politiques
+    imagehash: john_millons_64f6b29b6e
+    email: John.Millons@tbs-sct.gc.ca
+    twitter: JohnMillons
+  - archived: false
+    name: John O'Brien
+    title:
+      en: Head of Security
+      fr: Chef de la sécurité
+    imagehash: john_obrien_732d482bc4
+    email: john.obrien@tbs-sct.gc.ca
+    linkedin: boardom
+    twitter: boardom_ca
+  - archived: false
+    name: Josh Ruihley
+    title:
+      en: Senior Technical Advisor
+      fr: Conseiller technique principal
+    imagehash: josh_ruihley_f0432d66a3
+    email: Joshua.Ruihley@tbs-sct.gc.ca
+    github: jroo
+  - archived: false
+    name: Leanne Labelle
+    title:
+      en: Head of Procurement
+      fr: Chef de l’approvisionnement
+    imagehash: leane_labelle_54635926a6
+    email: leanne.labelle@tbs-sct.gc.ca
+    linkedin: leannelabelle
+    twitter: leannelabelle
+  - archived: false
+    name: Mario Garneau
+    title:
+      en: Delivery Manager - Platform
+      fr: Gestionnaire de livraison - Plateformes
+    imagehash: mario_garneau_24e76bb0e3
+    email: Mario.Garneau@tbs-sct.gc.ca
+    github: mcman12
+    twitter: mcman12
+  - archived: false
+    name: Mithula Naik
+    title:
+      en: Interim Head of Design Research
+      fr: Chef par intérim de la recherche en conception
+    imagehash: mithula_naik_baacaf3e0b
+    email: Mithula.Naik@tbs-sct.gc.ca
+  - archived: false
+    name: Paul Joseph
+    title:
+      en: Head of Internal Operations
+      fr: Chef des opérations internes
+    imagehash: paul_joseph_d15d7971bb
+    email: Paul.Joseph@tbs-sct.gc.ca
+    linkedin: lastingdiscovery
+  - archived: false
+    name: Sage Cram
+    title:
+      en: Head of Partnership Development
+      fr: Chef du développement des partenariats
+    imagehash: sage_cram_b9d6d4ed1f
+    email: sage.cram@tbs-sct.gc.ca
+  - archived: false
+    name: Wendy Luciani
+    title:
+      en: Director of Partnerships
+      fr: Directrice des partenariats
+    imagehash: wendy_luciani_c56815b339
+    email: Wendy.Luciani@tbs-sct.gc.ca
+    linkedin: wmluciani
+    twitter: wmluciani
+  - archived: false
+    name: Wissam Moussa
+    title:
+      en: Head of Software Development
+      fr: Chef du développement de logiciels
+    imagehash: wissam_moussa_b63ffe10f4
+    email: wissam.moussa@tbs-sct.gc.ca
+    linkedin: wmoussa
+    twitter: wmoussa_cds
+
+team:
+  - archived: false
+    name: Adrianne Lee
+    title:
+      en: Design Research
+      fr: Recherche en conception
+    imagehash: adrianne_lee_d99f3ad9d3
+    email: Adrianne.Lee@tbs-sct.gc.ca
+    linkedin: adriannehlee
+    twitter: adriannehlee
+  - archived: false
+    name: Alexa Davidson
+    title:
+      en: Talent
+      fr: Talent
+    imagehash: alexa_davidson_4fd32774b7
+    email: Alexa.Davidson@tbs-sct.gc.ca
+  - archived: false
+    name: Anik Brazeau
+    title:
+      en: Design
+      fr: Conception
+    imagehash: small_anik_brazeau_7786c918a3
+    email: Anik.Brazeau@tbs-sct.gc.ca
+    linkedin: anikbrazeau
+    twitter: brazeauanik
+  - archived: false
+    name: Antoine Augusti
+    title:
+      en: Development
+      fr: Développement
+    imagehash: antoine_augusti_25b7a5f805
+    email: Antoine.Augusti@tbs-sct.gc.ca
+    github: AntoineAugusti
+    linkedin: AntoineAugusti
+    twitter: AntoineAugusti
+  - archived: false
+    name: Bethany Dunfield
+    title:
+      en: Development
+      fr: Développement
+    imagehash: bethany_dunfield_6d207bc928
+    email: bethany.dunfield@tbs-sct.gc.ca
+    github: brdunfield
+  - archived: false
+    name: Brian Hendrick
+    title:
+      en: Design
+      fr: Conception
+    imagehash: brian_hendrick_093fcc456a
+    email: brian.hendrick@tbs-sct.gc.ca
+    linkedin: hendrickbrian
+  - archived: false
+    name: Brock Higgins
+    title:
+      en: Talent
+      fr: Talent
+    imagehash: brock_higgins_d1788c9fab
+    email: brock.higgins@tbs-sct.gc.ca
+    github: brockhigg10
+    linkedin: brockhiggins
+    twitter: brockhigg10
+  - archived: false
+    name: Bryan Willey
+    title:
+      en: Product Management
+      fr: Gestion de produits
+    imagehash: bryan_willey_1a472f5d9b
+    email: Bryan.Willey@tbs-sct.gc.ca
+    github: willeybryan
+    linkedin: bryan-willey
+  - archived: false
+    name: Calvin Rodo
+    title:
+      en: Development
+      fr: Développement
+    imagehash: small_calvin_rodo_b56b0d044a
+    email: calvin.rodo@tbs-sct.gc.ca
+    github: CalvinRodo
+    linkedin: calvin-rodo-54396710
+    twitter: CalvinR
+  - archived: false
+    name: Cayce Fischer
+    title:
+      en: Design
+      fr: Conception
+    imagehash: cayce_fischer_ef0f5d7929
+    email: cayce.fischer@cds-snc.ca
+  - archived: false
+    name: Charlotte Pedersen
+    title:
+      en: Outreach
+      fr: Liaison et diffusion
+    imagehash: charlotte_pederson_4a2c9b0a2d
+    email: Charlotte.Pedersen@tbs-sct.gc.ca
+    linkedin: charlottepedersen371
+    twitter: Charp90
+  - archived: false
+    name: Clementine Hahn
+    title:
+      en: Product Management
+      fr: Gestion de produits
+    imagehash: clementine_hahn_f181adb37a
+    email: Clementine.Hahn@tbs-sct.gc.ca
+    twitter: ClementineHahn
+  - archived: false
+    name: Courtney Claessens
+    title:
+      en: Product Management
+      fr: Gestion de produits
+    imagehash: courtney_claessens_af735e4523
+    email: Courtney.Claessens@tbs-sct.gc.ca
+    linkedin: courtneyclaessens
+  - archived: false
+    name: Dave Samojlenko
+    title:
+      en: Development
+      fr: Développement
+    imagehash: dave_samojlenko_fe93f1044d
+    github: dsamojlenko
+    twitter: dsamojlenko
+  - archived: false
+    name: Élise Cossette
+    title:
+      en: Outreach
+      fr: Liaison et diffusion
+    imagehash: elise_cossette_6140caed96
+    email: elise.cossette@tbs-sct.gc.ca
+    linkedin: élise-cossette-590b56ab
+  - archived: false
+    name: Emily Kuret
+    title:
+      en: Design
+      fr: Conceptionemily.kuret@tbs-sct.gc.ca
+    imagehash: small_emily_kuret_dcd8f527da
+    email: emily.kuret@tbs-sct.gc.ca
+  - archived: false
+    name: Emma Wootton
+    title:
+      en: Design
+      fr: Conception
+    imagehash: small_emma_wootton_c9769b6c90
+    email: emma.wootton@tbs-sct.gc.ca
+  - archived: false
+    name: Eric Pang
+    title:
+      en: Design
+      fr: Conception
+    imagehash: eric_pang_b30ee48f3f
+    email: eric.pang@tbs-sct.gc.ca
+    linkedin: eric-pang-ux
+    twitter: dekonstructed
+  - archived: false
+    name: Fitore Jaha Price
+    title:
+      en: Development
+      fr: Développement
+    imagehash: small_fitore_jaha_price_d714a79f1f
+    email: Fitore.JahaPrice@tbs-sct.gc.ca
+    github: fitore-cds
+    linkedin: fitorejaha
+    twitter: tirofe
+  - archived: false
+    name: Francois Moisan
+    title:
+      en: Support Technician
+      fr: Technicien de soutien
+    imagehash: francois_moisan_2335ae913c
+    email: francois.moisan@tbs-sct.gc.ca
+  - archived: false
+    name: Hillary Lorimer
+    title:
+      en: Design Research
+      fr: Recherche en conception
+    imagehash: hillary_lorimer_51b00bd7f2
+    email: Hillary.Lorimer@tbs-sct.gc.ca
+    linkedin: hillary-b-lorimer
+    twitter: hillarylorimer
+  - archived: false
+    name: Ioana Contu
+    title:
+      en: Design
+      fr: Conception
+    imagehash: small_ioana_contu_f8973b676d
+    email: ioana.contu@tbs-sct.gc.ca
+  - archived: false
+    name: Jeana Frost
+    title:
+      en: Design Research
+      fr: Recherche en conception
+    imagehash: jeana_frost_b05678fb7f
+    email: jeana.frost@tbs-sct.gc.ca
+    linkedin: jeanafrost
+  - archived: false
+    name: Jeff Maher
+    title:
+      en: Development
+      fr: Développement
+    imagehash: jeff_maher_e8b4885317
+    email: jeff.maher@tbs-sct.gc.ca
+    github: jeffmaher
+    linkedin: jeffmaher
+    twitter: plusjeff
+  - archived: false
+    name: Jennifer Fletcher
+    title:
+      en: Partnerships
+      fr: Partenariats
+    imagehash: jen_fletcher_c9156fb097
+    email: jennifer.fletcher@tbs-sct.gc.ca
+  - archived: false
+    name: Jessica Loadenthal
+    title:
+      en: Outreach
+      fr: Liaison et diffusion
+    imagehash: jessica_loadenthal_eeb5d01c0e
+    email: Jessica.Loadenthal@tbs-sct.gc.ca
+  - archived: false
+    name: Johanna Button
+    title:
+      en: Outreach
+      fr: Liaison et diffusion
+    imagehash: johanna_button_15e5de8ace
+    email: johanna.button@tbs-sct.gc.ca
+    linkedin: johanna-button-097825143
+    twitter: buttonjohanna
+  - archived: false
+    name: John Kenney
+    title:
+      en: Policy
+      fr: Politiques
+    imagehash: john_kenney_00a05b1a43
+    email: john.kenney@tbs-sct.gc.ca
+    linkedin: johnrkenney
+  - archived: false
+    name: Jose Jimenez
+    title:
+      en: Outreach
+      fr: Liaison et diffusion
+    imagehash: jose_jimenez_105407e800
+    email: jose.jimenez@cds-snc.ca
+    twitter: curious_jose
+  - archived: false
+    name: Julianna Rowsell
+    title:
+      en: Accessibility
+      fr: Accessibilité
+    imagehash: julianna_rowsell_1bea1541a8
+    email: julie-ann.rowsell@tbs-sct.gc.ca
+    github: JuliannaR
+    linkedin: julianna-rowsell-86625624
+    twitter: JuliannaRowsell
+  - archived: false
+    name: Kate Wilhelm
+    title:
+      en: Design
+      fr: Conception
+    imagehash: kate_wilhelm_dd0f381acd
+    email: kate.wilhelm@tbs-sct.gc.ca
+  - archived: false
+    name: Leah Finkelstein
+    title:
+      en: Talent
+      fr: Talent
+    imagehash: leah_finkelstein_7765f56e31
+    email: leah.finkelstein@tbs-sct.gc.ca
+    linkedin: leah-finkelstein
+  - archived: false
+    name: Lesley Wheldrake
+    title:
+      en: Talent
+      fr: Talent
+    imagehash: small_lesley_wheldrake_d7d498fdef
+    email: Lesley.Wheldrake@tbs-sct.gc.ca
+    linkedin: lwheldrake
+  - archived: false
+    name: Lucas Cherkewski
+    title:
+      en: Policy
+      fr: Politiques
+    imagehash: lucas_cherkewski_a87e6c9470
+    email: Lucas.Cherkewski@tbs-sct.gc.ca
+    github: lchski
+    linkedin: lchski
+    twitter: lchski
+  - archived: false
+    name: Max Neuvians
+    title:
+      en: Development
+      fr: Développement
+    imagehash: max_neuvians_75b0928209
+    github: maxneuvians
+    linkedin: maxneuvians
+  - archived: true
+    name: Megan Beretta
+    title:
+      en: Policy
+      fr: Politiques
+    imagehash: meg_beretta_2733fad2e3
+    email: megan.beretta@tbs-sct.gc.ca
+    linkedin: meganberetta
+    twitter: megberetta
+  - archived: false
+    name: Mel Banyard
+    title:
+      en: Design Research
+      fr: Recherche en conception
+    imagehash: mel_banyard_c9f6bc6b25
+    email: melissa.banyard@tbs-sct.gc.ca
+    linkedin: melbanyard
+    twitter: melbanyard
+  - archived: false
+    name: Nick Makuch
+    title:
+      en: Design | Development
+      fr: Conception | Développement
+    imagehash: nick_makuch_dd5ee4d9dd
+    email: nick.makuch@tbs-sct.gc.ca
+    github: nmakuch
+    twitter: makuch_nick
+  - archived: false
+    name: Omar Tehsin
+    title:
+      en: Development
+      fr: Développement
+    imagehash: omar_tehsin_03379a9d31
+    email: omar.tehsin@tbs-sct.gc.ca
+    github: omartehsin1
+    linkedin: omar-tehsin
+  - archived: false
+    name: Paul Craig
+    title:
+      en: Development
+      fr: Développement
+    imagehash: paul_craig_d42eeb431c
+    email: paul.craig@tbs-sct.gc.ca
+    github: pcraig3
+  - archived: false
+    name: Philippe Caron
+    title:
+      en: Design
+      fr: Conception
+    imagehash: small_Philippe_Caron_437f59e814
+    email: philippe.caron@tbs-sct.gc.ca
+  - archived: false
+    name: Philippe Tardif
+    title:
+      en: Outreach
+      fr: Liaison et diffusion
+    imagehash: small_philippe_tardif_e8b864fdce
+    email: philippe.tardif@cds-snc.ca
+    linkedin: philippe-tardif-136695175
+  - archived: false
+    name: Priyanka Rahman
+    title:
+      en: Internal Operations
+      fr: Opérations internes
+    imagehash: priyanka_rahman_c3c9d64df6
+    email: Priyanka.Rahman@tbs-sct.gc.ca
+    linkedin: priyanka-rahman-5b91a8145
+  - archived: false
+    name: Samantha Sadasivan
+    title:
+      en: Design
+      fr: Conception
+    imagehash: samantha_sadasivan_9249f20334
+    email: samantha.sadasivan@tbs-sct.gc.ca
+    twitter: samsadasivan
+  - archived: false
+    name: Sam Burton
+    title:
+      en: Policy
+      fr: Politiques
+    imagehash: sam_burton_8cc0f43672
+    email: Samantha.Burton@tbs-sct.gc.ca
+    linkedin: samanthaburton
+    twitter: thesamburton
+  - archived: false
+    name: Sana Qureshi
+    title:
+      en: Talent
+      fr: Talent
+    imagehash: sana_qureshi_a633d68604
+    email: Sana.Qureshi@tbs-sct.gc.ca
+    linkedin: sana-qureshi-35206a11
+  - archived: false
+    name: Sean Boots
+    title:
+      en: Policy
+      fr: Politiques
+    imagehash: sean_boots_7c3d1e2cdf
+    github: sboots
+    linkedin: seanboots
+    twitter: sboots
+  - archived: false
+    name: Stephanie Gauthier
+    title:
+      en: Talent
+      fr: Talent
+    imagehash: stephanie_gauthier_810f99aeb6
+    email: Stephanie.Gauthier@tbs-sct.gc.ca
+  - archived: false
+    name: Stephen McMurtry
+    title:
+      en: Development
+      fr: Développement
+    imagehash: stephen_mcmurtry_fe9914e139
+    email: Stephen.McMurtry@tbs-sct.gc.ca
+    linkedin: stephen-mcmurtry-1b4a8879
+    twitter: StephenMcMurtry
+  - archived: false
+    name: Steve Astels
+    title:
+      en: Development
+      fr: Développement
+    imagehash: steve_astels_1215157bf5
+    email: steve.astels@tbs-sct.gc.ca
+    github: sastels
+    linkedin: sastels
+    twitter: sastels
+  - archived: false
+    name: Stevie-Ray Talbot
+    title:
+      en: Product Management
+      fr: Gestion de produits
+    imagehash: stevie_ray_talbot_a27a93e939
+    email: Steven.Talbot@tbs-sct.gc.ca
+    twitter: StevieRayTalbot
+  - archived: false
+    name: Tim Arney
+    title:
+      en: Development
+      fr: Développement
+    imagehash: tim_arney_e07fe1ef06
+    email: Tim.Arney@tbs-sct.gc.ca
+  - archived: false
+    name: Victoria Chan
+    title:
+      en: Outreach
+      fr: Liaison et diffusion
+    imagehash: victoria_chan_639fffb1c6
+    email: victoria.chan@tbs-sct.gc.ca
+    github: victoriachanimal
+    linkedin: victoriakaychan
+    twitter: vchanimal

--- a/layouts/section/meet-the-team.html
+++ b/layouts/section/meet-the-team.html
@@ -9,19 +9,18 @@
 
   <div class="container">
     <div class="row team-listing exec wb-eqht">
-      {{ range $member := getJSON "http://cms-load-balancer-986685684.ca-central-1.elb.amazonaws.com/team-members?KeyContact=true&_sort=name:ASC" }}
+      {{ range $member := $.Site.Data.team.exec }}
       {{ $v1 := not (isset $member "archived") }}
       {{ if or ($v1) (eq $member.archived false) }}
-
       <div class="col-xs-12 col-sm-6 col-md-4">
         <div class="team-member">
           <div class="photo-container">
-              <img class="lazy" src="/img/cds/placeholder.gif" data-src="{{ if isset $member.Photo.formats "small" }}{{ $baseURL}}small_{{ $member.Photo.hash }}.jpg{{ else }}{{$baseURL}}{{ index $member.Photo.hash }}.jpg{{ end }}" data-srcset="{{ if isset $member.Photo.formats "small" }}{{ $baseURL}}small_{{ $member.Photo.hash }}.jpg{{ else }}{{$baseURL}}{{ index $member.Photo.hash }}.jpg{{ end }}" alt="{{ index $member "name" }}">   
+              <img class="lazy" src="/img/cds/placeholder.gif" data-src="{{ $baseURL}}{{ $member.imagehash }}.jpg" data-srcset="{{ $baseURL}}{{ $member.imagehash }}.jpg" alt="{{ index $member "name" }}">
           </div>
 
           <div class="text">
             <span class="name">{{ $member.name }}</span>
-            <span class="title">{{ index $member (printf "title%s" (upper (string ($.Site.Language)))) }}</span>
+            <span class="title">{{ index $member.title (string ( $.Site.Language) ) }}</span>
             <div class="social-links contact-info-social">
               {{ if and (ne $member.email nil) (ne $member.email "") }}
               <span class="social-icons">
@@ -64,22 +63,22 @@
   </div>
 
   <h2 class="section--title">{{i18n "meet-the-full-team"}}</h2>
+
   <div class="container">
     <div class="row team-listing wb-eqht">
-      {{ range $member := getJSON "http://cms-load-balancer-986685684.ca-central-1.elb.amazonaws.com/team-members?KeyContact=false&_sort=name:ASC" }}
+      {{ range $member := .Site.Data.team.team  }}
       {{ $v1 := not (isset $member "archived") }}
       {{ if or ($v1) (eq $member.archived false) }}
-
       <div class="col-xs-12 col-sm-6 col-md-4">
         <div class="team-member">
 
           <div class="photo-container">
-            <img class="lazy" src="/img/cds/placeholder.gif" data-src="{{ if isset $member.Photo.formats "small" }}{{ $baseURL}}small_{{ $member.Photo.hash }}.jpg{{ else }}{{$baseURL}}{{ index $member.Photo.hash }}.jpg{{ end }}" data-srcset="{{ if isset $member.Photo.formats "small" }}{{ $baseURL}}small_{{ $member.Photo.hash }}.jpg{{ else }}{{$baseURL}}{{ index $member.Photo.hash }}.jpg{{ end }}" alt="{{ index $member "name" }}">
+            <img class="lazy" src="/img/cds/placeholder.gif" data-src="{{ $baseURL}}{{ $member.imagehash }}.jpg" data-srcset="{{ $baseURL}}{{ $member.imagehash }}.jpg" alt="{{ index $member "name" }}">
           </div>
 
           <div class="text">
             <span class="name">{{ $member.name }}</span>
-            <span class="title">{{ index $member (printf "title%s" (upper (string ($.Site.Language)))) }}</span>
+            <span class="title">{{ index $member.title (string ( $.Site.Language) ) }}</span>
             <div class="social-links contact-info-social">
               {{ if and (ne $member.email nil) (ne $member.email "") }}
               <span class="social-icons">


### PR DESCRIPTION
When I migrated team data to Strapi, I removed the "middleman" team.yml file. Which worked well, except that when a change is made in strapi, the site needs to be rebuilt and deployed. The PR bot has no way to detect a change since no files are being changed.

So I'm restoring the team.yml file so that changes can be easily detected and rebuilt through existing pipelines.