### PR TITLE
Change which image is selected for thumbnail on recent blog post

### DIFF
--- a/content/en/blog/posts/learning-to-make-twitter-content-more-accessible.md
+++ b/content/en/blog/posts/learning-to-make-twitter-content-more-accessible.md
@@ -6,7 +6,7 @@ author: 'Jo Button, Outreach'
 date: '2021-03-12T15:00:00.000Z'
 image: https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com/accessibility_tweets_blog_banner_650f003408.jpg
 image-alt: A person using screen reading technology with their phone.
-thumb: https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com/thumbnail_accessibility_tweets_blog_banner_650f003408.jpg
+thumb: https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com/small_accessibility_tweets_blog_banner_650f003408.jpg
 translationKey: blog-accessible-tweets
 ---
 No one likes to be excluded or have their needs and feelings not considered. At least, I know I sure don’t.

--- a/content/fr/blog/posts/-apprendre-à-rendre-le-contenu-sur-twitter-plus-accessible.md
+++ b/content/fr/blog/posts/-apprendre-à-rendre-le-contenu-sur-twitter-plus-accessible.md
@@ -6,7 +6,7 @@ author: 'Jo Button, Liaison et diffusion'
 date: '2021-03-12T16:00:00.000Z'
 image: https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com/accessibility_tweets_blog_banner_650f003408.jpg
 image-alt: Une personne utilisant un lecteur d’écran sur son téléphone.
-thumb: https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com/thumbnail_accessibility_tweets_blog_banner_650f003408.jpg
+thumb: https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com/small_accessibility_tweets_blog_banner_650f003408.jpg
 translationKey: blog-accessible-tweets 
 ---
 Personne n’aime être exclu, et personne n’aime voir ses besoins et ses sentiments ignorés. Du moins, certainement pas moi.


### PR DESCRIPTION
The PR bot is selecting a thumbnail that is too small for the size of our actual thumbnails, leading to blurry images.

I'm bumping up to the next larger format for the most recent blog post. I will update the PR bot shortly!