### PR TITLE
Add an empty layout file to cut down on Hugo warnings when building the site

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,1 @@
+<!-- Empty layout for Hugo warnings -->


### PR DESCRIPTION
Previously, Hugo would complain about this multiple times when building the site with the following warning message:
> WARN 2021/03/26 12:44:19 found no layout file for "HTML" for "page": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.

This removes these warnings.
There are still a couple outstanding warnings, but they should be addressed whenever #2052 is.