### PR TITLE
fix: landmark issues found by axe

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -286,3 +286,7 @@ who-is-on-the-team:
   other: "Who is on the team"
 options-below:
   other: "using one of the options below"
+skip-links:
+  other: "Skip Navigation Links"
+menu:
+  other: "Main Site Menu"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -290,4 +290,7 @@ who-is-on-the-team:
   other: "Qui est dans l'équipe"
 options-below:
   other: "using one of the options below"
-
+skip-links:
+  other: "Liens saut de navigation"
+menu:
+  other: "Menu principal du site"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -73,7 +73,7 @@
       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager -->
 
-    <nav>
+    <nav aria-label="{{ i18n "skip-links" }}">
       <ul id="wb-tphp">
         <li class="wb-slc">
           <a class="wb-sl" href="#wb-cont">{{ i18n "skip-to-content" }}</a>
@@ -114,10 +114,10 @@
         </section>
         {{ end }}
       </section>
+      {{ block "index" . }}
+      {{end}}
     </main>
 
-    {{ block "index" . }}
-    {{end}}
 
     {{ block "footer" . }}
     {{ partial "social-links.html" . }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,5 +1,5 @@
 <nav role="navigation" id="wb-sm" data-trgt="mb-pnl"
-     class="cds-menu" typeof="SiteNavigationElement">
+     class="cds-menu" typeof="SiteNavigationElement" aria-label="{{ i18n "menu"}}">
   <div class="container topbar" id="site--topbar">
     <div class="row">
       <div class="col-xs-4 col-sm-3">


### PR DESCRIPTION
- Provides unique aria-labels to both Nav landmarks on the page this is related to success criteria 1.3.1 https://www.w3.org/TR/2008/REC-WCAG20-20081211/#content-structure-separation-programmatic
- Moves the index block into the main landmark so that we don't have content not inside a landmark.

We may need some review to see if the above is okay, I'm mainly thinking of moving the index block into the main landmark we may want to add a second main landmark and provide them with unique names.

This should have no real changes to the rendering of the page and should only affect those using screen readers. I will need a french speaker/content designer to review the new text to see if it makes sense as I just deepl and some google searches for translating.


This changes the number of a11y issues on the main page from 14 to 6 according to Axe.

