### PR TITLE
fix: adds a label to an svg object

### DIFF
--- a/layouts/engagement/default.html
+++ b/layouts/engagement/default.html
@@ -73,7 +73,7 @@
         <div class="row">
             <div class="brand col-xs-8 col-sm-9 col-md-6">
                 <a href="https://www.canada.ca/{{ .Site.Language }}.html">
-                    <object type="image/svg+xml" tabindex="-1" data="/img/sig-blk-{{ .Site.Language }}.svg">{{ i18n "goc" }}</object><span class="wb-inv"> {{ i18n "goc" }}</span></a>
+                    <object type="image/svg+xml" tabindex="-1" data="/img/sig-blk-{{ .Site.Language }}.svg" aria-label="{{ i18n "goc-symbol" }}">{{ i18n "goc" }}</object><span class="wb-inv"> {{ i18n "goc" }}</span></a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This fixes a serious a11y issue. The fix was to copy the aria label from
the fip.html page. I didn't replace the FIP in the engagement html
because I didn't know why it wasn't using it in the first place and
wanted to make sure the change was minimal.
