### PR TITLE
Revert "Change card headings for better accessibility. (#2322)"

### DIFF
--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -381,7 +381,7 @@ span.livefr {
   margin-bottom: 2em;
   box-shadow: 5px 8px 5px $medium-grey;
   height: 100%;
-  padding: 10px 25px 20px 25px;
+  padding: 10px 10px 20px 10px;
 
   @include desktop {
     padding-bottom: 0;
@@ -391,7 +391,7 @@ span.livefr {
     display: inline;
   }
 
-  h1,
+  h4,
   .title-link {
     font-weight: 500;
     margin: 12px 0;
@@ -410,7 +410,7 @@ span.livefr {
     }
   }
 
-  h2, p, a {
+  h5, p, a {
     font-size: 1.85rem;
     display: inline-block;
   }
@@ -424,15 +424,15 @@ span.livefr {
     }
   }
 
-  h1.live::after,
-  h1.livefr::after,
-  h1.alpha::after,
-  h1.alphafr::after,
-  h1.discovery::after,
-  h1.discoveryfr::after,
-  h1.découvertefr::after,
-  h1.beta::after,
-  h1.betafr::after {
+  h4.live::after,
+  h4.livefr::after,
+  h4.alpha::after,
+  h4.alphafr::after,
+  h4.discovery::after,
+  h4.discoveryfr::after,
+  h4.découvertefr::after,
+  h4.beta::after,
+  h4.betafr::after {
     display: inline-block;
     position: relative;
     bottom: 10px;
@@ -441,7 +441,6 @@ span.livefr {
     margin-top: 10px;
     border-radius: 3px;
     font-size: 1.2rem;
-    line-height: 1.2rem;
     text-transform: uppercase;
 
     @include mobile_only {
@@ -458,48 +457,47 @@ span.livefr {
     }
   }
 
-  h1.live::after,
-  h1.livefr::after {
+  h4.live::after,
+  h4.livefr::after {
     background-color: $live-color;
   }
 
-  h1.live::after {
+  h4.live::after {
     content: "Live";
   }
 
-  h1.livefr::after {
+  h4.livefr::after {
     content: "En ligne";
   }
 
-  h1.alpha::after,
-  h1.alphafr::after {
+  h4.alpha::after,
+  h4.alphafr::after {
     content: "Alpha";
     background-color: $alpha-color;
   }
 
-  h1.discovery::after,
-  h1.discoveryfr::after,
-  h1.découvertefr::after {
+  h4.discovery::after,
+  h4.discoveryfr::after,
+  h4.découvertefr::after {
     background-color: $discovery-color;
   }
 
-  h1.discovery::after { content: "Discovery"; }
-  h1.découvertefr::after,
-  h1.discoveryfr::after {
+  h4.discovery::after { content: "Discovery"; }
+  h4.découvertefr::after,
+  h4.discoveryfr::after {
     content: "Découverte";
   }
 
-  h1.beta::after,
-  h1.betafr::after {
+  h4.beta::after,
+  h4.betafr::after {
     background-color: $beta-color;
   }
 
-  h1.beta::after { content: "Beta"; }
-  h1.betafr::after { content: "Bêta"; }
+  h4.beta::after { content: "Beta"; }
+  h4.betafr::after { content: "Bêta"; }
 
-  h2 {
+  h5 {
     font-weight: 100;
-    margin-bottom: 11.5px;
 
     @include mobile_only {
       margin-top: 5px;
@@ -514,12 +512,17 @@ span.livefr {
     }
   }
 
-  h1 {
+  h1,
+  h2,
+  h4 {
     color: #000000;
-    line-height: 1.1em;
   }
 
   p { margin-bottom: 0px; }
+}
+
+.work-in-progress--platform-module {
+  padding: 10px;
 }
 
 .work-in-progress--product-summary {
@@ -722,6 +725,7 @@ span.livefr {
     max-width: 100%;
     height: auto;
   }
+
 }
 
 .work-with-us--process {

--- a/layouts/products/list.html
+++ b/layouts/products/list.html
@@ -1,51 +1,79 @@
 
 <section class="work-in-progress--product-module border-{{.Params.phase}}"
          id="{{.Params.translationKey}}">
-  <h1 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
-    {{ .Params.title }}
-  </h1>
+  <!-- Product Title-->
+  <div class="row">
+    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+      <div class="title-container">
+        <div>
+          <h4 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
+            {{ .Params.title }}
+          </h4>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- End Product Title-->
 
-  <!-- URL  -->
+  <!-- URL -->
   {{ with (index .Params "product-url")}}
-    <div class="service-link">
-      <a class="view-product" href='{{ . }}'>{{ i18n "view-product"}}</a>
+    <div class="row">
+      <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+        <div class="service-link"><a class="view-product" href='{{ . }}'>{{ i18n "view-product"}}</a></div>
+      </div>
     </div>
   {{ end }}
   <!-- END URL -->
 
-  <div class="work-in-progress--product-summary">
-    <p>{{ .Params.description }}</p>
+  <!-- Description -->
+  <div class="row">
+    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+      <div class="work-in-progress--product-summary">
+        <p>{{ .Params.description }}</p>
+      </div>
+    </div>
   </div>
+  <!-- End Description -->
 
   <!-- Partner -->
-  {{ if gt (len .Params.partners) 0 }}
-    <h2>{{ i18n "partner" }}{{ if gt (len .Params.partners) 1 }}s{{end}}:</h2>
-    {{ range .Params.partners }}
-      <p><a class="partner-link" href='{{ .url }}'>{{ .name }}</a></p>
+  <div class="row">
+    {{ if gt (len .Params.partners) 0 }}
+      <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+        <div class="work-in-progress--partners-long">
+          <h5>{{ i18n "partner" }}{{ if gt (len .Params.partners) 1 }}s{{end}}:</h5>
+          {{ range .Params.partners }}
+            <p><a class="partner-link" href='{{ .url }}'>{{ .name }}</a></p>
+          {{ end }}
+        </div>
+      </div>
     {{ end }}
-  {{ end }}
   <!-- End Partner -->
 
-  <!-- In progress team -->
-  <div class="work-in-progress--team">
-    <h2>Contact:</h2>
-    {{ range .Params.contact }}
-      <p><a class="contact-link" href='mailto:{{.email}}'>{{.name}}</a></p>
-    {{ end }}
-  </div>
-  <!-- End in progress team -->
-
-  <!-- In progress -->
-  <div class="work-in-progress--links">
-    {{with .Params.links }}
-      {{ if gt (len .) 0 }}
-        <h2>{{ i18n "links" }}:</h2>
-        {{range .}}
-          <p><a class="resource-link" href="{{ .url }}">{{.name}}</a></p>
+    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+      <!-- In progress team -->
+      <div class="work-in-progress--team">
+        <h5>Contact:</h5>
+        {{ range .Params.contact }}
+          <p><a class="contact-link" href='mailto:{{.email}}'>{{.name}}</a></p>
         {{ end }}
-      {{ end }}
-    {{ end }}
+      </div>
+      <!-- End in progress team -->
+    </div>
+
+    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+      <!-- In progress -->
+      <div class="work-in-progress--links">
+        {{with .Params.links }}
+          {{ if gt (len .) 0 }}
+            <h5>{{ i18n "links" }}:</h5>
+            {{range .}}
+              <p><a class="resource-link" href="{{ .url }}">{{.name}}</a></p>
+            {{ end }}
+          {{ end }}
+        {{ end }}
+      </div>
+      <!-- End in progress -->
+    </div>
   </div>
-  <!-- End in progress -->
 </section>
 

--- a/layouts/tools-and-resources/list.html
+++ b/layouts/tools-and-resources/list.html
@@ -1,38 +1,65 @@
 <section class="section work-in-progress--product-module work-in-progress--platform-module border-{{.Params.phase}}"
          id="{{.Params.translationKey}}">
-  <h1 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
-    {{ .Params.title }}
-  </h1>
+  <!-- Product Title-->
+  <div class="row">
+    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+      <div class="title-container">
+        <div>
+          <h4 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
+            {{ .Params.title }}
+          </h4>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- End Product Title-->
 
   <!-- URL -->
   {{ with (index .Params "product-url")}}
-    <div class="service-link">
-      <a class="view-product" href='{{ . }}'>{{ i18n "view-product"}}</a>
+    <div class="row">
+      <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+        <div class="service-link">
+          <a class="view-product" href='{{ . }}'>{{ i18n "view-product"}}</a></div>
+      </div>
     </div>
   {{ end }}
   <!-- END URL -->
 
-  <div class="work-in-progress--product-summary">
-    <p>{{ .Params.description }}</p>
+  <!-- DESC -->
+  <div class="row">
+    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+      <div class="work-in-progress--product-summary">
+        <p>{{ .Params.description }}</p>
+      </div>
+    </div>
   </div>
+  <!-- End DESC -->
 
   <!-- CONTACT -->
-  <div class="work-in-progress--team">
-    <h2>Contact:</h2>
-    {{ range .Params.contact }}
-      <p><a class="contact-link" href='mailto:{{.email}}'>{{ .name }}</a></p>
-    {{ end }}
+  <div class="row">
+    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+      <div class="work-in-progress--team">
+        <h5>Contact:</h5>
+        {{ range .Params.contact }}
+        <p><a class="contact-link" href='mailto:{{.email}}'>{{ .name }}</a></p>
+        {{ end }}
+      </div>
+    </div>
   </div>
   <!-- END CONTACT -->
 
-  <div class="work-in-progress--links">
-    {{with .Params.links }}
-      {{ if gt (len .) 0 }}
-        <h2>{{ i18n "links" }}:</h2>
-        {{range .}}
-          <p><a class="resource-link" href="{{ .url }}">{{.name}}</a></p>
+  <div class="row">
+    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+      <div class="work-in-progress--links">
+        {{with .Params.links }}
+          {{ if gt (len .) 0 }}
+            <h5>{{ i18n "links" }}:</h5>
+            {{range .}}
+              <p><a class="resource-link" href="{{ .url }}">{{.name}}</a></p>
+            {{ end }}
+          {{ end }}
         {{ end }}
-      {{ end }}
-    {{ end }}
+      </div>
+    </div>
   </div>
 </section>


### PR DESCRIPTION
# Summary | Résumé

This reverts commit 0b9268ab70b91a3e1aa8bfff9afb3a1199fd2a3d.

When looking at the changes it was decided it was better to skip a
header level on the main page then to have duplicate header levels which
happened with the fix. We were unable to get the current system to take
the header level as a template parameter.

This will go back to the backlog and we'll probably need to either
duplicate the list template, or change the site so the header levels are
the same when this template gets included.

Issue #2288
