### PR TITLE
fix all newsletter link

### DIFF
--- a/layouts/partials/mailing-list.html
+++ b/layouts/partials/mailing-list.html
@@ -51,9 +51,7 @@
               </div>
               <div class="row">
                 <div class="mce-privacy col-xs-12">
-                <a href="https://us15.campaign-archive.com/home/?u=729a207773f7324e217a1d945&id=eb357181d2"
-                    class="light-link wb-lbx"
-                    >{{ i18n "all-newsletter-link" }}</a>
+                <a href="https://us15.campaign-archive.com/home/?u=729a207773f7324e217a1d945&id=eb357181d2">{{ i18n "all-newsletter-link" }}</a>
                   <a href="#privacy-notice-modal"
                     aria-controls="privacy-notice-modal"
                     class="overlay-lnk light-link wb-lbx"


### PR DESCRIPTION

# Summary | Résumé
remove overlay classes from all newsletter link
This was preventing the link from properly opening, and the classes are unnecessary for styling.

---

# Test instructions | Instructions pour tester la modification

Make sure the "Read all newsletters" link on the yellow Subscribe to Newsletter box works properly when clicked.

![image](https://user-images.githubusercontent.com/6607541/123678110-e3a2af00-d813-11eb-9701-8a68263a4c41.png)

