### PR TITLE
Pre-declare variables before setting global.

### DIFF
--- a/assets/sass/engagement/_settings.scss
+++ b/assets/sass/engagement/_settings.scss
@@ -1,3 +1,11 @@
+$primary-color: null;
+$engagement-color: null;
+$organizing-color: null;
+$talent-color: null;
+$design-color: null;
+$foundations-color: null;
+$yourthoughts-color: null;
+
 $primary-color: #1d344b !global;
 
 $active-nav-background-colour: #110b0a;


### PR DESCRIPTION
# Summary | Résumé

This PR fixes a warning which appears as the declaration and setting of
a variable `!global` is deprecated. This PR pre-declares the variable at
the top of the file allowing it to be made global later.

Issue #2052