### PR TITLE
feat: add an aria-label to "View this product"

### DIFF
--- a/layouts/products/list.html
+++ b/layouts/products/list.html
@@ -19,7 +19,7 @@
   {{ with (index .Params "product-url")}}
     <div class="row">
       <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-        <div class="service-link"><a class="view-product" href='{{ . }}'>{{ i18n "view-product"}}</a></div>
+        <div class="service-link"><a class="view-product" aria-label="{{ $.Params.title }}" href='{{ . }}'>{{ i18n "view-product"}}</a></div>
       </div>
     </div>
   {{ end }}


### PR DESCRIPTION
Adds an aria label to the View this product links that lets screen
readers know what page they will go to.

To simplify translation I'm simply using the title of the card so we
don't have to worry about handling products that start with vowels and
articles if we want to use View the.

This may need some content design thinking to determine the best text we
want to use for those folks viewing the site with screenreaders.

Closes #2415
