### PR TITLE
fix: missed nav labels

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -290,3 +290,5 @@ skip-links:
   other: "Skip Navigation Links"
 menu:
   other: "Main Site Menu"
+footer-links:
+  other: "Footer links"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -294,3 +294,5 @@ skip-links:
   other: "Liens saut de navigation"
 menu:
   other: "Menu principal du site"
+footer-links:
+  other: "Liens en bas de page"

--- a/layouts/a11y/default.html
+++ b/layouts/a11y/default.html
@@ -47,7 +47,7 @@
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer1'?'&l='+l:'';j.async=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer1','GTM-TLGQ9K');</script>
     <!-- End Google Tag Manager -->
 
-    <nav>
+    <nav aria-label="{{ i18n "skip-links" }}">
       <ul id="wb-tphp">
         <li class="wb-slc">
           <a class="wb-sl" href="#wb-cont">{{ i18n "skip-to-content" }}</a>

--- a/layouts/engagement/default.html
+++ b/layouts/engagement/default.html
@@ -46,7 +46,8 @@
     })(window, document, 'script', 'dataLayer1', 'GTM-TLGQ9K');
 </script>
 <!-- End Google Tag Manager -->
-<nav>
+
+<nav aria-label="{{ i18n "skip-links" }}">
     <ul id="wb-tphp">
         <li class="wb-slc">
             <a class="wb-sl" href="#wb-cont">{{ i18n "skip-to-content" }}</a>
@@ -86,8 +87,8 @@
     <div class="brand">
         <div class="container">
             <div class="row">
-                <nav class="col-md-10 ftr-urlt-lnk">
-                    <h2 class="wb-inv">{{ i18n "about-this-site" }}</h2>
+                <nav class="col-md-10 ftr-urlt-lnk" aria-labelledby="about-footer-id">
+                    <h2 class="wb-inv" id="about-footer-id">{{ i18n "about-this-site" }}</h2>
 
                     {{ partial "footer-links.html" }}
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,7 @@
                 class="logo"></object>
       </div>
       <nav role="navigation"
-           class="col-xs-12 col-sm-8 col-sm-pull-4 goc-footer--links">
+           class="col-xs-12 col-sm-8 col-sm-pull-4 goc-footer--links" aria-label="{{ i18n "footer-links" }}">
         {{ partial "footer-links.html" }}
       </nav>
     </div>

--- a/layouts/roadmap/baseof.html
+++ b/layouts/roadmap/baseof.html
@@ -50,7 +50,7 @@
     })(window, document, 'script', 'dataLayer1', 'GTM-TLGQ9K');
 </script>
 <!-- End Google Tag Manager -->
-<nav>
+<nav aria-label="{{ i18n "skip-links" }}">
     <ul id="wb-tphp">
         <li class="wb-slc">
             <a class="wb-sl" href="#wb-cont">{{ i18n "skip-to-content" }}</a>
@@ -118,8 +118,8 @@
     <div class="brand">
         <div class="container">
             <div class="row">
-                <nav class="col-md-10 ftr-urlt-lnk">
-                    <h2 class="wb-inv">{{ i18n "about-this-site" }}</h2>
+                <nav class="col-md-10 ftr-urlt-lnk" aria-labelledby="about-footer-id">
+                    <h2 class="wb-inv" id="about-footer-id">{{ i18n "about-this-site" }}</h2>
 
                     {{ partial "footer-links.html" }}
 


### PR DESCRIPTION
- Adding labels to the `nav` landmark in the footers, if there is an H2
  I added an aria-labelledby and if there wasn't I added the text
  aria-label the text for that label should be reviewed by a content
  designer to make sure it makes sense but can probably be done later as
  footer links is generic enough it should work for now.

- Added labels to the skip links in the a11y handbook, the engagement
  page and the roadmap.
