### PR TITLE
Add draft for Contributing guidelines explaining how to update CMS managed content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,24 +2,55 @@
 
 # Contributing
 
-We welcome all contributions both internal and outside of CDS!
+We welcome all contributions, both internal and outside of CDS!
+
+We welcome content changes that fix typos, spelling mistakes and grammatical errors, as well as changes that help update links and information. All content should follow [markdown syntax](https://guides.github.com/features/mastering-markdown/). 
 
 ## Contributing CMS managed content
 
-The following forms of content are managed by our CMS, Strapi:
+The following forms of content are managed by our content management system (CMS), Strapi:
 
 - Blog Posts
-- Job Posts
-- Product cards ( Partnerships, Tools, and Resources ) and associated info:
+- Job posts
+- Product cards ( Partnerships, Platform tools and Resources ) and associated info:
   - Contacts for the above
-  - Product Links
-- CDS Team Members
+  - Product links
+- CDS team members
 
 These types of content must be updated through Strapi, otherwise updates will be overwritten by subsequent Strapi builds.
 
-If you are internal to CDS, and would like to update any of the above content, please contact Victoria Chan or the website team to get set up with a Strapi account.
-If you are external to CDS, and would like to update any CMS managed content, continue to make a PR as you would normally, and request that your changes be migrated into the CMS.
+If you are internal to CDS and would like to update any of the above content, please contact Victoria Chan or the website team to get set up with a Strapi account. 
 
-# Contribution
+If you are external to CDS and would like to update any CMS managed content, please continue to make a pull request as you would normally, and request that your changes be migrated into the CMS.
 
-TBD
+## Submitting pull requests
+
+Pull requests that need review can be tagged under the `needs-review` label. After you submit a pull request, we will do our best to respond within the timeframe of 3 business days and will provide an update once your changes have been made through the CMS. 
+
+## ---------------------------------------------------------------------
+
+# Contribution 
+
+Nous accueillons toutes les contributions internes et externes au SNC!
+
+Sont bienvenues toutes modifications de contenu qui corrigent une faute de frappe, une faute d’orthographe ou une erreur grammaticale, ainsi que toutes modifications qui tiennent à jour les liens et les renseignements publiés. Tout contenu doit suivre la [syntaxe Markdown](https://guides.github.com/features/mastering-markdown/). 
+
+## Contribuer au contenu géré par système de gestion de contenu (SGC)
+Les contenus suivants sont gérés par notre système de gestion de contenu (SGC), Strapi :
+
+- Articles de blogue
+- Offres d’emploi
+- Fiches de produit (Partenariats, Outils et ressources de l’équipe des plateformes) et renseignements connexes :
+  - Coordonnées de personnes-ressources pour les éléments ci-haut
+  - Liens vers les produits
+- Membres de l’équipe du SNC
+
+Ces types de contenu doivent être mis à jour à l’aide de Strapi, sinon toute mise à jour appliquée autrement sera écrasée par Strapi dans le futur.
+
+Si vous êtes un(e) employé(e) du SNC et que vous souhaitez mettre à jour du contenu parmi la liste ci-dessus, veuillez communiquer avec Victoria Chan ou l’équipe du site Web pour qu’on vous crée un compte Strapi. 
+
+Si vous n’êtes pas employés du SNC et que vous souhaitez mettre à jour du contenu géré par le SGC, veuillez continuer à soumettre des demandes de tirage (pull request) comme à l’habitude et demandez que vos modifications soient migrées vers le SGC.
+
+## Soumettre des demandes de tirage (pull request)
+
+Pour indiquer qu’une demande de tirage (pull request) doit être approuvée, utilisez l’étiquette `needs-review`. Lorsqu’une demande de tirage (pull request) est soumise, nous faisons de notre mieux pour y répondre dans un délai de 3 jours ouvrables. Nous vous aviserons dès que vos modifications auront été apportées à l’aide du SGC. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+[La version française suit.](#contribution)
+
+# Contributing
+
+We welcome all contributions both internal and outside of CDS!
+
+## Contributing CMS managed content
+
+The following forms of content are managed by our CMS, Strapi:
+
+- Blog Posts
+- Job Posts
+- Product cards ( Partnerships, Tools, and Resources ) and associated info:
+  - Contacts for the above
+  - Product Links
+- CDS Team Members
+
+These types of content must be updated through Strapi, otherwise updates will be overwritten by subsequent Strapi builds.
+
+If you are internal to CDS, and would like to update any of the above content, please contact Victoria Chan or the website team to get set up with a Strapi account.
+If you are external to CDS, and would like to update any CMS managed content, continue to make a PR as you would normally, and request that your changes be migrated into the CMS.
+
+# Contribution
+
+TBD

--- a/README.md
+++ b/README.md
@@ -63,3 +63,5 @@ Les versions française et anglaise seront hébergées à [localhost:1314](http:
 ## Système de gestion de contenu
 
 Développé par [Strapi](https://strapi.io/). Le code d’instance Strapi utilisé par ce site Web peut être consulté à [https://github.com/cds-snc/cds-website-cms](https://github.com/cds-snc/cds-website-cms).
+
+Veuillez consulter nos [directives sur les contributions au référentiel Github](CONTRIBUTING.md) pour apprendre comment apporter des modifications au contenu géré par le SGC.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Powered by [Hugo](https://gohugo.io/), and the [Web Experience Toolkit](https://
 
 1. Clone the repository.
 
-    ```
-    git clone https://github.com/cds-snc/digital-canada-ca.git
-    ```
+   ```
+   git clone https://github.com/cds-snc/digital-canada-ca.git
+   ```
 
 2. If you do not have Hugo installed on your machine, you will need to install it. We are running on an older version of Hugo ([v0.55.6](https://github.com/gohugoio/hugo/releases/tag/v0.55.6)). You can grab the appropriate [tar file here](https://github.com/gohugoio/hugo/releases/tag/v0.55.6), making sure to select the extended version. Then, [follow these instructions for installing it](https://bwaycer.github.io/hugo_tutorial.hugo/tutorials/installing-on-mac/#from-tarball). If you run into permissions issues, [here is a handy article to help fix the permissions](https://codewithhugo.com/catalina-permission-command-line-fix/).
 
@@ -20,9 +20,9 @@ We'd love to upgrage to the newer version, however it results in some breaking c
 
 3. Serve:
 
-    ```
-    hugo server -D 
-    ```
+   ```
+   hugo server -D
+   ```
 
 The English and French versions will be hosted at [localhost:1313](http://localhost:1313) and [localhost:1314](http://localhost:1314), respectively.
 
@@ -30,7 +30,7 @@ The English and French versions will be hosted at [localhost:1313](http://localh
 
 Powered by [Strapi](https://strapi.io/). The Strapi instance for this website can be found at [https://github.com/cds-snc/cds-website-cms](https://github.com/cds-snc/cds-website-cms).
 
-
+Please visit our [contribution guidelines](CONTRIBUTING.md) to learn how to best make updates to CMS managed content.
 
 ## ---------------------------------------------------------------------
 
@@ -42,21 +42,21 @@ Les sites [numerique.canada.ca](https://numerique.canada.ca) et [digital.canada.
 
 1. Clonez le référentiel.
 
-    ```
-    git clone https://github.com/cds-snc/digital-canada-ca.git
-    ```
+   ```
+   git clone https://github.com/cds-snc/digital-canada-ca.git
+   ```
 
 2. Installez Hugo sur votre ordinateur, si ce n’est pas déjà fait.
 
-    ```
-    brew install hugo
-    ```
+   ```
+   brew install hugo
+   ```
 
 3. Exécutez le serveur local.
 
-    ```
-    hugo server -D
-    ```
+   ```
+   hugo server -D
+   ```
 
 Les versions française et anglaise seront hébergées à [localhost:1314](http://localhost:1314) et à [localhost:1313](http://localhost:1313), respectivement.
 


### PR DESCRIPTION
# Summary | Résumé

Documentation on how to update content on the website in the post Strapi world has been poor. Collabbing with @victoriachanimal to fix this!

This PR adds a CONTRIBUTING.md file, which explains which content is managed in the CMS, and how to go about updating it (since PRs alone will not 'stick' if the content is managed by Strapi).

Putting up a first draft here, while Vic is away, hopefully will finalize and send out for translation later this week!