### PR TITLE
fix: a11y tracker CI

### DIFF
--- a/.github/workflows/a11y_tracking.yaml
+++ b/.github/workflows/a11y_tracking.yaml
@@ -3,7 +3,7 @@ name: "A11y tracking"
 on:
   push:
     branches:
-      - main
+      - master
 
 defaults:
   run:


### PR DESCRIPTION
This PR fixes the A11Y tracker CI because this is an older repo and still uses the older non- `main` branch convention.