### PR TITLE
Matching English and French translation keys for blog posts

### DIFF
--- a/content/fr/blog/posts/choisir-nos-projets.md
+++ b/content/fr/blog/posts/choisir-nos-projets.md
@@ -14,7 +14,7 @@ author: 'Wendy Luciani, partenariats'
 date: '2017-08-24 10:00:00 -0400'
 image: https://de2an9clyit2x.cloudfront.net/picking_our_projects_2017_b3fdfe5d6f.jpg
 image-alt: Affiches dans les locaux du SNC.
-translationKey: picking-our-projects/
+translationKey: picking-our-projects
 thumb: https://de2an9clyit2x.cloudfront.net/small_picking_our_projects_2017_b3fdfe5d6f.jpg
 ---
 J’ai grandi sur une ferme. Mon enfance a été marquée par la sensation du gravier sous mes pieds, la terre sur mes mains et le bonheur de choisir des fruits et des légumes directement du champ. J’aimerais pouvoir vous dire que choisir des projets est semblable, mais je n’ai toujours pas vu de gravier, de terre, de fruits ou de légumes pendant une discussion portant sur un partenariat (points bonis si vous y arrivez!)

--- a/content/fr/blog/posts/concevoir-pour-le-canada.md
+++ b/content/fr/blog/posts/concevoir-pour-le-canada.md
@@ -8,7 +8,7 @@ author: 'Chris Govias, conception'
 date: '2017-09-21 09:00:00 -0400'
 image: https://de2an9clyit2x.cloudfront.net/blog_designing_for_canada_2017_a6cf251b7c.jpg
 image-alt: 'Chris Govias, Design'
-translationKey: designing-for-canada/
+translationKey: designing-for-canada
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_designing_for_canada_2017_a6cf251b7c.jpg
 ---
 Après un bref congé sabbatique et une décennie passée au Royaume-Uni, je suis fier d’annoncer que je serai le premier chef de la conception au Service numérique canadien (SNC), une nouvelle initiative du gouvernement du Canada.

--- a/content/fr/blog/posts/lancement-d’un-service-alpha.md
+++ b/content/fr/blog/posts/lancement-d’un-service-alpha.md
@@ -14,7 +14,7 @@ image: https://de2an9clyit2x.cloudfront.net/get_updates_c19_phone_fr_963f308dbc.
 image-alt: >-
   Une personne en train de s’abonner au service «Obtenir les nouvelles sur la
   COVID-19» sur son téléphone mobile.
-translationKey: get-updates-blog-2
+translationKey: launch-of-the-canadian-digital-service
 thumb: https://de2an9clyit2x.cloudfront.net/small_get_updates_c19_phone_fr_963f308dbc.jpg
 ---
 *Marcel Saulnier et Jennifer Hollington sont tous deux sous-ministres adjoints à Santé Canada. M. Saulnier a supervisé la conception et le lancement du service de notification par courriel « [Obtenir les nouvelles sur la COVID-19](https://www.canada.ca/covid19nouvelles) » dans le cadre de sa participation au groupe de travail sur la COVID-19. L’équipe des communications de Mme Hollington a repris le service alors que celui-ci s’inscrit dans la fonction de communication de Santé Canada.*

--- a/content/fr/blog/posts/parler-numerique-en-francais.md
+++ b/content/fr/blog/posts/parler-numerique-en-francais.md
@@ -12,7 +12,7 @@ description: >-
 author: 'Annie Leblond, communications'
 image: https://de2an9clyit2x.cloudfront.net/blog_discussing_digital_in_french_2017_0d1d34a4de.jpg
 image-alt: Clavier d’ordinateur avec une touche illustrant le drapeau de la France.
-translationKey: discussing-digital-in-french/
+translationKey: discussing-digital-in-french
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_discussing_digital_in_french_2017_0d1d34a4de.jpg
 ---
 Demain, le 30 septembre, ce sera la Journée mondiale de la traduction. Pour moi, parler du numérique en français, c’est un défi&nbsp;: Nommer correctement les nouveautés technologiques et *surtout* – surtout – ne pas perdre de vue que nous nous adressons à «&nbsp;du vrai monde&nbsp;». **Penser à l’utilisateur d’abord, le placer au cœur de notre travail, c’est aussi dans les mots que nous choisissons**.

--- a/content/fr/blog/posts/pourquoi-canada-a-besoin-service-numerique.md
+++ b/content/fr/blog/posts/pourquoi-canada-a-besoin-service-numerique.md
@@ -13,7 +13,7 @@ image: https://de2an9clyit2x.cloudfront.net/why_canada_needs_a_digital_service_2
 image-alt: >-
   Ryan Androsoff, Lena Trudeau, Anatole Papadopoulos, Olivia Neal et Pascale
   Elvas
-translationKey: why-canada-needs-a-digital-service/
+translationKey: why-canada-needs-a-digital-service
 thumb: https://de2an9clyit2x.cloudfront.net/small_why_canada_needs_a_digital_service_2017_83f1ff7d59.jpg
 ---
 Pendant plusieurs mois, j’ai travaillé en coulisses pour défendre cette cause qu’est le Service numérique canadien (SNC). J’ai beaucoup réfléchi à la raison d’être d’une organisation dédiée aux services numériques au Canada, ainsi qu’au potentiel de cette organisation de changer la façon de concevoir les services gouvernementaux.

--- a/content/fr/blog/posts/recherche-dirigeant-principal-du-service-numerique-canadien.md
+++ b/content/fr/blog/posts/recherche-dirigeant-principal-du-service-numerique-canadien.md
@@ -12,7 +12,7 @@ author: 'Yaprak Baltacıoğlu, Secrétaire du Conseil du Trésor'
 date: '2017-09-12 09:00:00 -0400'
 image: https://de2an9clyit2x.cloudfront.net/wanted_ceo_cds_2017_992dcbf98e.jpg
 image-alt: 'Yaprak Baltacıoğlu, Secrétaire du Conseil du Trésor'
-translationKey: wanted-ceo-cds/
+translationKey: wanted-ceo-cds
 thumb: https://de2an9clyit2x.cloudfront.net/small_wanted_ceo_cds_2017_992dcbf98e.jpg
 ---
  Les services fournis par notre gouvernement jouent un rôle important dans la vie de millions de gens.

--- a/content/fr/blog/posts/retrospective-sur-lapi-denerguide.md
+++ b/content/fr/blog/posts/retrospective-sur-lapi-denerguide.md
@@ -13,7 +13,7 @@ image-alt: >-
   Sept membres de l’équipe sont assis autour d’une table. Ils regardent deux
   personnes debouts devant eux qui regroupent des papiers autocollants («
   post-it ») sur le tableau blanc.
-translationKey: retrospective-on-EnerGuide-api
+translationKey: retrospective-on-energuide-api
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_energuide_retro_f4780d2e1d.jpg
 ---
 


### PR DESCRIPTION
English and French translation keys don't match for some of our early blog posts (eg. https://digital.canada.ca/2017/08/03/why-canada-needs-a-digital-service/), or there is an extra "/" at the end of some French translation keys.

This PR matches the translation keys for several of our past blog posts so that the language toggle appears for both languages. 