### PR TITLE
Remove WET-BOEW JS includes.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -129,8 +129,6 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"
       integrity="sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT"
       crossorigin="anonymous"></script>
-    <script src="/lib-cds/gcweb-dist/wet-boew/js/wet-boew.min.js"></script>
-    <script src="/lib-cds/gcweb-dist/GCWeb/js/theme.min.js"></script>
     <script src="/js/cds-app.js"></script>
     <script src="/js/lazyload.js" async=""></script>
 

--- a/layouts/a11y/default.html
+++ b/layouts/a11y/default.html
@@ -104,8 +104,6 @@
       <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"
           integrity="sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT"
           crossorigin="anonymous"></script>
-      <script src="/lib-cds/gcweb-dist/wet-boew/js/wet-boew.min.js"></script>
-      <script src="/lib-cds/gcweb-dist/GCWeb/js/theme.min.js"></script>
       <script src="/js/cds-app.js"></script>
       <script src="/js/lazyload.js" async=""></script>
 

--- a/layouts/engagement/default.html
+++ b/layouts/engagement/default.html
@@ -103,8 +103,6 @@
     </div>
 </footer>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
-<script src="/lib-cds/gcweb-dist/wet-boew/js/wet-boew.min.js"></script>
-<script src="/lib-cds/gcweb-dist/GCWeb/js/theme.min.js"></script>
 
 <!-- Extras -->
 <script src="/js/engagement-app.js"></script>

--- a/layouts/roadmap/baseof.html
+++ b/layouts/roadmap/baseof.html
@@ -135,8 +135,6 @@
     </div>
 </footer>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
-<script src="/lib-cds/gcweb-dist/wet-boew/js/wet-boew.min.js"></script>
-<script src="/lib-cds/gcweb-dist/GCWeb/js/theme.min.js"></script>
 
 <!-- Extras -->
 <script src="/js/roadmap-app.js"></script>


### PR DESCRIPTION
# Summary | Résumé

This PR removes the script tags using the WET-BOEW JS files as they
don't appear to be used.