### PR TITLE
Updating Contact Us link on Partnerships page

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,4 +1,4 @@
-unot-found:
+not-found:
   other: "Sorry, eh?"
 aria-canada-website:
   other: "Government of Canada"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,4 +1,4 @@
-not-found:
+unot-found:
   other: "Sorry, eh?"
 aria-canada-website:
   other: "Government of Canada"
@@ -58,6 +58,8 @@ partnerships:
   other: "Partnerships"
 partnerships-contact-us:
     other: "Contact us"
+partnerships-contact-us-link:
+    other: "https://forms-formulaires.alpha.canada.ca/id/45"
 partnerships-intro:
   other: "At the Canadian Digital Service (CDS), we partner up with federal departments to design, test and build simple, easy to use services. Our goal is to improve the experience – for people who deliver government services and people who use those services."
 partnerships-how-it-works:

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -58,6 +58,8 @@ partnerships:
   other: "Partenariats"
 partnerships-contact-us:
   other: "Communiquez avec nous"
+partnerships-contact-us-link:
+    other: "https://forms-formulaires.alpha.canada.ca/fr/id/45"
 partnerships-intro:
   other: "Au Service numérique canadien (SNC), nous établissons des partenariats avec les ministères fédéraux pour concevoir, tester et bâtir des services simples et faciles à utiliser. Notre objectif est d’améliorer l’expérience des personnes qui fournissent les services gouvernementaux tout comme celle des personnes qui les utilisent."
 partnerships-how-it-works:

--- a/layouts/section/partnerships.html
+++ b/layouts/section/partnerships.html
@@ -56,7 +56,7 @@
       <p>{{ i18n "partnerships-interested-in-chatting" }}</p>
     </div>
     <div class='col-md-5 col-xs-12'>
-      <a href="mailto:CDS-SNC@tbs-sct.gc.ca" id="partnerships-contact-us-link">
+      <a href={{ i18n "partnerships-contact-us-link"}} id="partnerships-contact-us-link">
         {{ i18n "partnerships-contact-us" }}
       </a>
     </div>


### PR DESCRIPTION
Updating the "Contact Us" button link on the Partnerships page to the following intake forms:

- English link: https://forms-formulaires.alpha.canada.ca/id/45
- French link: https://forms-formulaires.alpha.canada.ca/fr/id/45
