### PR TITLE
Change card headings for better accessibility.

### DIFF
--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -46,7 +46,7 @@
   border-top: 1px solid $black;
 
   h1 {
-    font-size: 3rem; 
+    font-size: 3rem;
 
     @include mobile_only {
       font-size: 2.5rem;
@@ -130,7 +130,7 @@
   p {
     margin-bottom: 10px;
   }
- 
+
 }
 
 .homepage--our-team {
@@ -210,16 +210,16 @@
     display: flex;
     justify-content: space-between;
 
-    @include mobile_only { 
-      text-align: center; 
+    @include mobile_only {
+      text-align: center;
     }
 
-    @include tablet { 
-      text-align: center; 
+    @include tablet {
+      text-align: center;
     }
 
-    @include desktop { 
-      text-align: left; 
+    @include desktop {
+      text-align: left;
     }
 
     @media( max-width: 1220px) {
@@ -244,8 +244,8 @@
         margin-bottom: 5px;
       }
 
-      @include desktop { 
-        text-align: left; 
+      @include desktop {
+        text-align: left;
       }
     }
   }
@@ -381,8 +381,8 @@ span.livefr {
   margin-bottom: 2em;
   box-shadow: 5px 8px 5px $medium-grey;
   height: 100%;
-  padding: 10px 10px 20px 10px;
-  
+  padding: 10px 25px 20px 25px;
+
   @include desktop {
     padding-bottom: 0;
   }
@@ -391,26 +391,26 @@ span.livefr {
     display: inline;
   }
 
-  h4, 
+  h1,
   .title-link {
     font-weight: 500;
     margin: 12px 0;
-  
-    @include mobile_only { 
-      font-size: 2.4rem; 
+
+    @include mobile_only {
+      font-size: 2.4rem;
     }
 
     @include tablet {
       font-size: 2.6rem;
     }
 
-    @include desktop { 
-      font-size: 3rem; 
+    @include desktop {
+      font-size: 3rem;
       margin-top: 20px;
     }
   }
 
-  h5, p, a {
+  h2, p, a {
     font-size: 1.85rem;
     display: inline-block;
   }
@@ -424,15 +424,15 @@ span.livefr {
     }
   }
 
-  h4.live::after,
-  h4.livefr::after,
-  h4.alpha::after,
-  h4.alphafr::after,
-  h4.discovery::after,
-  h4.discoveryfr::after,
-  h4.découvertefr::after,
-  h4.beta::after,
-  h4.betafr::after {
+  h1.live::after,
+  h1.livefr::after,
+  h1.alpha::after,
+  h1.alphafr::after,
+  h1.discovery::after,
+  h1.discoveryfr::after,
+  h1.découvertefr::after,
+  h1.beta::after,
+  h1.betafr::after {
     display: inline-block;
     position: relative;
     bottom: 10px;
@@ -441,6 +441,7 @@ span.livefr {
     margin-top: 10px;
     border-radius: 3px;
     font-size: 1.2rem;
+    line-height: 1.2rem;
     text-transform: uppercase;
 
     @include mobile_only {
@@ -457,47 +458,48 @@ span.livefr {
     }
   }
 
-  h4.live::after,
-  h4.livefr::after {
+  h1.live::after,
+  h1.livefr::after {
     background-color: $live-color;
   }
 
-  h4.live::after {
+  h1.live::after {
     content: "Live";
   }
 
-  h4.livefr::after {
+  h1.livefr::after {
     content: "En ligne";
   }
 
-  h4.alpha::after,
-  h4.alphafr::after {
+  h1.alpha::after,
+  h1.alphafr::after {
     content: "Alpha";
     background-color: $alpha-color;
   }
 
-  h4.discovery::after,
-  h4.discoveryfr::after,
-  h4.découvertefr::after {
+  h1.discovery::after,
+  h1.discoveryfr::after,
+  h1.découvertefr::after {
     background-color: $discovery-color;
   }
 
-  h4.discovery::after { content: "Discovery"; }
-  h4.découvertefr::after,
-  h4.discoveryfr::after { 
+  h1.discovery::after { content: "Discovery"; }
+  h1.découvertefr::after,
+  h1.discoveryfr::after {
     content: "Découverte";
   }
 
-  h4.beta::after,
-  h4.betafr::after {
+  h1.beta::after,
+  h1.betafr::after {
     background-color: $beta-color;
   }
 
-  h4.beta::after { content: "Beta"; }
-  h4.betafr::after { content: "Bêta"; }
+  h1.beta::after { content: "Beta"; }
+  h1.betafr::after { content: "Bêta"; }
 
-  h5 {
+  h2 {
     font-weight: 100;
+    margin-bottom: 11.5px;
 
     @include mobile_only {
       margin-top: 5px;
@@ -512,17 +514,12 @@ span.livefr {
     }
   }
 
-  h1,
-  h2,
-  h4 {
+  h1 {
     color: #000000;
+    line-height: 1.1em;
   }
 
   p { margin-bottom: 0px; }
-}
-
-.work-in-progress--platform-module {
-  padding: 10px;
 }
 
 .work-in-progress--product-summary {
@@ -663,13 +660,13 @@ span.livefr {
 .section--title-offset{
   font-size: 3rem;
   margin:0 0 2rem;
-  
+
 }
 
 .flexbox {
   display: flex;
-  
-  
+
+
 
   .steps-icon {
     flex: 0 0 70px;
@@ -692,7 +689,7 @@ span.livefr {
 
 .our-job--listing {
   margin: 40px 0;
-  
+
   h3 {
     margin: 0 20px;
   }
@@ -714,7 +711,7 @@ span.livefr {
 
     @include logo_break{
       flex-direction: column;
-    } 
+    }
   }
 
   .post {
@@ -728,12 +725,12 @@ span.livefr {
     @include logo_break{
       width: 80%;
       margin: 10px 0;
-    } 
+    }
 
     @include mobile_only {
       width: 100%;
     }
-    
+
 
     p {
       margin-bottom: 0px;
@@ -745,7 +742,7 @@ span.livefr {
       font-size: 2rem;
       font-weight: 600;
       text-decoration: underline;
-      
+
     }
   }
 }
@@ -766,7 +763,7 @@ span.livefr {
     max-width: 100%;
     height: auto;
   }
-    
+
   .section-smallcaps-title {
     font-weight: 500;
     font-size: 1.75rem;
@@ -953,7 +950,7 @@ span.livefr {
     flex-direction: column;
     width: 80%;
     margin: 0 auto 30px auto;
-  } 
+  }
 
   .post:first-child {
     padding-top: 0;
@@ -971,7 +968,7 @@ span.livefr {
 
   .post:nth-child(odd) {
     margin-right: 30px;
-    
+
     @media (max-width: 950px) {
       margin-right: 0;
     }
@@ -1206,8 +1203,8 @@ article.post {
     }
   }
 
-  #mc_embed_signup_scroll { 
-    padding: 0; 
+  #mc_embed_signup_scroll {
+    padding: 0;
     display: flex;
     flex-direction: row;
     margin-bottom: 25px;
@@ -1251,8 +1248,8 @@ article.post {
     margin-top: 0;
     padding-left: 0;
 
-    a { 
-      @include label; 
+    a {
+      @include label;
       &:first-child { margin-right: 23px; }
     }
   }
@@ -1496,7 +1493,7 @@ article.post {
 
  .partnerships-info {
   margin: 6rem 0 4rem 0;
-  
+
   h2 {
     margin: 2rem 0 1rem 0;
   }
@@ -1531,8 +1528,8 @@ article.post {
   padding-bottom: 2.5rem;
   background-color: $primary-color;
 
-   p { 
-     font-weight: 900; 
+   p {
+     font-weight: 900;
      color: $black;
     }
 

--- a/layouts/products/list.html
+++ b/layouts/products/list.html
@@ -1,79 +1,51 @@
 
 <section class="work-in-progress--product-module border-{{.Params.phase}}"
          id="{{.Params.translationKey}}">
-  <!-- Product Title-->
-  <div class="row">
-    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-      <div class="title-container">
-        <div>
-          <h4 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
-            {{ .Params.title }}
-          </h4>
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- End Product Title-->
+  <h1 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
+    {{ .Params.title }}
+  </h1>
 
   <!-- URL -->
   {{ with (index .Params "product-url")}}
-    <div class="row">
-      <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-        <div class="service-link"><a class="view-product" href='{{ . }}'>{{ i18n "view-product"}}</a></div>
-      </div>
+    <div class="service-link">
+      <a class="view-product" href='{{ . }}'>{{ i18n "view-product"}}</a>
     </div>
   {{ end }}
   <!-- END URL -->
 
-  <!-- Description -->
-  <div class="row">
-    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-      <div class="work-in-progress--product-summary">
-        <p>{{ .Params.description }}</p>
-      </div>
-    </div>
+  <div class="work-in-progress--product-summary">
+    <p>{{ .Params.description }}</p>
   </div>
-  <!-- End Description -->
 
   <!-- Partner -->
-  <div class="row">
-    {{ if gt (len .Params.partners) 0 }}
-      <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-        <div class="work-in-progress--partners-long">
-          <h5>{{ i18n "partner" }}{{ if gt (len .Params.partners) 1 }}s{{end}}:</h5>
-          {{ range .Params.partners }}
-            <p><a class="partner-link" href='{{ .url }}'>{{ .name }}</a></p>
-          {{ end }}
-        </div>
-      </div>
+  {{ if gt (len .Params.partners) 0 }}
+    <h2>{{ i18n "partner" }}{{ if gt (len .Params.partners) 1 }}s{{end}}:</h2>
+    {{ range .Params.partners }}
+      <p><a class="partner-link" href='{{ .url }}'>{{ .name }}</a></p>
     {{ end }}
+  {{ end }}
   <!-- End Partner -->
 
-    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-      <!-- In progress team -->
-      <div class="work-in-progress--team">
-        <h5>Contact:</h5>
-        {{ range .Params.contact }}
-          <p><a class="contact-link" href='mailto:{{.email}}'>{{.name}}</a></p>
-        {{ end }}
-      </div>
-      <!-- End in progress team -->
-    </div>
-
-    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-      <!-- In progress -->
-      <div class="work-in-progress--links">
-        {{with .Params.links }}
-          {{ if gt (len .) 0 }}
-            <h5>{{ i18n "links" }}:</h5>
-            {{range .}}
-              <p><a class="resource-link" href="{{ .url }}">{{.name}}</a></p>
-            {{ end }}
-          {{ end }}
-        {{ end }}
-      </div>
-      <!-- End in progress -->
-    </div>
+  <!-- In progress team -->
+  <div class="work-in-progress--team">
+    <h2>Contact:</h2>
+    {{ range .Params.contact }}
+      <p><a class="contact-link" href='mailto:{{.email}}'>{{.name}}</a></p>
+    {{ end }}
   </div>
+  <!-- End in progress team -->
+
+  <!-- In progress -->
+  <div class="work-in-progress--links">
+    {{with .Params.links }}
+      {{ if gt (len .) 0 }}
+        <h2>{{ i18n "links" }}:</h2>
+        {{range .}}
+          <p><a class="resource-link" href="{{ .url }}">{{.name}}</a></p>
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  </div>
+  <!-- End in progress -->
 </section>
 

--- a/layouts/products/list.html
+++ b/layouts/products/list.html
@@ -5,7 +5,7 @@
     {{ .Params.title }}
   </h1>
 
-  <!-- URL -->
+  <!-- URL  -->
   {{ with (index .Params "product-url")}}
     <div class="service-link">
       <a class="view-product" href='{{ . }}'>{{ i18n "view-product"}}</a>

--- a/layouts/tools-and-resources/list.html
+++ b/layouts/tools-and-resources/list.html
@@ -1,65 +1,38 @@
 <section class="section work-in-progress--product-module work-in-progress--platform-module border-{{.Params.phase}}"
          id="{{.Params.translationKey}}">
-  <!-- Product Title-->
-  <div class="row">
-    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-      <div class="title-container">
-        <div>
-          <h4 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
-            {{ .Params.title }}
-          </h4>
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- End Product Title-->
+  <h1 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
+    {{ .Params.title }}
+  </h1>
 
   <!-- URL -->
   {{ with (index .Params "product-url")}}
-    <div class="row">
-      <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-        <div class="service-link">
-          <a class="view-product" href='{{ . }}'>{{ i18n "view-product"}}</a></div>
-      </div>
+    <div class="service-link">
+      <a class="view-product" href='{{ . }}'>{{ i18n "view-product"}}</a>
     </div>
   {{ end }}
   <!-- END URL -->
 
-  <!-- DESC -->
-  <div class="row">
-    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-      <div class="work-in-progress--product-summary">
-        <p>{{ .Params.description }}</p>
-      </div>
-    </div>
+  <div class="work-in-progress--product-summary">
+    <p>{{ .Params.description }}</p>
   </div>
-  <!-- End DESC -->
 
   <!-- CONTACT -->
-  <div class="row">
-    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-      <div class="work-in-progress--team">
-        <h5>Contact:</h5>
-        {{ range .Params.contact }}
-        <p><a class="contact-link" href='mailto:{{.email}}'>{{ .name }}</a></p>
-        {{ end }}
-      </div>
-    </div>
+  <div class="work-in-progress--team">
+    <h2>Contact:</h2>
+    {{ range .Params.contact }}
+      <p><a class="contact-link" href='mailto:{{.email}}'>{{ .name }}</a></p>
+    {{ end }}
   </div>
   <!-- END CONTACT -->
 
-  <div class="row">
-    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-      <div class="work-in-progress--links">
-        {{with .Params.links }}
-          {{ if gt (len .) 0 }}
-            <h5>{{ i18n "links" }}:</h5>
-            {{range .}}
-              <p><a class="resource-link" href="{{ .url }}">{{.name}}</a></p>
-            {{ end }}
-          {{ end }}
+  <div class="work-in-progress--links">
+    {{with .Params.links }}
+      {{ if gt (len .) 0 }}
+        <h2>{{ i18n "links" }}:</h2>
+        {{range .}}
+          <p><a class="resource-link" href="{{ .url }}">{{.name}}</a></p>
         {{ end }}
-      </div>
-    </div>
+      {{ end }}
+    {{ end }}
   </div>
 </section>


### PR DESCRIPTION
# Summary | Résumé

This PR changes the headings of the product cards to use h1/h2 instead
of h4/h5. In the latter case, the homepage would have headings h1, h2,
h4, h5 which causes an accessibility warning.

This PR changes the cards to use h1/h2 as the headings are inside a
section and updates the stylings to match. Most of the divs have been
removed as the cards still appear to format correctly without all the
tag nesting.

Fixes #2288