### PR TITLE
Fixup .File.Dir warning from Hugo.

### DIFF
--- a/content/en/products/products/e-briefing-app.md
+++ b/content/en/products/products/e-briefing-app.md
@@ -5,6 +5,7 @@ description: >-
   An application to replace internal paper-based briefing binders.
 phase: alpha
 status: past
+productkind: partnership
 onhomepage: false
 contact:
   - email: mario.garneau@tbs-sct.gc.ca

--- a/content/en/products/products/energuide-api.md
+++ b/content/en/products/products/energuide-api.md
@@ -5,6 +5,7 @@ description: >-
   A public-facing application programming interface (API) to open up access to EnerGuide Home Energy Ratings data in a transparent and reusable way.
 phase: alpha
 status: past
+productkind: partnership
 onhomepage: false
 contact:
   - email: jennifer.fletcher@tbs-sct.gc.ca

--- a/content/en/products/products/find-financial-help-during-covid-19.md
+++ b/content/en/products/products/find-financial-help-during-covid-19.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://covid-benefits.alpha.canada.ca/en/start
 phase: alpha
 status: past
+productkind: partnership
 onhomepage: false
 contact:
   - email: CDS-SNC@tbs-sct.gc.ca

--- a/content/en/products/products/find-relevant-benefits-for-veterans.md
+++ b/content/en/products/products/find-relevant-benefits-for-veterans.md
@@ -5,6 +5,7 @@ description: >-
   An online tool to make it easier for Veterans and their family members to determine which benefits, programs, and services are relevant to them.
 phase: live
 status: past
+productkind: partnership
 onhomepage: false
 contact:
   - email: courtney.claessens@tbs-sct.gc.ca

--- a/content/en/products/products/government-of-canada-exposure-notifications-mobile-app.md
+++ b/content/en/products/products/government-of-canada-exposure-notifications-mobile-app.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://www.canada.ca/en/public-health/services/diseases/coronavirus-disease-covid-19/covid-alert.html
 phase: live
 status: in-flight
+productkind: partnership
 onhomepage: true
 contact:
   - email: CDS-SNC@tbs-sct.gc.ca

--- a/content/en/products/products/guidance-on-regulatory-consultation.md
+++ b/content/en/products/products/guidance-on-regulatory-consultation.md
@@ -5,6 +5,7 @@ description: >-
   Providing guidance on efforts to engage Canadians on regulations by identifying and validating user and business needs, conducting a market analysis of existing digital products, and presenting recommendations concerning procuring a product vs. building and maintaining a custom product.
 phase: discovery
 status: past
+productkind: partnership
 onhomepage: false
 contact:
   - email: CDS-SNC@tbs-sct.gc.ca

--- a/content/en/products/products/help-canadians-access-the-cpp-disability-benefit.md
+++ b/content/en/products/products/help-canadians-access-the-cpp-disability-benefit.md
@@ -5,6 +5,7 @@ description: >-
   Exploring how to improve service delivery for Canadians with disabilities and their children who apply for Canada Pension Plan (CPP) benefits.
 phase: alpha
 status: in-flight
+productkind: partnership
 onhomepage: true
 contact:
   - email: courtney.claessens@tbs-sct.gc.ca

--- a/content/en/products/products/help-canadians-with-low-income-file-taxes.md
+++ b/content/en/products/products/help-canadians-with-low-income-file-taxes.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://claim-tax-benefits.herokuapp.com/start
 phase: beta
 status: past
+productkind: partnership
 onhomepage: false
 contact:
   - email: clementine.hahn@tbs-sct.gc.ca

--- a/content/en/products/products/impact-canada-challenge-platform.md
+++ b/content/en/products/products/impact-canada-challenge-platform.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://impact.canada.ca/
 phase: beta
 status: past
+productkind: partnership
 onhomepage: false
 contact:
   - email: CDS-SNC@tbs-sct.gc.ca

--- a/content/en/products/products/make-it-easier-to-identify-tender-opportunities.md
+++ b/content/en/products/products/make-it-easier-to-identify-tender-opportunities.md
@@ -5,6 +5,7 @@ description: >-
   Exploring a service to create a modern, single point of access to all tenders across governments, including publicly funded academic, social, and health institutions.
 phase: discovery
 status: past
+productkind: partnership
 onhomepage: false
 contact:
   - email: steven.talbot@cds-snc.ca

