### PR TITLE
Change heading structure for partnership list.

### DIFF
--- a/assets/sass/cds/_base.scss
+++ b/assets/sass/cds/_base.scss
@@ -15,8 +15,8 @@
 
 // CDS Base Styles and Style Overrides
 html {
-	// This sets the base font size as 1rem or 10px. 
-	font-size: 62.5%; 
+	// This sets the base font size as 1rem or 10px.
+	font-size: 62.5%;
 }
 
 body, h1, h2, h3, h4, h5, h6, p, ul, ol, li, a {
@@ -33,7 +33,7 @@ a {
 	color 		: inherit;
 	font-weight 	: 500;
 	transition: all 0.3s ease-in-out;
-	
+
 
 	@include mobile_only {
 		font-size: 1.75rem;
@@ -107,7 +107,7 @@ h1, .h1 {
 	}
 }
 
-h2 {
+h2, .h2 {
 	font-family: "SourceSansPro", sans-serif;
 	font-weight: 500;
 	margin-top: 0;
@@ -141,7 +141,7 @@ html .container {
 .term {
 	font-style:italic;
 }
-		
+
 .col-sm-10,
 .col-sm-offset-1 {
 	margin: 0;
@@ -190,7 +190,7 @@ html .container {
 			bottom: -2rem;
 		}
 	}
-	
+
 
 	@include tablet {
 		font-size: 3.5rem;

--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -391,7 +391,7 @@ span.livefr {
     display: inline;
   }
 
-  h1,
+  .h1,
   .title-link {
     font-weight: 500;
     margin: 12px 0;
@@ -410,7 +410,7 @@ span.livefr {
     }
   }
 
-  h2, p, a {
+  .h2, p, a {
     font-size: 1.85rem;
     display: inline-block;
   }
@@ -424,15 +424,15 @@ span.livefr {
     }
   }
 
-  h1.live::after,
-  h1.livefr::after,
-  h1.alpha::after,
-  h1.alphafr::after,
-  h1.discovery::after,
-  h1.discoveryfr::after,
-  h1.découvertefr::after,
-  h1.beta::after,
-  h1.betafr::after {
+  .h1.live::after,
+  .h1.livefr::after,
+  .h1.alpha::after,
+  .h1.alphafr::after,
+  .h1.discovery::after,
+  .h1.discoveryfr::after,
+  .h1.découvertefr::after,
+  .h1.beta::after,
+  .h1.betafr::after {
     display: inline-block;
     position: relative;
     bottom: 10px;
@@ -458,46 +458,46 @@ span.livefr {
     }
   }
 
-  h1.live::after,
-  h1.livefr::after {
+  .h1.live::after,
+  .h1.livefr::after {
     background-color: $live-color;
   }
 
-  h1.live::after {
+  .h1.live::after {
     content: "Live";
   }
 
-  h1.livefr::after {
+  .h1.livefr::after {
     content: "En ligne";
   }
 
-  h1.alpha::after,
-  h1.alphafr::after {
+  .h1.alpha::after,
+  .h1.alphafr::after {
     content: "Alpha";
     background-color: $alpha-color;
   }
 
-  h1.discovery::after,
-  h1.discoveryfr::after,
-  h1.découvertefr::after {
+  .h1.discovery::after,
+  .h1.discoveryfr::after,
+  .h1.découvertefr::after {
     background-color: $discovery-color;
   }
 
-  h1.discovery::after { content: "Discovery"; }
-  h1.découvertefr::after,
-  h1.discoveryfr::after {
+  .h1.discovery::after { content: "Discovery"; }
+  .h1.découvertefr::after,
+  .h1.discoveryfr::after {
     content: "Découverte";
   }
 
-  h1.beta::after,
-  h1.betafr::after {
+  .h1.beta::after,
+  .h1.betafr::after {
     background-color: $beta-color;
   }
 
-  h1.beta::after { content: "Beta"; }
-  h1.betafr::after { content: "Bêta"; }
+  .h1.beta::after { content: "Beta"; }
+  .h1.betafr::after { content: "Bêta"; }
 
-  h2 {
+  .h2 {
     font-weight: 100;
     margin-bottom: 11.5px;
 
@@ -514,9 +514,10 @@ span.livefr {
     }
   }
 
-  h1 {
+  .h1 {
     color: #000000;
     line-height: 1.1em;
+    width: 100%;
   }
 
   p { margin-bottom: 0px; }

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,17 +18,17 @@
       </div>
 
       <div class='row equal'>
-          {{ $posts := where .Site.Pages ".Section" "==" "products" }}
-          {{ $homepage := where $posts ".Params.onhomepage" true }}
-          {{ range $idx, $post := first 4 $homepage }}
-            {{ if and (ne $idx 0) (eq (mod $idx 2) 0) }}
-      </div>
-      <!-- The following renders same styles + list of products featured in Partnerships page -->
-      <div class='row equal'>
-        {{ end }}
-        <div class='col-md-6 col-xs-12'>
-          {{ .Render "list"}}
-        </div>
+        {{ $posts := where .Site.Pages ".Section" "==" "products" }}
+        {{ $homepage := where $posts ".Params.onhomepage" true }}
+        {{ range $idx, $post := first 4 $homepage }}
+          {{ if and (ne $idx 0) (eq (mod $idx 2) 0) }}
+            </div>
+            <!-- The following renders same styles + list of products featured in Partnerships page -->
+            <div class='row equal'>
+          {{ end }}
+          <div class='col-md-6 col-xs-12'>
+            {{ .Render "list"}}
+          </div>
         {{ end }}
       </div>
     </section>

--- a/layouts/products/list.html
+++ b/layouts/products/list.html
@@ -1,9 +1,10 @@
 
 <section class="work-in-progress--product-module border-{{.Params.phase}}"
          id="{{.Params.translationKey}}">
-  <h1 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
+  <div class='h1 {{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'
+      role="heading">
     {{ .Params.title }}
-  </h1>
+  </div>
 
   <!-- URL  -->
   {{ with (index .Params "product-url")}}
@@ -19,7 +20,10 @@
 
   <!-- Partner -->
   {{ if gt (len .Params.partners) 0 }}
-    <h2>{{ i18n "partner" }}{{ if gt (len .Params.partners) 1 }}s{{end}}:</h2>
+    <div class='h2'>
+      {{ i18n "partner" }}{{ if gt (len .Params.partners) 1 }}s{{end}}:
+    </div>
+
     {{ range .Params.partners }}
       <p><a class="partner-link" href='{{ .url }}'>{{ .name }}</a></p>
     {{ end }}
@@ -28,7 +32,7 @@
 
   <!-- In progress team -->
   <div class="work-in-progress--team">
-    <h2>Contact:</h2>
+    <div class="h2">Contact:</div>
     {{ range .Params.contact }}
       <p><a class="contact-link" href='mailto:{{.email}}'>{{.name}}</a></p>
     {{ end }}
@@ -39,7 +43,7 @@
   <div class="work-in-progress--links">
     {{with .Params.links }}
       {{ if gt (len .) 0 }}
-        <h2>{{ i18n "links" }}:</h2>
+        <div class="h2">{{ i18n "links" }}:</div>
         {{range .}}
           <p><a class="resource-link" href="{{ .url }}">{{.name}}</a></p>
         {{ end }}

--- a/layouts/tools-and-resources/list.html
+++ b/layouts/tools-and-resources/list.html
@@ -1,8 +1,9 @@
 <section class="section work-in-progress--product-module work-in-progress--platform-module border-{{.Params.phase}}"
          id="{{.Params.translationKey}}">
-  <h1 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
+  <div class='h1 {{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'
+      role="heading">
     {{ .Params.title }}
-  </h1>
+  </div>
 
   <!-- URL -->
   {{ with (index .Params "product-url")}}
@@ -18,7 +19,7 @@
 
   <!-- CONTACT -->
   <div class="work-in-progress--team">
-    <h2>Contact:</h2>
+    <div class="h2">Contact:</div>
     {{ range .Params.contact }}
       <p><a class="contact-link" href='mailto:{{.email}}'>{{ .name }}</a></p>
     {{ end }}
@@ -28,7 +29,7 @@
   <div class="work-in-progress--links">
     {{with .Params.links }}
       {{ if gt (len .) 0 }}
-        <h2>{{ i18n "links" }}:</h2>
+        <div class="h2">{{ i18n "links" }}:</div>
         {{range .}}
           <p><a class="resource-link" href="{{ .url }}">{{.name}}</a></p>
         {{ end }}


### PR DESCRIPTION
# Summary | Résumé

This PR changes the partnership include to not use h1/h2 anymore.
Instead div's are used which are styled with classes `.h1` and `.h2`.
The top level div is marked as a `role=heading` but the others are not
as they don't really work like headings in the card.

Issue #2288