### PR TITLE
Update guide-to-interviewing headers.

### DIFF
--- a/content/en/tools-and-resources/guide-interviewing.html
+++ b/content/en/tools-and-resources/guide-interviewing.html
@@ -15,7 +15,7 @@ aliases: [/guide-entrevue/]
 
             <h2><strong>Key elements of interviewing</strong></h2>
 
-            <h4>1. Ask productive questions.</h4>
+            <h3>1. Ask productive questions.</h3>
                 <p><a href="https://portigal.com/seventeen-types-of-interviewing-questions/">Steve Portigal offers</a> the following palette of useful questions:</p>
                 <ul>
                     <li><strong>Ask about sequence.</strong> “Describe a typical workday. What do you do when you first sit down at your station? - Then, what do you do next?”</li>
@@ -26,9 +26,9 @@ aliases: [/guide-entrevue/]
                     <li><strong>Ask about organizational structure.</strong> “Who does that department report to?”</li>
                 </ul>
 
-            <h4>Questions to probe on what's unsaid</h4>
+            <h3>Questions to probe on what's unsaid</h3>
                 <ul>
-                    <li><strong>Ask for clarification.</strong> “When you refer to “that” you are talking about the newest server, right?”</li>  
+                    <li><strong>Ask for clarification.</strong> “When you refer to “that” you are talking about the newest server, right?”</li>
                     <li><strong>Ask about code words/native language.</strong> “Why do you call it the ‘Batcave?’”</li>
                     <li><strong>Ask about emotional cues.</strong> “Why do you laugh when you mention ‘Best Buy?’”</li>
                     <li><strong>Ask why.</strong> “I’ve tried to get my boss to adopt this format, but she just won’t do it-” “Why do you think she hasn’t?”</li>
@@ -38,7 +38,7 @@ aliases: [/guide-entrevue/]
                     <li><strong>Teach another.</strong> “If you had to ask your son to operate your system, how would you explain it to him?”</li>
                 </ul>
 
-            <h4>2. Listen to what people say (the “rapport engine”).</h4>
+            <h3>2. Listen to what people say (the “rapport engine”).</h3>
                 <ul>
                     <li>Ask your question and then stop.</li>
                     <li>Maintain eye contact and open body language.</li>
@@ -51,7 +51,7 @@ aliases: [/guide-entrevue/]
                     <li>Avoiding interrupting. Let there be a little bit of silence.</li>
                 </ul>
 
-            <h4>3. Manage the flow.</h4>
+            <h3>3. Manage the flow.</h3>
                 <ul>
                     <li>Progress between phases:</li>
                     <li>Warming up</li>
@@ -66,8 +66,8 @@ aliases: [/guide-entrevue/]
                     <li>Give people an out if they get uncomfortable.</li>
                     <li>Give people an opportunity to ask their own questions as well. Those questions can be revealing.</li>
                 </ul>
-            
-            <h4>4. Don't only ask questions.</h4>
+
+            <h3>4. Don't only ask questions.</h3>
                 <p>Instead, ask people to:</p>
                 <ul>
                     <li>Complete tasks.</li>
@@ -77,7 +77,7 @@ aliases: [/guide-entrevue/]
                     <li>If you can watch them complete a task.</li>
                 </ul>
 
-            <h4>5. Look for patterns, not outliers</h4>
+            <h3>5. Look for patterns, not outliers</h3>
                 <ul>
                     <li>Use as close to verbatim notes as you can.</li>
                     <li>Focus on what you heard most frequently, not what was most interesting.</li>
@@ -87,16 +87,16 @@ aliases: [/guide-entrevue/]
                 </ul>
 
             <hr>
-            
+
             <h2><strong>Resources</strong></h2>
-            <h4>From others</h4>
+            <h3>From others</h3>
             <ul>
                 <li><a href="https://18f.gsa.gov/2016/06/20/build-empathy-with-stakeholder-interviews-part-1-preparation/">"Building empathy with stakeholder interviews"</a> from 18F</li>
                 <li><a href="https://18f.gsa.gov/2016/02/09/tips-for-capturing-the-best-data-from-user-interviews/">"Tips for capturing the best data from interviews"</a> from 18F</li>
                 <li>Portigal, S. (2013). <strong>Interviewing users: how to uncover compelling insights.</strong> Rosenfeld Media.</li>
             </ul>
 
-            <h4>From CDS</h4>
+            <h3>From CDS</h3>
                 <ul>
                     <li><a href="https://docs.google.com/document/d/10yAV4DzfJfwwg9-9JirBguo3eMxuZPw6bigbfSDUqhQ/edit?usp=drive_web&ouid=115428102159383580616">"Five keys to interviewing"</a> research community meeting</li>
                 </ul>

--- a/content/fr/tools-and-resources/guide-interviewing.html
+++ b/content/fr/tools-and-resources/guide-interviewing.html
@@ -16,7 +16,7 @@ url: /outils-et-ressources/guide-entrevue/
 
             <h2><strong>Éléments clés des tests d’utilisabilité</strong></h2>
 
-            <h4>1. Poser des questions efficaces.</h4>
+            <h3>1. Poser des questions efficaces.</h3>
                 <p><a href="https://portigal.com/seventeen-types-of-interviewing-questions/">Steve Portigal propose</a> la palette de questions utiles qui suit.</p>
                 <ul>
                     <li><strong>Des questions relatives à une séquence</strong>: « Décrivez une journée typique de travail. Que faites-vous lorsque vous vous asseyez pour la première fois à votre poste? Que faites-vous ensuite? » </li>