--- a/content/en/products/products/open-call-catalogue-to-help-governments-respond-to-covid-19.md
+++ b/content/en/products/products/open-call-catalogue-to-help-governments-respond-to-covid-19.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://opencall-appelouvert.alpha.canada.ca/#/
 phase: alpha
 status: in-flight
+productkind: partnership
 onhomepage: true
 contact:
   - email: honey.dacanay@da-an.ca

--- a/content/en/products/products/report-a-cybercrime.md
+++ b/content/en/products/products/report-a-cybercrime.md
@@ -5,6 +5,7 @@ description: >-
   Iterating on a service that makes it easier for victims of cybercrime to report an incident and get guidance on what they can do to protect themselves.
 phase: beta
 status: in-flight
+productkind: partnership
 onhomepage: true
 contact:
   - email: emily.kuret@tbs-sct.gc.ca

--- a/content/en/products/products/reschedule-a-citizenship-test.md
+++ b/content/en/products/products/reschedule-a-citizenship-test.md
@@ -5,6 +5,7 @@ description: >-
   A service that allows people to reschedule their citizenship test online, moving away from paper-based processes and providing a simpler, easier and faster user experience for citizenship applicants.
 phase: beta
 status: past
+productkind: partnership
 onhomepage: false
 contact:
   - email: CDS-SNC@tbs-sct.gc.ca

--- a/content/en/products/products/track-web-security-compliance.md
+++ b/content/en/products/products/track-web-security-compliance.md
@@ -5,6 +5,7 @@ description: >-
   An online tool to check which government sites and web services are meeting good security practices, such as requiring privacy-protecting Hypertext Transfer Protocol Secure (HTTPS) connections.
 phase: beta
 status: past
+productkind: partnership
 onhomepage: false
 contact:
   - email: courtney.claessens@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/platform-tools/a11y-tracker.md
+++ b/content/en/tools-and-resources/platform-tools/a11y-tracker.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://github.com/cds-snc/a11y-tracker
 phase: alpha
 status: in-flight
+productkind: platform-tool
 onhomepage: false
 contact:
   - email: julie-ann.rowsell@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/platform-tools/book-an-appointment-with-government.md
+++ b/content/en/tools-and-resources/platform-tools/book-an-appointment-with-government.md
@@ -5,6 +5,7 @@ description: >-
   Researching a common way of booking appointments with government, to get people the in-person assistance they need.
 phase: discovery
 status: in-flight
+productkind: platform-tool
 onhomepage: false
 contact:
   - email: steven.talbot@cds-snc.ca

--- a/content/en/tools-and-resources/platform-tools/bundle-size-tracker.md
+++ b/content/en/tools-and-resources/platform-tools/bundle-size-tracker.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://github.com/cds-snc/bundle-size-tracker
 phase: beta
 status: in-flight
+productkind: platform-tool
 onhomepage: false
 contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/platform-tools/cds-log-driver.md
+++ b/content/en/tools-and-resources/platform-tools/cds-log-driver.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://github.com/cds-snc/logDriver
 phase: beta
 status: in-flight
+productkind: platform-tool
 onhomepage: false
 contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/platform-tools/continuous-security.md
+++ b/content/en/tools-and-resources/platform-tools/continuous-security.md
@@ -5,6 +5,7 @@ description: >-
   Security and risk management is often thought of at the end of a delivery phase, which prevents delivery teams from continuous delivery - we're working with IT security professionals and delivery teams to understand what it will take to make continuous security a reality.
 phase: discovery
 status: in-flight
+productkind: platform-tool
 onhomepage: false
 contact:
   - email: caitlin.tuba@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/platform-tools/dependency-checker.md
+++ b/content/en/tools-and-resources/platform-tools/dependency-checker.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://github.com/cds-snc/dependency-checker
 phase: beta
 status: in-flight
+productkind: platform-tool
 onhomepage: false
 contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/platform-tools/github-actions.md
+++ b/content/en/tools-and-resources/platform-tools/github-actions.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://github.com/cds-snc/github-actions
 phase: beta
 status: in-flight
+productkind: platform-tool
 onhomepage: false
 contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/platform-tools/help-public-servants-create-and-manage-forms.md
+++ b/content/en/tools-and-resources/platform-tools/help-public-servants-create-and-manage-forms.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://forms-formulaires.alpha.canada.ca/id/20
 phase: alpha
 status: in-flight
+productkind: platform-tool
 onhomepage: false
 contact:
   - email: steven.talbot@cds-snc.ca

