### PR TITLE
Fix missing content with new Hugo.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -23,7 +23,7 @@
           {{ range $idx, $post := first 4 $homepage }}
             {{ if and (ne $idx 0) (eq (mod $idx 2) 0) }}
       </div>
-      <!-- The following renders same styles + list of products featured in Partnerships page -->
+      <!-- The following renders same styles + list of products featured in Partnerships page  -->
       <div class='row equal'>
         {{ end }}
         <div class='col-md-6 col-xs-12'>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -88,7 +88,7 @@
       </div>
       <div class="row blog-posts">
         {{ $p := where .Site.Pages "Section" "==" "blog" }}
-        {{ $posts := where $p ".Params.processed" ">" 0 }}
+        {{ $posts := where $p ".Params.author" "!=" nil }}
         {{ range first 3 $posts }}
           <div class="col-xs-12 col-md-4">
             <div class='post'>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,7 +18,7 @@
       </div>
 
       <div class='row equal'>
-          {{ $posts := where .Pages ".Section" "==" "products" }}
+          {{ $posts := where .Site.Pages ".Section" "==" "products" }}
           {{ $homepage := where $posts ".Params.onhomepage" true }}
           {{ range $idx, $post := first 4 $homepage }}
             {{ if and (ne $idx 0) (eq (mod $idx 2) 0) }}
@@ -87,7 +87,8 @@
         </div>
       </div>
       <div class="row blog-posts">
-        {{ $posts := where .Pages "Section" "blog" }}
+        {{ $p := where .Site.Pages "Section" "==" "blog" }}
+        {{ $posts := where $p ".Params.processed" ">" 0 }}
         {{ range first 3 $posts }}
           <div class="col-xs-12 col-md-4">
             <div class='post'>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -23,7 +23,7 @@
           {{ range $idx, $post := first 4 $homepage }}
             {{ if and (ne $idx 0) (eq (mod $idx 2) 0) }}
       </div>
-      <!-- The following renders same styles + list of products featured in Partnerships page  -->
+      <!-- The following renders same styles + list of products featured in Partnerships page -->
       <div class='row equal'>
         {{ end }}
         <div class='col-md-6 col-xs-12'>


### PR DESCRIPTION
# Summary | Résumé

It seems with newer Hugo the main page needs to use `.Site.Pages`
instead of `.Pages` in order for the page content to show up.

This seems to also pull in the folder as a data item, it's fine for the
products as they have an `onhomepage` filter. For the blog posts I added
in a filter to make sure there was a `author` tag in order to filter
out the folder.

Issue #2052