### PR TITLE
Update references to old primary branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     working_directory: /tmp/cds-website-source
     steps:
       - checkout
-      
+
       # Load git submodules
       - run:
           name: "Load git submodules"
@@ -30,7 +30,7 @@ jobs:
       - restore_cache:
           keys:
             - cds-website-source-{{ checksum ".circle-sha" }}
-      
+
       # Build compiled sites
       - run:
           name: "Build English and French sites"
@@ -113,4 +113,4 @@ workflows:
             - test
           filters:
             branches:
-              only: master
+              only: main

--- a/.github/workflows/a11y_tracking.yaml
+++ b/.github/workflows/a11y_tracking.yaml
@@ -3,7 +3,7 @@ name: "A11y tracking"
 on:
   push:
     branches:
-      - master
+      - main
 
 defaults:
   run:

--- a/content/en/tools-and-resources/digital-reading-list.html
+++ b/content/en/tools-and-resources/digital-reading-list.html
@@ -63,7 +63,9 @@ aliases: [/liste-lecture-concernant/]
             <p>In addition to the articles above, newsletters from <a href="https://us6.campaign-archive.com/home/?u=1446581f8674f47a26b615a46&id=1d6bfa1e3c">Code for Canada</a>, <a href="https://us18.campaign-archive.com/home/?u=267242671076d81909a499704&id=ae89be3b94">Public Digital</a>, <a href="https://wearecommons.us/newsletter/">The Commons</a>, and the
                <a href="https://brookfieldinstitute.us11.list-manage.com/subscribe?u=ef9e6a170a06b2ddfd5e8ada6&id=40901e1368">The Brookfield Institute</a> are a great resource. You can also subscribe to the <a href="https://canada.us15.list-manage.com/subscribe?u=729a207773f7324e217a1d945&id=eb357181d2">CDS newsletter</a> to hear regular
                 updates on our work.</p>
-            <p>Have a suggestion to add to this page? <a href="mailto:cds-snc@tbs-sct.gc.ca">Send us an email</a> or <a href="https://github.com/cds-snc/digital-canada-ca/blob/master/content/en/tools-and-resources/digital-reading-list.html">make a pull request</a> on our GitHub repository.
+            <p>Have a suggestion to add to this page? <a
+              href="mailto:cds-snc@tbs-sct.gc.ca">Send us an email</a> or <a
+              href="https://github.com/cds-snc/digital-canada-ca/blob/main/content/en/tools-and-resources/digital-reading-list.html">make a pull request</a> on our GitHub repository.
             </p>
         </div>
     </div>

--- a/content/fr/tools-and-resources/digital-reading-list.html
+++ b/content/fr/tools-and-resources/digital-reading-list.html
@@ -45,7 +45,9 @@ url: /outils-et-ressources/liste-lecture-concernant/
 
             <p>En plus des articles ci-dessus, les infolettres de <a href="https://us6.campaign-archive.com/home/?u=1446581f8674f47a26b615a46&id=1d6bfa1e3c">Code for Canada</a>, de <a href="https://us18.campaign-archive.com/home/?u=267242671076d81909a499704&id=ae89be3b94">Public Digital</a>, de <a href="https://wearecommons.us/newsletter/">The Commons</a>, et du
                 <a href="https://brookfieldinstitute.us11.list-manage.com/subscribe?u=ef9e6a170a06b2ddfd5e8ada6&id=40901e1368">Brookfield Institute</a> sont d’excellentes ressources. Vous pouvez également vous abonner à <a href="https://canada.us15.list-manage.com/subscribe?u=729a207773f7324e217a1d945&id=5fe89f4d28">l’infolettre du Service numérique canadien</a> pour obtenir des mises à jour régulières sur notre travail.</p>
-            <p>Avez-vous une suggestion à ajouter à cette page? <a href="mailto:cds-snc@tbs-sct.gc.ca">Envoyez-nous un courriel</a> ou <a href="https://github.com/cds-snc/digital-canada-ca/blob/master/content/fr/tools-and-resources/digital-reading-list.html">faites une demande de tirage</a> (PR) dans notre dépôt GitHub.
+            <p>Avez-vous une suggestion à ajouter à cette page? <a
+              href="mailto:cds-snc@tbs-sct.gc.ca">Envoyez-nous un courriel</a>
+            ou <a href="https://github.com/cds-snc/digital-canada-ca/blob/main/content/fr/tools-and-resources/digital-reading-list.html">faites une demande de tirage</a> (PR) dans notre dépôt GitHub.
             </p>
         </div>
     </div>

--- a/layouts/roadmap/default.html
+++ b/layouts/roadmap/default.html
@@ -3,16 +3,16 @@
 <div class="roadmap-container">
 
 	<div class="roadmap-content" id="main-content">
-		
+
 		{{ .Content }}
 
 		<p class="text-right">
-			<span class="sr-only">{{ i18n "roadmap-date-modified" }}</span> 
+			<span class="sr-only">{{ i18n "roadmap-date-modified" }}</span>
 			<time datetime="{{ .Params.dateUpdated }}">
 				{{ .Params.dateUpdatedString }}
 			</time>
 			{{ if .Params.versionLabel }}
-			<a href="https://github.com/cds-snc/digital-canada-ca/blob/master/content/{{ .File.Lang }}/{{ .File.Path }}" class="version-history-link" title="{{ i18n "version-history" }}">{{ .Params.versionLabel }}</a>
+			<a href="https://github.com/cds-snc/digital-canada-ca/blob/main/content/{{ .File.Lang }}/{{ .File.Path }}" class="version-history-link" title="{{ i18n "version-history" }}">{{ .Params.versionLabel }}</a>
 			{{ end }}
 		</p>
 


### PR DESCRIPTION
# Summary | Résumé

The primary branch has been changed to `main`. This PR updates various
points in the repo which use the old branch name.

Issue #2249