### PR TITLE
fixed browse button

### DIFF
--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -805,6 +805,7 @@ span.livefr {
     display: inline-block;
     background-color: black;
     margin-bottom: 2rem;
+    margin-top: 1rem;
 
     div {
       cursor: pointer;
@@ -813,9 +814,17 @@ span.livefr {
       font-size: 23px;
       font-weight: 600;
     }
+
+  }
+  .resume {
+    opacity: 0;
+    width: 0.1px;
+    height: 0.1px;
+    position: absolute;
   }
   .no-file-chosen {
     font-size: 22px;
+    font-weight: 100;
     margin-left: 2rem;
   }
   .help-text {

--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -802,7 +802,7 @@ span.livefr {
   }
   .browse {
     cursor: pointer;
-    display: inline-block;
+    padding: 2px;
     background-color: black;
     margin-bottom: 2rem;
     margin-top: 1rem;

--- a/layouts/section/job-posting.en.html
+++ b/layouts/section/job-posting.en.html
@@ -92,16 +92,18 @@
 
       <!-- Resume -->
 
-      <label for="resume">Resume
+      
       <div class="form-group">
-        <div class="browse">
-          <div>Browse...
-            <input class="resume" type="file" id="resume" name="resume"
-              accept="application/msword, application/pdf, text/plain" required  />
-          </div>
+        <label for="resume">Resume
+          <div class="browse">
+            <div>Browse...
+              <input class="resume" type="file" id="resume" name="resume"
+                accept="application/msword, application/pdf, text/plain" required  />
+            </div>
 
-        </div>
-      </label>
+          </div>
+        </label>
+      
         <span class="no-file-chosen" id="no-file-chosen-text">No file selected</span>
 
       </div>

--- a/layouts/section/job-posting.en.html
+++ b/layouts/section/job-posting.en.html
@@ -92,15 +92,16 @@
 
       <!-- Resume -->
 
-      <label for="resume">Resume</label>
+      <label for="resume">Resume
       <div class="form-group">
         <div class="browse">
           <div>Browse...
             <input class="resume" type="file" id="resume" name="resume"
-              accept="application/msword, application/pdf, text/plain" required style="display: none;" />
+              accept="application/msword, application/pdf, text/plain" required  />
           </div>
 
         </div>
+      </label>
         <span class="no-file-chosen" id="no-file-chosen-text">No file selected</span>
 
       </div>

--- a/layouts/section/job-posting.fr.html
+++ b/layouts/section/job-posting.fr.html
@@ -97,7 +97,7 @@
           <div class="browse">
             <div>Parcourir...
               <input class="resume" type="file" id="resume" name="resume"
-                accept="application/msword, application/pdf, text/plain" required style="display: none;" />
+                accept="application/msword, application/pdf, text/plain" required />
             </div>
 
           </div>

--- a/layouts/section/job-posting.fr.html
+++ b/layouts/section/job-posting.fr.html
@@ -92,7 +92,7 @@
 
       <!-- Resume -->
 
-      <label for="resume">CV</label>
+      <label for="resume">CV
       <div class="form-group">
         <div class="browse">
           <div>Parcourir...
@@ -101,6 +101,7 @@
           </div>
 
         </div>
+      </label>
         <span class="no-file-chosen" id="no-file-chosen-text">Aucun fichier sélectionné</span>
 
 

--- a/layouts/section/job-posting.fr.html
+++ b/layouts/section/job-posting.fr.html
@@ -92,16 +92,16 @@
 
       <!-- Resume -->
 
-      <label for="resume">CV
       <div class="form-group">
-        <div class="browse">
-          <div>Parcourir...
-            <input class="resume" type="file" id="resume" name="resume"
-              accept="application/msword, application/pdf, text/plain" required style="display: none;" />
-          </div>
+        <label for="resume">CV
+          <div class="browse">
+            <div>Parcourir...
+              <input class="resume" type="file" id="resume" name="resume"
+                accept="application/msword, application/pdf, text/plain" required style="display: none;" />
+            </div>
 
-        </div>
-      </label>
+          </div>
+        </label>
         <span class="no-file-chosen" id="no-file-chosen-text">Aucun fichier sélectionné</span>
 
 


### PR DESCRIPTION
# Summary | Résumé

Browse button was not working as there was a bit of an issue with the label. Fixed browse button for FR and EN. Also removed `display: none` from the input.