### PR TITLE
fixed broken link

### DIFF
--- a/content/en/blog/posts/how-we’re-trying-to-make-virtual-onboarding-better.md
+++ b/content/en/blog/posts/how-we’re-trying-to-make-virtual-onboarding-better.md
@@ -61,7 +61,7 @@ In addition to providing people with the tactical information they need before t
 
 ## Learning lots
 
-We’re only a couple of months into this program. Since our Talent team is always trying to improve employee experience, we’ve been regularly soliciting feedback from new hires. The feedback we get helps us as we onboard our [growing team](https://digital.canada.ca/careers/).
+We’re only a couple of months into this program. Since our Talent team is always trying to improve employee experience, we’ve been regularly soliciting feedback from new hires. The feedback we get helps us as we onboard our [growing team](https://digital.canada.ca/join-our-team/).
 
 So far, it’s been very positive. People tell us that the orientation sessions have given them a space to ask questions, meet managers, and make new friends. Now at our all-team meetings, people recognize more faces on their screen. That’s music to our ears! In our current fully virtual work environment, we want to keep our new employees connected and make sure they feel welcome!
 

--- a/content/en/careers/_index.html
+++ b/content/en/careers/_index.html
@@ -3,7 +3,7 @@ type: section
 title: careers
 image: work-with-us.jpg
 layout: careers
-aliases: [/carrieres/]
+aliases: [/work-with-us/, /carrieres/]
 ---
 
 <section class="work-with-us--section bg-med-grey">

--- a/content/en/careers/_index.html
+++ b/content/en/careers/_index.html
@@ -3,7 +3,7 @@ type: section
 title: careers
 image: work-with-us.jpg
 layout: careers
-aliases: [/work-with-us/, /carrieres/]
+aliases: [/work-with-us/, /carrieres/, /join-our-team/]
 ---
 
 <section class="work-with-us--section bg-med-grey">

--- a/content/en/careers/positions/executive-assistant.md
+++ b/content/en/careers/positions/executive-assistant.md
@@ -7,8 +7,6 @@ description: >-
 archived: false
 translationKey: executive-assistant-cos
 leverId: de6ae5bc-d267-4539-89b4-c4d1497ccbf0
-aliases:
-    - /join-our-team/positions/executive-assistant/
 ---
 
 The Canadian Digital Service (CDS) is tasked with changing how the federal government designs and delivers digital services, to reduce the risk of product failure, lower costs, ensure user privacy and system security, and, above all, improves people’s lives by putting their needs and concerns front and center. We believe every experience Canadians have with their government should meet or exceed their reasonable modern expectations that digital services be safe, fast, easy, transparent, and accessible. Working in the open, we’re building capacity across the government for better service delivery. And we need you.

--- a/content/en/careers/positions/senior-front-end-software-developer.md
+++ b/content/en/careers/positions/senior-front-end-software-developer.md
@@ -7,8 +7,6 @@ description: >-
 archived: false
 translationKey: sr-frontend-developer
 leverId: 6e9992fd-4ee4-4eee-9f62-dc7cd806528a
-aliases:
-    - /join-our-team/positions/senior-front-end-software-developer/
 ---
 
 The Canadian Digital Service (CDS) is tasked with changing how the federal government designs and delivers digital services, to reduce the risk of product failure, lower costs, ensure user privacy and system security, and, above all, improves people’s lives by putting their needs and concerns front and center. We believe every experience Canadians have with their government should meet or exceed their reasonable modern expectations that digital services be safe, fast, easy, transparent, and accessible. Working in the open, we’re building capacity across the government for better service delivery. And we need you.

--- a/content/en/careers/positions/technical-support-developer.md
+++ b/content/en/careers/positions/technical-support-developer.md
@@ -7,8 +7,6 @@ description: >-
 archived: false
 translationKey: technical-support-dev
 leverId: 2bf581e6-d1cb-4cbf-aca9-6e91c5eb13f1
-aliases:
-    - /join-our-team/positions/technical-support-developer/
 ---
 
 The Canadian Digital Service (CDS) is tasked with changing how the federal government designs and delivers digital services, to reduce the risk of product failure, lower costs, ensure user privacy and system security, and, above all, improves people’s lives by putting their needs and concerns front and center. We believe every experience Canadians have with their government should meet or exceed their reasonable modern expectations that digital services be safe, fast, easy, transparent, and accessible. Working in the open, we’re building capacity across the government for better service delivery. And we need you.

--- a/content/en/careers/positions/translator-content-coordinator.md
+++ b/content/en/careers/positions/translator-content-coordinator.md
@@ -7,8 +7,6 @@ description: >-
 archived: false
 translationKey: translate-content-coordinator
 leverId: 74410168-af05-42dc-af82-d413c73ba970
-aliases:
-    - /join-our-team/positions/translator-content-coordinator/
 ---
 
 The Canadian Digital Service (CDS) is changing how the federal government designs and delivers digital services. We’re here to improve people’s lives by changing how the government builds technology. We do this by putting people's needs and concerns front and centre. Every experience Canadians have with their government should be safe, fast, easy, transparent, and accessible. We are working in the open to help everyone across government improve service delivery. We need you.

--- a/content/en/join-our-team/index.html
+++ b/content/en/join-our-team/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv = "refresh" content = "0; url = https://digital.canada.ca/careers/" />

--- a/content/en/join-our-team/positions/executive-assistant.html
+++ b/content/en/join-our-team/positions/executive-assistant.html
@@ -1,0 +1,1 @@
+<meta http-equiv = "refresh" content = "0; url = https://digital.canada.ca/careers/positions/executive-assistant/" />

--- a/content/en/join-our-team/positions/senior-front-end-software-developer.html
+++ b/content/en/join-our-team/positions/senior-front-end-software-developer.html
@@ -1,0 +1,1 @@
+<meta http-equiv = "refresh" content = "0; url = https://digital.canada.ca/careers/positions/senior-front-end-software-developer/" />

--- a/content/en/join-our-team/positions/technical-support-developer.html
+++ b/content/en/join-our-team/positions/technical-support-developer.html
@@ -1,0 +1,1 @@
+<meta http-equiv = "refresh" content = "0; url = https://digital.canada.ca/careers/positions/technical-support-developer/" />

--- a/content/en/join-our-team/positions/translator-content-coordinator.html
+++ b/content/en/join-our-team/positions/translator-content-coordinator.html
@@ -1,0 +1,1 @@
+<meta http-equiv = "refresh" content = "0; url = https://digital.canada.ca/careers/positions/translator-content-coordinator/" />

--- a/content/fr/blog/posts/améliorer-l’intégration-des-nouveaux-employés-en-période-de-télétravail.md
+++ b/content/fr/blog/posts/améliorer-l’intégration-des-nouveaux-employés-en-période-de-télétravail.md
@@ -60,7 +60,7 @@ En plus de recevoir les renseignements dont ils ont besoin pour se lancer dans l
 
 ## Les apprentissages
 
-Même si le programme n’existe que depuis quelques mois, notre équipe de talent cherche toujours à améliorer l’expérience des employés et nous sollicitons régulièrement la rétroaction des participants. Les commentaires que nous recevons aideront à intégrer les nouveaux membres de notre [équipe en pleine croissance](https://numerique.canada.ca/carrieres/).
+Même si le programme n’existe que depuis quelques mois, notre équipe de talent cherche toujours à améliorer l’expérience des employés et nous sollicitons régulièrement la rétroaction des participants. Les commentaires que nous recevons aideront à intégrer les nouveaux membres de notre [équipe en pleine croissance](https://numerique.canada.ca/rejoindre-notre-equipe/).
 
 Jusqu’à présent, les commentaires sont très positifs. Les participants nous ont dit que les séances d’orientation leur ont permis de poser des questions, de rencontrer les gestionnaires et de se faire de nouveaux amis. Désormais, lors de nos réunions de tout le personnel, les gens reconnaissent de plus en plus de personnes. Je suis agréablement surprise du résultat! Dans notre environnement de télétravail actuel, nous voulons nous assurer que nos nouveaux collègues sont branchés et qu’ils se sentent les bienvenus.
 

--- a/content/fr/careers/_index.html
+++ b/content/fr/careers/_index.html
@@ -3,7 +3,7 @@ type: section
 title: carrieres
 image: work-with-us.jpg
 layout: careers
-aliases: [/careers/]
+aliases: [/careers/, /travaillez-avec-nous/]
 url: /carrieres/
 ---
 

--- a/content/fr/careers/_index.html
+++ b/content/fr/careers/_index.html
@@ -3,7 +3,7 @@ type: section
 title: carrieres
 image: work-with-us.jpg
 layout: careers
-aliases: [/careers/, /travaillez-avec-nous/]
+aliases: [/careers/, /travaillez-avec-nous/, /rejoindre-notre-equipe/]
 url: /carrieres/
 ---
 

--- a/content/fr/careers/positions/adjoint-e-de-direction.md
+++ b/content/fr/careers/positions/adjoint-e-de-direction.md
@@ -7,8 +7,6 @@ description: >-
 archived: false
 translationKey: executive-assistant-cos
 leverId: de6ae5bc-d267-4539-89b4-c4d1497ccbf0
-aliases:
-    - /join-our-team/positions/adjoint-e-de-direction/
 ---
 
 Le Service numérique canadien (SNC) est chargé de changer la façon dont le gouvernement fédéral conçoit et fournit les services numériques, afin de réduire les risques d’échec des produits, de réduire les coûts, de garantir la confidentialité des utilisateurs et la sécurité des systèmes, et surtout, d’améliorer la vie des gens en appelant l’attention sur leurs besoins et préoccupations. Selon nous, chaque expérience vécue par les Canadiennes et Canadiens lorsqu’ils interagissent avec le gouvernement devrait répondre ou dépasser leurs attentes modernes et valables voulant que les services numériques soient sûrs, rapides, faciles, transparents et accessibles. Nous travaillons ouvertement, renforçant ainsi les capacités dans tout le gouvernement pour améliorer la prestation de services. Et nous avons besoin de vous.

--- a/content/fr/careers/positions/développeur-de-soutien.md
+++ b/content/fr/careers/positions/développeur-de-soutien.md
@@ -7,8 +7,6 @@ description: >-
 archived: false
 translationKey: technical-support-dev
 leverId: 2bf581e6-d1cb-4cbf-aca9-6e91c5eb13f1
-aliases:
-    - /join-our-team/positions/développeur-de-soutien/
 ---
 
 Le Service numérique canadien (SNC) change la façon dont le gouvernement fédéral conçoit et offre les services numériques. Nous sommes ici pour améliorer la vie des gens en changeant la façon dont le gouvernement développe la technologie. Pour ce faire, nous plaçons les besoins et les préoccupations des citoyens au premier plan. Chaque interaction entre les Canadiens et Canadiennes et le gouvernement devrait être sécuritaire, rapide, facile, transparente et accessible. Nous travaillons ouvertement pour aider tout le monde au sein du gouvernement à améliorer la prestation des services. Nous avons besoin de vous.

--- a/content/fr/careers/positions/développeur-principal-de-logiciels-frontaux.md
+++ b/content/fr/careers/positions/développeur-principal-de-logiciels-frontaux.md
@@ -7,8 +7,6 @@ description: >-
 archived: false
 translationKey: sr-frontend-developer
 leverId: 6e9992fd-4ee4-4eee-9f62-dc7cd806528a
-aliases:
-    - /join-our-team/positions/développeur-principal-de-logiciels-frontaux/
 ---
 
 Le Service numérique canadien (SNC) change la façon dont le gouvernement fédéral conçoit et offre les services numériques. Nous sommes ici pour améliorer la vie des gens en changeant la façon dont le gouvernement développe la technologie. Pour ce faire, nous plaçons les besoins et les préoccupations des citoyens au premier plan. Chaque interaction entre les Canadiens et Canadiennes et le gouvernement devrait être sécuritaire, rapide, facile, transparente et accessible. Nous travaillons ouvertement pour aider tout le monde au sein du gouvernement à améliorer la prestation des services. Nous avons besoin de vous.

--- a/content/fr/careers/positions/traducteur-traductrice---coordonnateur-coordonnatrice-de-contenu.md
+++ b/content/fr/careers/positions/traducteur-traductrice---coordonnateur-coordonnatrice-de-contenu.md
@@ -7,8 +7,6 @@ description: >-
 archived: false
 translationKey: translate-content-coordinator
 leverId: 74410168-af05-42dc-af82-d413c73ba970
-aliases:
-    - /join-our-team/positions/traducteur-traductrice-coordonnateur-coordonnatrice-de-contenu/
 ---
 
 Le Service numérique canadien (SNC) change la façon dont le gouvernement fédéral conçoit et offre les services numériques. Nous sommes ici pour améliorer la vie des gens en changeant la façon dont le gouvernement développe la technologie. Pour ce faire, nous plaçons les besoins et les préoccupations des citoyens au premier plan. Chaque interaction entre les Canadiens et Canadiennes et le gouvernement devrait être sécuritaire, rapide, facile, transparente et accessible. Nous travaillons ouvertement pour aider tout le monde au sein du gouvernement à améliorer la prestation des services. Nous avons besoin de vous.

--- a/content/fr/join-our-team/index.html
+++ b/content/fr/join-our-team/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv = "refresh" content = "0; url = https://numerique.canada.ca/careers/" />
+<meta http-equiv = "refresh" content = "0; url = https://numerique.canada.ca/carrieres/" />

--- a/content/fr/join-our-team/index.html
+++ b/content/fr/join-our-team/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv = "refresh" content = "0; url = https://numerique.canada.ca/careers/" />

--- a/content/fr/join-our-team/positions/adjoint-e-de-direction.html
+++ b/content/fr/join-our-team/positions/adjoint-e-de-direction.html
@@ -1,0 +1,1 @@
+<meta http-equiv = "refresh" content = "0; url = https://numerique.canada.ca/careers/positions/adjoint-e-de-direction/" />

--- a/content/fr/join-our-team/positions/développeur-de-soutien.html
+++ b/content/fr/join-our-team/positions/développeur-de-soutien.html
@@ -1,0 +1,1 @@
+<meta http-equiv = "refresh" content = "0; url = https://numerique.canada.ca/careers/positions/développeur-de-soutien/" />

--- a/content/fr/join-our-team/positions/développeur-principal-de-logiciels-frontaux.html
+++ b/content/fr/join-our-team/positions/développeur-principal-de-logiciels-frontaux.html
@@ -1,0 +1,1 @@
+<meta http-equiv = "refresh" content = "0; url = https://numerique.canada.ca/careers/positions/développeur-principal-de-logiciels-frontaux/" />

--- a/content/fr/join-our-team/positions/traducteur-traductrice-coordonnateur-coordonnatrice-de-contenu.html
+++ b/content/fr/join-our-team/positions/traducteur-traductrice-coordonnateur-coordonnatrice-de-contenu.html
@@ -1,0 +1,1 @@
+<meta http-equiv = "refresh" content = "0; url = https://numerique.canada.ca/careers/positions/traducteur-traductrice-coordonnateur-coordonnatrice-de-contenu/" />

--- a/content/fr/rejoindre-notre-equipe/index.html
+++ b/content/fr/rejoindre-notre-equipe/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv = "refresh" content = "0; url = https://numerique.canada.ca/careers/" />
+<meta http-equiv = "refresh" content = "0; url = https://numerique.canada.ca/carrieres/" />

--- a/content/fr/rejoindre-notre-equipe/index.html
+++ b/content/fr/rejoindre-notre-equipe/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv = "refresh" content = "0; url = https://numerique.canada.ca/careers/" />

--- a/layouts/partials/404.en.html
+++ b/layouts/partials/404.en.html
@@ -1,5 +1,5 @@
 <div class="section error">
-    <p>We can’t find the page you’re looking for. Maybe we can interest you in a job instead? Apply <a href="https://digital.canada.ca/work-with-us/">here</a> and help deliver world-class digital services! </p>
+    <p>We can’t find the page you’re looking for. Maybe we can interest you in a job instead? Apply <a href="https://digital.canada.ca/careers/">here</a> and help deliver world-class digital services! </p>
 
     <p>You can also head back to our <a href="/">home page</a> or <a href="#contact-us-links">get in touch</a> where we’d be happy to help.</p>
 

--- a/layouts/partials/404.fr.html
+++ b/layouts/partials/404.fr.html
@@ -1,7 +1,7 @@
 <div class="section error">
 
     <p>Nous ne trouvons pas la page que vous cherchez. Mais peut-être pouvons-nous vous trouver un emploi à la place?
-        Postulez <a href="https://numerique.canada.ca/travaillez-avec-nous">ici</a> et aidez-nous à fournir des
+        Postulez <a href="https://numerique.canada.ca/carrieres">ici</a> et aidez-nous à fournir des
         services numériques hors pair!
     </p>
 


### PR DESCRIPTION
# Summary | Résumé

We were running into issues where anything related to /work-with-us/ or /join-our-team/ would lead to a 404 page. This will now redirect to /careers/ for both EN or FR.

Also fixed the "apply now" link in the 404 page to redirect to the careers page.

This also reverts the aliases that were added on the MD file and created html files 