### PR TITLE
Remove safeHTML hack and use duplicate template.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -27,7 +27,6 @@
       <div class='row equal'>
         {{ end }}
         <div class='col-md-6 col-xs-12'>
-          {{ .Scratch.Set "level" "h3" }}
           {{ .Render "list" }}
         </div>
         {{ end }}

--- a/layouts/partials/partnerships_product_item.html
+++ b/layouts/partials/partnerships_product_item.html
@@ -6,9 +6,9 @@
     <div class="col-sm-10 col-sm-offset-1 col-xs-12">
       <div class="title-container">
         <div>
-          <h3 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
+          <h4 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
             {{ .Params.title }}
-          </h3>
+          </h4>
         </div>
       </div>
     </div>
@@ -76,4 +76,5 @@
     </div>
   </div>
 </section>
+
 

--- a/layouts/section/partnerships.html
+++ b/layouts/section/partnerships.html
@@ -93,14 +93,13 @@
     <div class='row equal'>
       {{ $inflight := where .Site.Pages ".Params.status" "==" "in-flight" }}
       {{ range $elem_index, $elem_val := $inflight | intersect $products }}
-      {{ if and (ne $elem_index 0) (eq (mod $elem_index 2) 0) }}
-    </div>
-    <div class='row equal'>
-      {{ end }}
-      <div class='col-md-6 col-xs-12'>
-        {{ .Scratch.Set "level" "h4" }}
-        {{ .Render "list"}}
-      </div>
+        {{ if and (ne $elem_index 0) (eq (mod $elem_index 2) 0) }}
+          </div>
+          <div class='row equal'>
+        {{ end }}
+        <div class='col-md-6 col-xs-12'>
+          {{ partial "partnerships_product_item" $elem_val }}
+        </div>
       {{ end }}
     </div>
   </div>
@@ -115,14 +114,13 @@
     <div class='row equal'>
       {{ $past := where .Site.Pages ".Params.status" "==" "past" }}
       {{ range $elem_index, $elem_val := $past | intersect $products }}
-      {{ if and (ne $elem_index 0) (eq (mod $elem_index 2) 0) }}
-    </div>
-    <div class='row equal'>
-      {{ end }}
-      <div class='col-md-6 col-xs-12'>
-        {{ .Scratch.Set "level" "h4" }}
-        {{ .Render "list"}}
-      </div>
+        {{ if and (ne $elem_index 0) (eq (mod $elem_index 2) 0) }}
+          </div>
+          <div class='row equal'>
+        {{ end }}
+        <div class='col-md-6 col-xs-12'>
+          {{ partial "partnerships_product_item" $elem_val }}
+        </div>
       {{ end }}
     </div>
   </div>

--- a/layouts/section/products.html
+++ b/layouts/section/products.html
@@ -23,7 +23,6 @@
             <div class='row equal'>
           {{ end }}
           <div class='col-md-6 col-xs-12'>
-            {{ .Scratch.Set "level" "h3" }}
             {{ $elem_val.Render "list"}}
           </div>
         {{ end }}
@@ -36,7 +35,6 @@
             <div class='row equal'>
           {{ end }}
           <div class='col-md-6 col-xs-12'>
-            {{ .Scratch.Set "level" "h3" }}
             {{ .Render "list"}}
           </div>
         {{ end }}

--- a/layouts/section/tools-and-resources.html
+++ b/layouts/section/tools-and-resources.html
@@ -33,7 +33,6 @@
       <div class='row equal'>
         {{ end }}
         <div class='col-md-6 col-xs-12'>
-          {{ .Scratch.Set "level" "h3" }}
           {{ .Render "list"}}
         </div>
         {{ end }}
@@ -55,7 +54,6 @@
           <div class='row equal'>
             {{ end }}
             <div class='col-md-6 col-xs-12'>
-              {{ .Scratch.Set "level" "h3" }}
               {{ .Render "list"}}
             </div>
             {{ end }}

--- a/layouts/tools-and-resources/list.html
+++ b/layouts/tools-and-resources/list.html
@@ -5,9 +5,9 @@
     <div class="col-sm-10 col-sm-offset-1 col-xs-12">
       <div class="title-container">
         <div>
-          {{ safeHTML "<" }}{{ .Scratch.Get "level" }} class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
+          <h3 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
             {{ .Params.title }}
-          {{ safeHTML "<" }}/{{ .Scratch.Get "level" }}>
+          </h3>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Summary | Résumé

This PR duplicates the card template on the partnerships page and then
sets the correct `h` values for the various usages. This should
hopefully fix the flake seen in the html proofer.