### PR TITLE
[Don't merge] Updating structure of Tools and Resources product cards

### DIFF
--- a/content/en/products/products/ircc-rescheduler.md
+++ b/content/en/products/products/ircc-rescheduler.md
@@ -8,8 +8,8 @@ description: >-
 product-url: ''
 phase: beta / bêta
 contact:
-  - email: ross.ferguson@tbs-sct.gc.ca
-    name: Ross Ferguson
+  - email: CDS-SNC@tbs-sct.gc.ca
+    name: CDS-SNC@tbs-sct.gc.ca
 partners:
   - name: 'Immigration, Refugees and Citizenship Canada'
     url: 'https://www.canada.ca/en/immigration-refugees-citizenship.html'

--- a/content/en/products/products/pco-impact-canada.md
+++ b/content/en/products/products/pco-impact-canada.md
@@ -7,8 +7,8 @@ description: >-
 product-url: 'https://impact.canada.ca/'
 phase: beta
 contact:
-  - email: ross.ferguson@tbs-sct.gc.ca
-    name: Ross Ferguson
+  - email: CDS-SNC@tbs-sct.gc.ca
+    name: CDS-SNC@tbs-sct.gc.ca
 partners:
   - name: Privy Council Office
     url: 'https://www.canada.ca/en/innovation-hub.html'

--- a/content/en/tools-and-resources/platform-tools/a11y-tracker.md
+++ b/content/en/tools-and-resources/platform-tools/a11y-tracker.md
@@ -8,7 +8,5 @@ contact:
   - email: julie-ann.rowsell@tbs-sct.gc.ca
     name: Julianna Rowsell
 status: in-flight
-links:
-  - name: a11y Tracker
-    url: "https://github.com/cds-snc/a11y-tracker"
+product-url: https://github.com/cds-snc/a11y-tracker
 ---

--- a/content/en/tools-and-resources/platform-tools/bookings.md
+++ b/content/en/tools-and-resources/platform-tools/bookings.md
@@ -9,6 +9,6 @@ contact:
     name: Stevie-Ray Talbot 
 status: in-flight
 links:
-  - name: Book an appointment with government
+  - name: Documentation
     url: https://cds-snc.github.io/booking-documentation/
 ---

--- a/content/en/tools-and-resources/platform-tools/branch-review.md
+++ b/content/en/tools-and-resources/platform-tools/branch-review.md
@@ -8,7 +8,5 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: The Platform Team
 status: in-flight
-links:
-  - name: Kubernetes branch reviews
-    url: "https://github.com/cds-snc/kubernetes-branch-review"
+product-url: https://github.com/cds-snc/kubernetes-branch-review
 ---

--- a/content/en/tools-and-resources/platform-tools/bundle-tracker.md
+++ b/content/en/tools-and-resources/platform-tools/bundle-tracker.md
@@ -8,7 +8,5 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: The Platform Team
 status: in-flight
-links:
-  - name: Bundle size tracker
-    url: "https://github.com/cds-snc/bundle-size-tracker"
+product-url: https://github.com/cds-snc/bundle-size-tracker
 ---

--- a/content/en/tools-and-resources/platform-tools/continuous-security.md
+++ b/content/en/tools-and-resources/platform-tools/continuous-security.md
@@ -8,6 +8,4 @@ contact:
   - email: caitlin.tuba@tbs-sct.gc.ca
     name: Caitlin Tuba
 status: in-flight
-links:
-  - name: Continuous Security
 ---

--- a/content/en/tools-and-resources/platform-tools/dependancy-checker.md
+++ b/content/en/tools-and-resources/platform-tools/dependancy-checker.md
@@ -8,7 +8,5 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: The Platform Team
 status: in-flight
-links:
-  - name: Dependency checker
-    url: "https://github.com/cds-snc/dependency-checker"
+product-url: https://github.com/cds-snc/dependency-checker
 ---

--- a/content/en/tools-and-resources/platform-tools/forms.md
+++ b/content/en/tools-and-resources/platform-tools/forms.md
@@ -8,6 +8,4 @@ contact:
   - email: steven.talbot@cds-snc.ca
     name: Stevie-Ray Talbot 
 status: in-flight
-links:
-  - name: Help public servants create and manage forms
 ---

--- a/content/en/tools-and-resources/platform-tools/github-actions.md
+++ b/content/en/tools-and-resources/platform-tools/github-actions.md
@@ -8,8 +8,6 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: The Platform Team
 status: in-flight
-links:
-  - name: GitHub actions
-    url: 'https://github.com/cds-snc/github-actions'
+product-url: https://github.com/cds-snc/github-actions
 ---
 

--- a/content/en/tools-and-resources/platform-tools/log-driver.md
+++ b/content/en/tools-and-resources/platform-tools/log-driver.md
@@ -1,5 +1,5 @@
 ---
-title: CDS log driver 🇨🇦
+title: CDS log driver 🇨
 translationKey: log-driver
 description: >-
   A tool to move logs (console messages) out of developer consoles and into tracking services like StackDriver.
@@ -8,7 +8,5 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: The Platform Team
 status: in-flight
-links:
-  - name: CDS log driver 🇨🇦
-    url: "https://github.com/cds-snc/logDriver"
+product-url: https://github.com/cds-snc/logDriver
 ---

--- a/content/en/tools-and-resources/platform-tools/notify.md
+++ b/content/en/tools-and-resources/platform-tools/notify.md
@@ -8,7 +8,5 @@ contact:
   - email: bryan.willey@tbs-sct.gc.ca
     name: Bryan Willey
 status: in-flight
-links:
-  - name: Notify
-    url: "https://notification.alpha.canada.ca/?lang=en"
+product-url: https://notification.alpha.canada.ca/?lang=en
 ---

--- a/content/en/tools-and-resources/platform-tools/pii-tracker.md
+++ b/content/en/tools-and-resources/platform-tools/pii-tracker.md
@@ -8,7 +8,5 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: The Platform Team
 status: in-flight
-links:
-  - name: Personal identifiable information checking
-    url: "https://github.com/cds-snc/pii-checker"
+product-url: https://github.com/cds-snc/pii-checker
 ---

--- a/content/en/tools-and-resources/platform-tools/security-goals.md
+++ b/content/en/tools-and-resources/platform-tools/security-goals.md
@@ -8,7 +8,5 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: The Platform Team
 status: in-flight
-links:
-  - name: Security goals
-    url: "https://github.com/cds-snc/security-goals"
+product-url: https://github.com/cds-snc/security-goals
 ---

--- a/content/en/tools-and-resources/platform-tools/time-to-interactive.md
+++ b/content/en/tools-and-resources/platform-tools/time-to-interactive.md
@@ -8,7 +8,5 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: The Platform Team
 status: in-flight
-links:
-  - name: Time to interactive tracking
-    url: "https://github.com/cds-snc/tti-tools-tracker"
+product-url: https://github.com/cds-snc/tti-tools-tracker
 ---

--- a/content/fr/products/products/guidance.md
+++ b/content/fr/products/products/guidance.md
@@ -7,7 +7,7 @@ translationKey: "guidance"
 partners:
     - { name: "Secrétariat du Conseil du Trésor du Canada", url: "https://www.canada.ca/fr/secretariat-conseil-tresor.html"}
 contact:
-    - { name: "Ross Ferguson", email: "ross.ferguson@tbs-sct.gc.ca" }
+    - { name: CDS-SNC@tbs-sct.gc.ca, email: CDS-SNC@tbs-sct.gc.ca }
 status: "past"
 links: []
 ---

--- a/content/fr/products/products/pco-impact-canada.md
+++ b/content/fr/products/products/pco-impact-canada.md
@@ -8,8 +8,8 @@ description: >-
 product-url: 'https://impact.canada.ca/'
 phase: beta
 contact:
-  - email: ross.ferguson@tbs-sct.gc.ca
-    name: Ross Ferguson
+  - email: CDS-SNC@tbs-sct.gc.ca
+    name: CDS-SNC@tbs-sct.gc.ca
 partners:
   - name: Bureau du Conseil privé
     url: 'https://www.canada.ca/fr/centre-innovation.html'

--- a/content/fr/tools-and-resources/platform-tools/a11y-tracker.md
+++ b/content/fr/tools-and-resources/platform-tools/a11y-tracker.md
@@ -8,7 +8,5 @@ contact:
   - email: julie-ann.rowsell@tbs-sct.gc.ca
     name: Julianna Rowsell
 status: in-flight
-links:
-  - name: Outil de suivi a11y
-    url: "https://github.com/cds-snc/a11y-tracker"
+product-url: https://github.com/cds-snc/a11y-tracker
 ---

--- a/content/fr/tools-and-resources/platform-tools/bookings.md
+++ b/content/fr/tools-and-resources/platform-tools/bookings.md
@@ -9,6 +9,6 @@ contact:
     name: Stevie-Ray Talbot 
 status: in-flight
 links:
-  - name: Prendre rendez-vous avec le gouvernement
+  - name: Documentation
     url: https://cds-snc.github.io/booking-documentation/
 ---

--- a/content/fr/tools-and-resources/platform-tools/branch-review.md
+++ b/content/fr/tools-and-resources/platform-tools/branch-review.md
@@ -8,8 +8,6 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: Équipe des plateformes
 status: in-flight
-links:
-  - name: Examens Kubernetes des branches
-    url: 'https://github.com/cds-snc/kubernetes-branch-review'
+product-url: https://github.com/cds-snc/kubernetes-branch-review
 ---
 

--- a/content/fr/tools-and-resources/platform-tools/bundle-tracker.md
+++ b/content/fr/tools-and-resources/platform-tools/bundle-tracker.md
@@ -8,8 +8,6 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: Équipe des plateformes
 status: in-flight
-links:
-  - name: Outil de suivi de la taille des paquets
-    url: 'https://github.com/cds-snc/bundle-size-tracker'
+product-url: https://github.com/cds-snc/bundle-size-tracker
 ---
 

--- a/content/fr/tools-and-resources/platform-tools/continuous-security.md
+++ b/content/fr/tools-and-resources/platform-tools/continuous-security.md
@@ -8,6 +8,4 @@ contact:
   - email: caitlin.tuba@tbs-sct.gc.ca
     name: Caitlin Tuba
 status: in-flight
-links:
-  - name: Sécurité continue
 ---

--- a/content/fr/tools-and-resources/platform-tools/dependancy-recommendations.md
+++ b/content/fr/tools-and-resources/platform-tools/dependancy-recommendations.md
@@ -8,8 +8,6 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: Équipe des plateformes
 status: in-flight
-links:
-  - name: Vérificateur des dépendances
-    url: 'https://github.com/cds-snc/dependency-checker'
+product-url: https://github.com/cds-snc/dependency-checker
 ---
 

--- a/content/fr/tools-and-resources/platform-tools/forms.md
+++ b/content/fr/tools-and-resources/platform-tools/forms.md
@@ -8,6 +8,4 @@ contact:
   - email: steven.talbot@cds-snc.ca
     name: Stevie-Ray Talbot 
 status: in-flight
-links:
-  - name: Aider les fonctionnaires à créer et à gérer des formulaires
 ---

--- a/content/fr/tools-and-resources/platform-tools/github-actions.md
+++ b/content/fr/tools-and-resources/platform-tools/github-actions.md
@@ -8,8 +8,6 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: Équipe des plateformes
 status: in-flight
-links:
-  - name: Actions GitHub
-    url: 'https://github.com/cds-snc/github-actions'
+product-url: https://github.com/cds-snc/github-actions
 ---
 

--- a/content/fr/tools-and-resources/platform-tools/log-driver.md
+++ b/content/fr/tools-and-resources/platform-tools/log-driver.md
@@ -8,8 +8,6 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: Équipe des plateformes
 status: in-flight
-links:
-  - name: Camelot du SNC 🇨🇦
-    url: 'https://github.com/cds-snc/logDriver'
+product-url: https://github.com/cds-snc/logDriver
 ---
 

--- a/content/fr/tools-and-resources/platform-tools/notify.md
+++ b/content/fr/tools-and-resources/platform-tools/notify.md
@@ -8,7 +8,5 @@ contact:
   - email: bryan.willey@tbs-sct.gc.ca
     name: Bryan Willey
 status: in-flight
-links:
-  - name: Notification
-    url: "https://notification.alpha.canada.ca/?lang=fr"
+product-url: https://notification.alpha.canada.ca/?lang=fr
 ---

--- a/content/fr/tools-and-resources/platform-tools/pii-tracker.md
+++ b/content/fr/tools-and-resources/platform-tools/pii-tracker.md
@@ -8,8 +8,6 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: Équipe des plateformes
 status: in-flight
-links:
-  - name: Vérificateur de renseignements d’identification personnelle
-    url: 'https://github.com/cds-snc/pii-checker'
+product-url: https://github.com/cds-snc/pii-checker
 ---
 

--- a/content/fr/tools-and-resources/platform-tools/security-goals.md
+++ b/content/fr/tools-and-resources/platform-tools/security-goals.md
@@ -8,8 +8,6 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: Équipe des plateformes
 status: in-flight
-links:
-  - name: Objectifs de sécurité
-    url: 'https://github.com/cds-snc/security-goals'
+product-url: https://github.com/cds-snc/security-goals
 ---
 

--- a/content/fr/tools-and-resources/platform-tools/time-to-interactive.md
+++ b/content/fr/tools-and-resources/platform-tools/time-to-interactive.md
@@ -8,8 +8,6 @@ contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca
     name: Équipe des plateformes
 status: in-flight
-links:
-  - name: Outil de suivi du temps d’interactivité
-    url: 'https://github.com/cds-snc/tti-tools-tracker'
+product-url: https://github.com/cds-snc/tti-tools-tracker
 ---
 

--- a/layouts/tools-and-resources/list.html
+++ b/layouts/tools-and-resources/list.html
@@ -45,6 +45,7 @@
         {{ end }}
       </div>
     </div>
+  </div>
   <!-- END CONTACT -->
 
   <div class="row">

--- a/layouts/tools-and-resources/list.html
+++ b/layouts/tools-and-resources/list.html
@@ -46,5 +46,19 @@
       </div>
     </div>
   <!-- END CONTACT -->
+
+  <div class="row">
+    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+      <div class="work-in-progress--links">
+        {{with .Params.links }}
+          {{ if gt (len .) 0 }}
+            <h5>{{ i18n "links" }}:</h5>
+            {{range .}}
+              <p><a href="{{ .url }}">{{.name}}</a></p>
+            {{ end }}
+          {{ end }}
+        {{ end }}
+      </div>
+    </div>
   </div>
 </section>

--- a/layouts/tools-and-resources/list.html
+++ b/layouts/tools-and-resources/list.html
@@ -6,9 +6,7 @@
       <div class="title-container">
         <div>
           <h4 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
-            {{ range .Params.links }}
-              <a class="title-link" href="{{ .url }}">{{.name}}</a>
-            {{ end }}
+            {{ .Params.title }}
           </h4>
         </div>
       </div>


### PR DESCRIPTION
Unlike product cards listed in the Partnerships section, the title of a Tools/Resources product card links directly to the product (otherwise leading to the Homepage if there isn't an available link), and does not feature a field for product-urls. 

This PR includes the following changes:
- Bringing back product-url field for Tools and Resources product, so that links can be accessed through "View this product" 
- Bringing back links field for Tools and Resources product, so that Work in Progress links can be featured on product cards
- Based the above, updating links for each Tools and Resources product so that Product links and Work in Progress links (eg. Documentation) and referenced in the right place
- Ensuring product card contacts are updated