@@ -27,9 +27,9 @@ url: /outils-et-ressources/guide-entrevue/
                     <li><strong>La structure organisationnelle</strong>: « À qui le ministère rend-il des comptes? »</li>
                 </ul>
 
-            <h4>Questions pour examiner les non-dits</h4>
+            <h3>Questions pour examiner les non-dits</h3>
                 <ul>
-                    <li><strong>Demander des précisions</strong>: : « Quand vous dites “cela”, vous parlez du serveur le plus récent, n’est-ce pas? »</li>  
+                    <li><strong>Demander des précisions</strong>: : « Quand vous dites “cela”, vous parlez du serveur le plus récent, n’est-ce pas? »</li>
                     <li><strong>Questions sur le langage codé ou la langue maternelle</strong>: « Pourquoi l’appelez-vous la “Batcave”? »</li>
                     <li><strong>Poser des questions à propos des signaux affectifs</strong>: « Pourquoi riez-vous lorsque vous mentionnez “Best Buy”? »</li>
                     <li><strong>Chercher à savoir pourquoi</strong>: « J’ai essayé de convaincre ma patronne d’adopter ce format, mais elle ne veut pas. » « Pourquoi pensez-vous qu’elle ne l’adopte pas? »</li>
@@ -39,7 +39,7 @@ url: /outils-et-ressources/guide-entrevue/
                     <li><strong>Enseigner à une autre personne</strong>: « Si vous deviez demander à votre fils d’exploiter votre système, comment lui en expliqueriez-vous le fonctionnement? »</li>
                 </ul>
 
-            <h4>2. Écouter les personnes (le « moteur des bonnes relations »).</h4>
+            <h3>2. Écouter les personnes (le « moteur des bonnes relations »).</h3>
                 <ul>
                     <li>Posez votre question, puis ne dites plus rien.</li>
                     <li>Gardez le contact visuel et assurez-vous de maintenir un langage corporel ouvert.</li>
@@ -52,7 +52,7 @@ url: /outils-et-ressources/guide-entrevue/
                     <li>Évitez d’interrompre le participant. Laissez un peu de place au silence.</li>
                 </ul>
 
-            <h4>3. Gérer le flot.</h4>
+            <h3>3. Gérer le flot.</h3>
                 <ul>
                     <li>Établissez une progression entre les phases:</li>
                     <li>Échauffement;</li>
@@ -67,8 +67,8 @@ url: /outils-et-ressources/guide-entrevue/
                     <li>Offrez une sortie aux personnes si elles deviennent mal à l’aise.</li>
                     <li>Laissez aux personnes l’occasion de poser leurs propres questions également. Celles-ci peuvent être révélatrices.</li>
                 </ul>
-            
-            <h4>4. Ne pas uniquement poser des questions.</h4>
+
+            <h3>4. Ne pas uniquement poser des questions.</h3>
                 <p>Demandez par exemple aux personnes de:</p>
                 <ul>
                     <li>Réaliser des tâches;</li>
@@ -78,7 +78,7 @@ url: /outils-et-ressources/guide-entrevue/
                     <li>Si vous pouvez, observez-les pendant qu’ils réalisent une tâche.</li>
                 </ul>
 
-            <h4>5. Chercher des tendances, et non des anomalies.</h4>
+            <h3>5. Chercher des tendances, et non des anomalies.</h3>
                 <ul>
                     <li>Utilisez des notes verbatim autant que vous pouvez.</li>
                     <li>Concentrez-vous sur ce que vous avez entendu le plus souvent, et non sur ce qui était le plus intéressant.</li>
@@ -86,18 +86,18 @@ url: /outils-et-ressources/guide-entrevue/
                     <li>Tirez des conclusions, puis faites à nouveau une analyse.</li>
                     <li>Ne faites pas l’analyse tout seul.</li>
                 </ul>
-            
+
             <hr>
-            
+
             <h2><strong>Ressources</strong></h2>
-            <h4>En provenance de sources externes</h4>
+            <h3>En provenance de sources externes</h3>
             <ul>
                 <li><a href="https://18f.gsa.gov/2016/06/20/build-empathy-with-stakeholder-interviews-part-1-preparation/">Instaurer l’empathie à l’aide d’entrevues avec les parties prenantes</a> de 18F (page en anglais seulement)</li>
                 <li><a href="https://18f.gsa.gov/2016/02/09/tips-for-capturing-the-best-data-from-user-interviews/">Conseils pour recueillir les meilleures données lors d’entrevues</a> de 18F (page en anglais seulement)</li>
                 <li>Portigal, S. (2013). <strong>Interviewing users: how to uncover compelling insights.</strong> Rosenfeld Media.</li>
             </ul>
 
-            <h4>En provenance du SNC</h4>
+            <h3>En provenance du SNC</h3>
                 <ul>
                     <li>Réunion de la communauté de recherche <a href="https://docs.google.com/document/d/10yAV4DzfJfwwg9-9JirBguo3eMxuZPw6bigbfSDUqhQ/edit?usp=drive_web&ouid=115428102159383580616">« Cinq éléments clés de l’entrevue »</a> (document en anglais seulement)</li>
                 </ul>


### PR DESCRIPTION
# Summary | Résumé

This PR changes the `h4` headers on the guide-to-interviewing pages to
`h3`s in order to make them sequential.

This fixes up the heading-order accessibility violation [1].

[1]: https://a11y-tools-query.herokuapp.com/violations/cds-snc%2Fdigital-canada-ca/a71ef9fda80a0b17a723c306bfe8f7776c9e757f#violation6