--- a/content/en/tools-and-resources/platform-tools/kubernetes-branch-reviews.md
+++ b/content/en/tools-and-resources/platform-tools/kubernetes-branch-reviews.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://github.com/cds-snc/kubernetes-branch-review
 phase: beta
 status: in-flight
+productkind: platform-tool
 onhomepage: false
 contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/platform-tools/notify.md
+++ b/content/en/tools-and-resources/platform-tools/notify.md
@@ -2,10 +2,11 @@
 title: 'Notify'
 translationKey: notify-product
 description: >-
-  Keeping people updated as they use government services, by providing a simple and efficient way for government to build simple email and text notifications into their services. 
+  Keeping people updated as they use government services, by providing a simple and efficient way for government to build simple email and text notifications into their services.
 product-url: https://notification.canada.ca/
 phase: beta
 status: in-flight
+productkind: platform-tool
 onhomepage: false
 contact:
   - email: bryan.willey@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/platform-tools/personal-identifiable-information-checking.md
+++ b/content/en/tools-and-resources/platform-tools/personal-identifiable-information-checking.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://github.com/cds-snc/pii-checker
 phase: beta
 status: in-flight
+productkind: platform-tool
 onhomepage: false
 contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/platform-tools/security-goals.md
+++ b/content/en/tools-and-resources/platform-tools/security-goals.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://github.com/cds-snc/security-goals
 phase: alpha
 status: in-flight
+productkind: platform-tool
 onhomepage: false
 contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/platform-tools/time-to-interactive-tracking.md
+++ b/content/en/tools-and-resources/platform-tools/time-to-interactive-tracking.md
@@ -6,6 +6,7 @@ description: >-
 product-url: https://github.com/cds-snc/tti-tools-tracker
 phase: alpha
 status: in-flight
+productkind: platform-tool
 onhomepage: false
 contact:
   - email: CDSPlatform.PlateformesSNC@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/resources/a-guide-to-research-interviewing.md
+++ b/content/en/tools-and-resources/resources/a-guide-to-research-interviewing.md
@@ -5,6 +5,7 @@ description: >-
   A 101 on research interviewing.
 phase: live
 status: in-flight
+productkind: resource
 onhomepage: false
 contact:
   - email: CDS-SNC@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/resources/a-guide-to-usability-testing.md
+++ b/content/en/tools-and-resources/resources/a-guide-to-usability-testing.md
@@ -5,6 +5,7 @@ description: >-
   A 101 on usability testing.
 phase: live
 status: in-flight
+productkind: resource
 onhomepage: false
 contact:
   - email: CDS-SNC@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/resources/accessibility-handbook.md
+++ b/content/en/tools-and-resources/resources/accessibility-handbook.md
@@ -5,6 +5,7 @@ description: >-
   A set of guidelines for creating accessible and inclusive content for people with disabilities.
 phase: alpha
 status: in-flight
+productkind: resource
 onhomepage: false
 contact:
   - email: julie-ann.rowsell@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/resources/cds-product-evaluation-framework.md
+++ b/content/en/tools-and-resources/resources/cds-product-evaluation-framework.md
@@ -5,6 +5,7 @@ description: >-
   An outline of how CDS evaluates products and how they are delivered.
 phase: live
 status: in-flight
+productkind: resource
 onhomepage: false
 contact:
   - email: CDS-SNC@tbs-sct.gc.ca

--- a/content/en/tools-and-resources/resources/digital-government-reading-list.md
+++ b/content/en/tools-and-resources/resources/digital-government-reading-list.md
@@ -5,6 +5,7 @@ description: >-
   A list of articles to learn more about digital service delivery and technology modernization.
 phase: live
 status: in-flight
+productkind: resource
 onhomepage: false
 contact:
   - email: sean.boots@tbs-sct.gc.ca

--- a/layouts/section/partnerships.html
+++ b/layouts/section/partnerships.html
@@ -72,7 +72,7 @@
 
           {{ $blog_url := "picking-our-projects" }}
           {{ if eq $.Site.Language.Lang "fr" }}
-          {{ $blog_url = "choisir-nos-projets" }}
+            {{ $blog_url = "choisir-nos-projets" }}
           {{ end }}
           <a href="{{with $.Site.GetPage $blog_url}}{{.Permalink}}{{ end }}">
             {{ i18n "blog-post" }}.
@@ -83,7 +83,7 @@
   </div>
 
   <!-- In-flight partnerships -->
-  {{ $products := where .Site.Pages ".File.Dir" "==" "products/products/" }}
+  {{ $products := where .Site.Pages ".Params.productkind" "==" "partnership" }}
   <div class='container'>
     <div class='row'>
       <div class='col-xs-12'>
