### PR TITLE
fix: remove redundant role on form

### DIFF
--- a/layouts/section/job-posting.en.html
+++ b/layouts/section/job-posting.en.html
@@ -22,7 +22,6 @@
         <form
           enctype="multipart/form-data"
           class="text-left"
-          role="form"
           id="contactForm"
         >
           <!-- jobId -->

--- a/layouts/section/job-posting.fr.html
+++ b/layouts/section/job-posting.fr.html
@@ -22,7 +22,6 @@
         <form
           enctype="multipart/form-data"
           class="text-left"
-          role="form"
           id="contactForm"
         >
           <!-- jobId -->


### PR DESCRIPTION
This is just a deque best practice fix.

This fixes the aria-allowed-role issue found in grouped validations (I'd
link to it but I can't :sad:)

This role is redundant as the element is already a role and so does not
need another role attached to it.

MDN information on Role = Form

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Form_Role

Deque University Issue
https://dequeuniversity.com/rules/axe/4.1/aria-allowed-role
