### PR TITLE
fix: set title and pretitle of blogpost to black

### DIFF
--- a/assets/sass/cds/_components.scss
+++ b/assets/sass/cds/_components.scss
@@ -446,7 +446,7 @@
     font-weight: 100;
     margin-top: 0;
     margin-top: 1.5rem;
-    color: $primary-color;
+    color: $black;
     margin-left: 0;
     margin-right: 0;
     padding-left: 0;
@@ -487,7 +487,7 @@
 
     a {
       text-decoration: none;
-      color: $white;
+      color: $black;
       font-weight: 100;
     }
   }


### PR DESCRIPTION
The blogpost title and pretitle were yellow and white respectively and
this caused serious a11y issues regarding contrast, this sets both of
them to black and so will fix the issue.


Fixes #2437 