### PR TITLE
Fixup heading order in guide to usability testing

### DIFF
--- a/content/en/tools-and-resources/guide-usability-testing.html
+++ b/content/en/tools-and-resources/guide-usability-testing.html
@@ -9,12 +9,12 @@ aliases: [/guide-tests-d-utilisabilité/]
         <div class="col-sm-10 col-sm-offset-1 col-xs-12">
             <h2><strong>What is usability testing?</strong></h2>
 
-            <p>Usability testing is asking people to complete tasks and observing what happens.</p>           
-            
+            <p>Usability testing is asking people to complete tasks and observing what happens.</p>
+
             <hr>
 
             <h2><strong>Key elements of usability testing</strong></h2>
-    
+
             <ul>
                 <li><strong>Make a plan.</strong> Write down the purpose, participants and tasks before your start. <a href="https://www.userfocus.co.uk/pdf/usabilitydashboard.pdf">Sample one page usability testing plan.</a></li>
                 <li><strong>Recruit enough people.</strong> Don’t test with one or two people and call it done. Use at least five different people of different backgrounds. <a href="https://www.uxmatters.com/mt/archives/2016/01/how-to-determine-the-right-number-of-participants-for-usability-studies.php">More thoughts on how many people to include.</a></li>
@@ -22,11 +22,11 @@ aliases: [/guide-tests-d-utilisabilité/]
                 <li><strong>While facilitating tests, be quiet.</strong> Ask participants to complete a task and then be silent. Don’t coach them or react to what they do. Focus on observing what’s easy and hard.<a href="http://sensible.com/downloads/things-a-therapist-would-say.pdf"> Tips on what to say when people ask you questions.</a></li>
                 <li><strong>Look for patterns across participants.</strong> Don’t start making changes based on one participant. Fix what several people struggle with. Two possible tools for doing so:<a href="https://www.smashingmagazine.com/2013/04/rainbow-spreadsheet-collaborative-ux-research-tool/">the rainbow spreadsheet</a> and the <a href="http://usabilityworks.com/consensus-on-observations-in-real-time-keeping-a-rolling-list-of-issues/">rolling issues list.</a></li>
             </ul>
-           
+
             <hr>
-            
+
             <h2><strong>Resources</strong></h2>
-            <h4>From others</h4>
+            <h3>From others</h3>
 
             <ul>
                 <li><a href="https://18f.gsa.gov/2018/11/20/introduction-to-remote-moderated-usability-testing-part-2-how/">"How to conduct usability testing"</a> from 18F</li>
@@ -41,12 +41,12 @@ aliases: [/guide-tests-d-utilisabilité/]
                 <li><a href="http://usabilityworks.com/consensus-on-observations-in-real-time-keeping-a-rolling-list-of-issues/">"Rolling issues list for analyzing testing"</a> from Dana Chisnell</li>
             </ul>
 
-            <h4>From CDS</h4>
+            <h3>From CDS</h3>
             <ul>
                 <li>Example: <a href="https://docs.google.com/document/d/1GW9GhvWqLDscLOb_CP8y0pGmW_iZ8MaSnELb_5w4hd0/edit">Usability testing plans from the VAC project</a></li>
                 <li>Example: <a href="https://docs.google.com/presentation/d/1V_fhCoBXGRApBt3AI8qg4PFaRGXyDUkQmQ2YNjKScXI/edit#slide=id.g36be40e022_0_10">Usability testing plans for an IRCC sprint</a></li>
                 <li>Example: <a href="https://docs.google.com/presentation/d/1L6r6fBTVVUiuaBWNwjv0LWAfiYHMYyGuR2lepad24Mo/edit?usp=drive_web&ouid=115428102159383580616">Community presentation on lightweight usability testing</a></li>
             </ul>
         </div>
-    </div>	
+    </div>
     </section>

--- a/content/fr/tools-and-resources/guide-usability-testing.html
+++ b/content/fr/tools-and-resources/guide-usability-testing.html
@@ -14,7 +14,7 @@ url: /outils-et-ressources/guide-tests-d-utilisabilite/
                 se passe.</p>
 
             <h2><strong>Éléments clés des tests d’utilisabilité</strong></h2>
-            
+
             <hr>
 
             <ul>
@@ -32,7 +32,7 @@ url: /outils-et-ressources/guide-tests-d-utilisabilite/
             <hr>
 
             <h2><strong>Ressources</strong></h2>
-            <h4>En provenance de sources externes</h4>
+            <h3>En provenance de sources externes</h3>
 
             <ul>
                 <li><a
@@ -52,7 +52,7 @@ url: /outils-et-ressources/guide-tests-d-utilisabilite/
                         Liste courante des problèmes d’analyse des tests</a> (page en anglais seulement) de Dana Chisnell</li>
             </ul>
 
-            <h4>En provenance du SNC</h4>
+            <h3>En provenance du SNC</h3>
             <ul>
                 <li>Exemple: <a
                         href="https://docs.google.com/document/d/1GW9GhvWqLDscLOb_CP8y0pGmW_iZ8MaSnELb_5w4hd0/edit">Plans du test d’utilisabilité du projet d’ACC</a> (document en anglais seulement)</li>


### PR DESCRIPTION
# Summary | Résumé

This fixes the header-order issue in the guide to usability testing [1].

[1]: https://a11y-tools-query.herokuapp.com/violations/cds-snc%2Fdigital-canada-ca/a7b90b63ebde8c9953707e9c476de6843c871482#violation1