### PR TITLE
Updated French Apply now button on Homepage

### DIFF
--- a/content/fr/website-usability-testing.html
+++ b/content/fr/website-usability-testing.html
@@ -24,7 +24,7 @@ url: /test-d-utilisabilite-du-site-web/
         
             <p>Lors de l’entretien, qui devrait durer de 45 à 60 minutes, on vous posera des questions sur le site Web du SNC et sur vos attentes envers le SNC.</p>
             
-            <p>Remarques :</p>
+            <p>Remarques : </p>
             <ul>
                 <li>Votre participation à cette étude est volontaire et vous pourrez arrêter à tout moment pour n’importe quelle raison. L’entretien aura lieu pendant les heures de bureau, entre 9 h et 17 h HE (heure de l’Est).</li>
                 <li>Vos réponses sont confidentielles, ce qui signifie qu’elles ne pourront servir à vous identifier.</li>

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -287,7 +287,7 @@ but-need-help:
 product-impact:
   other: "Nos produits auront un impact sur la vie quotidienne des gens. C’est une expérience passionnante à vivre. Faites-en partie!"
 apply-now:
-  other: "Appliquer maintenant"
+  other: "Soumettre votre candidature"
 what-were-working-on:
   other: "Sur quoi travaillons-nous?"
 who-is-on-the-team:


### PR DESCRIPTION
Updating "Apply now" button on French homepage, from "Appliquer maintenant" to "Soumettre votre candidature"
