### PR TITLE
[a11y] Fixup skip to main content list tag.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -67,17 +67,19 @@
     <!-- EN -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PZ6LLXT" height="0" width="0"
         style="display:none;visibility:hidden"></iframe></noscript>
-    
+
     <!-- FR -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T7JHWPJ"
       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager -->
 
-    <ul id="wb-tphp" role="navigation" aria-label='{{ i18n "skip-to-content" }}'>
-      <li class="wb-slc">
-        <a class="wb-sl" href="#wb-cont">{{ i18n "skip-to-content" }}</a>
-      </li>
-    </ul>
+    <nav>
+      <ul id="wb-tphp">
+        <li class="wb-slc">
+          <a class="wb-sl" href="#wb-cont">{{ i18n "skip-to-content" }}</a>
+        </li>
+      </ul>
+    </nav>
 
     <header role="banner">
       {{ partial "fip.html" . }}

--- a/layouts/a11y/default.html
+++ b/layouts/a11y/default.html
@@ -47,11 +47,13 @@
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer1'?'&l='+l:'';j.async=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer1','GTM-TLGQ9K');</script>
     <!-- End Google Tag Manager -->
 
-    <ul id="wb-tphp" role="navigation" aria-label='{{ i18n "skip-to-content" }}'>
-      <li class="wb-slc">
-        <a class="wb-sl" href="#wb-cont">{{ i18n "skip-to-content" }}</a>
-      </li>
-    </ul>
+    <nav>
+      <ul id="wb-tphp">
+        <li class="wb-slc">
+          <a class="wb-sl" href="#wb-cont">{{ i18n "skip-to-content" }}</a>
+        </li>
+      </ul>
+    </nav>
 
     <header role="banner">
       {{ partial "fip.html" . }}

--- a/layouts/engagement/default.html
+++ b/layouts/engagement/default.html
@@ -46,11 +46,13 @@
     })(window, document, 'script', 'dataLayer1', 'GTM-TLGQ9K');
 </script>
 <!-- End Google Tag Manager -->
-<ul id="wb-tphp" role="navigation" aria-label='{{ i18n "skip-to-content" }}'>
-    <li class="wb-slc">
-        <a class="wb-sl" href="#wb-cont">{{ i18n "skip-to-content" }}</a>
-    </li>
-</ul>
+<nav>
+    <ul id="wb-tphp">
+        <li class="wb-slc">
+            <a class="wb-sl" href="#wb-cont">{{ i18n "skip-to-content" }}</a>
+        </li>
+    </ul>
+</nav>
 <header role="banner">
     <div id="wb-bnr" class="container">
         <section id="wb-lng" class="visible-md visible-lg text-right">
@@ -86,7 +88,7 @@
             <div class="row">
                 <nav class="col-md-10 ftr-urlt-lnk">
                     <h2 class="wb-inv">{{ i18n "about-this-site" }}</h2>
-                    
+
                     {{ partial "footer-links.html" }}
 
                 </nav>

--- a/layouts/roadmap/baseof.html
+++ b/layouts/roadmap/baseof.html
@@ -50,11 +50,13 @@
     })(window, document, 'script', 'dataLayer1', 'GTM-TLGQ9K');
 </script>
 <!-- End Google Tag Manager -->
-<ul id="wb-tphp" role="navigation" aria-label='{{ i18n "skip-to-content" }}'>
-    <li class="wb-slc">
-        <a class="wb-sl" href="#wb-cont">{{ i18n "skip-to-content" }}</a>
-    </li>
-</ul>
+<nav>
+    <ul id="wb-tphp">
+        <li class="wb-slc">
+            <a class="wb-sl" href="#wb-cont">{{ i18n "skip-to-content" }}</a>
+        </li>
+    </ul>
+</nav>
 <header role="banner">
     <div id="wb-bnr" class="container">
         <div class="row">
@@ -79,7 +81,7 @@
                         </div>
                     </section>
             </div>
-        </div>        
+        </div>
     </div>
 
     <div class="header-cds-lockup-container">
@@ -118,7 +120,7 @@
             <div class="row">
                 <nav class="col-md-10 ftr-urlt-lnk">
                     <h2 class="wb-inv">{{ i18n "about-this-site" }}</h2>
-                    
+
                     {{ partial "footer-links.html" }}
 
                 </nav>


### PR DESCRIPTION
# Summary | Résumé
Lighthouse was showing an error about the skip to main content `li` tag
not being contained in a `ul`. The a11-tools-query gave a bit more
context that the `ul` should not have a `navigation` role (fixing both
the invalid `navigation` role on the `ul` and the `li` missing a
non-role'd parent).

This change uses the same `ul` as is used on Canada.ca and to wrap the
`ul` in a `nav` similar to Canada.ca.

Fixes #2129

# Test instructions | Instructions pour tester la modification
This is changing the global templates for a bunch of pages, so probably a good idea to check around on a few random pages to make sure everything is OK.

# Reviewer checklist | Liste de vérification du réviseur
- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce que ça devrait être divisé en de plus petites demandes de tirage (« pull requests ») afin de réduire le risque lié aux modifications?
