### PR TITLE
Fixup heading order on evaluation framework pages.

### DIFF
--- a/content/en/tools-and-resources/evaluation-framework.html
+++ b/content/en/tools-and-resources/evaluation-framework.html
@@ -9,7 +9,7 @@ aliases: [/cadre-devaluation/]
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-xs-12">
             <h2><strong>Principles</strong></h2>
-            <h4>Here are some things that CDS believes about evaluation:</h4>
+            <h3>Here are some things that CDS believes about evaluation:</h3>
             <ul>
                 <li>Every delivery is subject to evaluation. Evaluation is a constant in the product delivery lifecycle;
                     it takes place in every story, sprint and every phase.</li>
@@ -28,7 +28,7 @@ aliases: [/cadre-devaluation/]
             <hr>
 
             <h2><strong>Categories of evaluation metrics</strong></h2>
-            <h4>CDS collects qualitative and quantitative metrics in 4 categories:</h4>
+            <h3>CDS collects qualitative and quantitative metrics in 4 categories:</h3>
             <ol>
                 <li><strong>Delivery</strong><br>The wellbeing, functioning and productivity of a team </li>
                 <li><strong>Partner capacity</strong><br>Partners ability to work with new principles, technologies and
@@ -40,7 +40,7 @@ aliases: [/cadre-devaluation/]
             <hr>
 
             <h2><strong>Evaluation in the delivery phases</strong></h2>
-            <h4>Evaluation metrics and reporting increases in precision and frequency at each phase:</h4>
+            <h3>Evaluation metrics and reporting increases in precision and frequency at each phase:</h3>
             <ol>
                 <li><strong>Discover</strong><br>Exploring what the metrics should be, how to get them based on
                     research, and existing baseline information about user needs</li>
@@ -52,7 +52,7 @@ aliases: [/cadre-devaluation/]
             </ol>
             <hr>
 
-            <h4>Examples of evaluation metrics</h4>
+            <h3>Examples of evaluation metrics</h3>
 
             <p>These are some examples of measurements that could be collected during each phase for each metric
                 category: </p>
@@ -276,7 +276,7 @@ aliases: [/cadre-devaluation/]
             <hr>
 
             <h2><strong>Responsibilities for evaluation</strong></h2>
-            <h4>Here are the typical responsibilities on a delivery team for evaluation:</h4>
+            <h3>Here are the typical responsibilities on a delivery team for evaluation:</h3>
             <ul>
                 <li><strong>Design</strong><br>Joining in with setting, capturing and analysing metrics; acting on the
                     evaluation to make design choices</li>

--- a/content/fr/tools-and-resources/evaluation-framework.html
+++ b/content/fr/tools-and-resources/evaluation-framework.html
@@ -10,7 +10,7 @@ url: /outils-et-ressources/cadre-devaluation/
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-xs-12">
             <h2><strong>Principes</strong></h2>
-            <h4>Voici quelques préceptes auxquels croit le SNC en matière d’évaluation.</h4>
+            <h3>Voici quelques préceptes auxquels croit le SNC en matière d’évaluation.</h3>
             <ul>
                 <li>Toute prestation fait l’objet d’une évaluation. L’évaluation est une constante du cycle de vie de livraison des produits. Elle est réalisée pour chaque récit utilisateur, chaque sprint et chaque phase.</li>
                 <li>Nos évaluations servent à prendre des décisions, à comprendre nos progrès et à démontrer notre rendement du capital investi.</li>
@@ -23,7 +23,7 @@ url: /outils-et-ressources/cadre-devaluation/
             <hr>
 
             <h2><strong>Catégories de paramètres d’évaluation</strong></h2>
-            <h4>Le SNC recueille des mesures qualitatives et quantitatives dans quatre catégories.</h4>
+            <h3>Le SNC recueille des mesures qualitatives et quantitatives dans quatre catégories.</h3>
             <ol>
                 <li><strong>Prestation</strong><br>Bien-être, fonctionnement et productivité d’une équipe.</li>
                 <li><strong>Capacité des partenaires</strong><br>Capacité des partenaires à travailler avec de nouveaux principes, technologies et techniques.</li>
@@ -33,7 +33,7 @@ url: /outils-et-ressources/cadre-devaluation/
             <hr>
 
             <h2><strong>Évaluation aux étapes de prestation</strong></h2>
-            <h4>Les paramètres et les rapports d’évaluation augmentent en précision et en fréquence à chaque phase.</h4>
+            <h3>Les paramètres et les rapports d’évaluation augmentent en précision et en fréquence à chaque phase.</h3>
             <ol>
                 <li><strong>Découverte </strong><br>Analyse de ce que devraient être les paramètres, de la façon de les obtenir en se fondant sur la recherche, et des renseignements de base disponibles à propos des besoins des utilisateurs.</li>
                 <li><strong>Alpha</strong><br>Tests et suivi des paramètres au moyen de prototypes.</li>
@@ -43,7 +43,7 @@ url: /outils-et-ressources/cadre-devaluation/
             </ol>
             <hr>
 
-            <h4>Exemples de paramètres d’évaluation</h4>
+            <h3>Exemples de paramètres d’évaluation</h3>
 
             <p>Voici des exemples de mesures qui pourraient être recueillies au cours de chaque phase pour chaque catégorie de paramètre.</p>
 
@@ -54,7 +54,7 @@ url: /outils-et-ressources/cadre-devaluation/
                         <th colspan="2">Découverte</th>
                     </tr>
                     <tr>
-                        <td>Prestation - <br>Information permettant de comprendre dans quelle mesure nous utilisons les ressources dans la découverte. 
+                        <td>Prestation - <br>Information permettant de comprendre dans quelle mesure nous utilisons les ressources dans la découverte.
                         </td>
                         <td>
                             <ul>
@@ -252,7 +252,7 @@ url: /outils-et-ressources/cadre-devaluation/
             <hr>
 
             <h2><strong>Responsabilités de l’évaluation</strong></h2>
-            <h4>Voici les responsabilités généralement attribuées à une équipe de prestation pour une évaluation.</h4>
+            <h3>Voici les responsabilités généralement attribuées à une équipe de prestation pour une évaluation.</h3>
             <ul>
                 <li><strong>Conception</strong><br>Participer à la définition, à la saisie et à l’analyse des paramètres; donner suite à l’évaluation pour décider des choix de conception.</li>
                 <li><strong>Développement</strong><br>Participer à la définition, à la saisie et à l’analyse des paramètres; extraire les données générées par l’infrastructure des applications; donner suite à l’évaluation pour décider des choix techniques.


### PR DESCRIPTION
# Summary | Résumé

This PR changes the `h4` headers to `h3` headers on the valuation
framework to make them correctly increase in order.

This fixes the `heading-order` accessibility violation [1].

[1]: https://a11y-tools-query.herokuapp.com/violations/cds-snc%2Fdigital-canada-ca/a71ef9fda80a0b17a723c306bfe8f7776c9e757f#violation9