@@ -93,13 +93,13 @@
     <div class='row equal'>
       {{ $inflight := where .Site.Pages ".Params.status" "==" "in-flight" }}
       {{ range $elem_index, $elem_val := $inflight | intersect $products }}
-      {{ if and (ne $elem_index 0) (eq (mod $elem_index 2) 0) }}
-    </div>
-    <div class='row equal'>
-      {{ end }}
-      <div class='col-md-6 col-xs-12'>
-        {{ .Render "list"}}
-      </div>
+        {{ if and (ne $elem_index 0) (eq (mod $elem_index 2) 0) }}
+          </div>
+          <div class='row equal'>
+        {{ end }}
+        <div class='col-md-6 col-xs-12'>
+          {{ .Render "list"}}
+        </div>
       {{ end }}
     </div>
   </div>
@@ -114,13 +114,13 @@
     <div class='row equal'>
       {{ $past := where .Site.Pages ".Params.status" "==" "past" }}
       {{ range $elem_index, $elem_val := $past | intersect $products }}
-      {{ if and (ne $elem_index 0) (eq (mod $elem_index 2) 0) }}
-    </div>
-    <div class='row equal'>
-      {{ end }}
-      <div class='col-md-6 col-xs-12'>
-        {{ .Render "list"}}
-      </div>
+        {{ if and (ne $elem_index 0) (eq (mod $elem_index 2) 0) }}
+          </div>
+          <div class='row equal'>
+        {{ end }}
+        <div class='col-md-6 col-xs-12'>
+          {{ .Render "list"}}
+        </div>
       {{ end }}
     </div>
   </div>

--- a/layouts/section/tools-and-resources.html
+++ b/layouts/section/tools-and-resources.html
@@ -23,7 +23,7 @@
           </div>
         </div>
 
-      {{ $products := where .Site.Pages ".File.Dir" "==" "tools-and-resources/platform-tools/" }}
+      {{ $products := where .Site.Pages ".Params.productkind" "==" "platform-tool" }}
       <div class='row equal'>
         {{ $inflight := where .Site.Pages ".Params.status" "==" "in-flight" }}
         {{ range $elem_index, $elem_val := $inflight | intersect $products }}
@@ -40,24 +40,23 @@
 
         <!-- RESOURCES LIST -->
       <div class="section tools-and-resources--resources">
-
-          <div class="col-xs-12">
-            <h2>{{ i18n "tools-and-resources-resources-title" | safeHTML }}</h2>
-            <p>{{ i18n "tools-and-resources-resources-description" | safeHTML }}</p>
+        <div class="col-xs-12">
+          <h2>{{ i18n "tools-and-resources-resources-title" | safeHTML }}</h2>
+          <p>{{ i18n "tools-and-resources-resources-description" | safeHTML }}</p>
+        </div>
+        {{ $products := where .Site.Pages ".Params.productkind" "==" "resource" }}
+        <div class='row equal'>
+          {{ $inflight := where .Site.Pages ".Params.status" "==" "in-flight" }}
+          {{ range $elem_index, $elem_val := $inflight | intersect $products }}
+          {{ if and (ne $elem_index 0) (eq (mod $elem_index 2) 0) }}
+        </div>
+        <div class='row equal'>
+          {{ end }}
+          <div class='col-md-6 col-xs-12'>
+            {{ .Render "list"}}
           </div>
-          {{ $products := where .Site.Pages ".File.Dir" "==" "tools-and-resources/resources/" }}
-          <div class='row equal'>
-            {{ $inflight := where .Site.Pages ".Params.status" "==" "in-flight" }}
-            {{ range $elem_index, $elem_val := $inflight | intersect $products }}
-            {{ if and (ne $elem_index 0) (eq (mod $elem_index 2) 0) }}
-          </div>
-          <div class='row equal'>
-            {{ end }}
-            <div class='col-md-6 col-xs-12'>
-              {{ .Render "list"}}
-            </div>
-            {{ end }}
-          </div>
+          {{ end }}
+        </div>
       </div>
   </section>
 </div>


### PR DESCRIPTION
# Summary | Résumé

This PR removes the .File.Dir warning generated by Hugo on startup. It
does this by removing the use of .File.Dir and adding a new key into the
parameters for each of our types of things (partnership, platform-tool
or resource). This key is then used `.Params.productkind` to do the
filtering instead of the `.File.Dir` check.

Issue #2052
