### PR TITLE
removed validation requirements

### DIFF
--- a/layouts/section/job-posting.en.html
+++ b/layouts/section/job-posting.en.html
@@ -131,8 +131,7 @@
 
         </div>
 
-        <textarea class="form-control validate-required validate-maxwords" id="samples" name="samples" rows="5"
-          aria-required="true" aria-describedby="body-required word-count-message"></textarea>
+        <textarea class="form-control" id="samples" name="samples" rows="5"></textarea>
       </div>
       <!-- Submit-->
       <div>

--- a/layouts/section/job-posting.fr.html
+++ b/layouts/section/job-posting.fr.html
@@ -127,8 +127,7 @@
           <span class="url">Liens URL SVP!</span>
 
         </div>
-        <textarea class="form-control validate-required validate-maxwords" id="samples" name="samples" rows="5"
-          aria-required="true" aria-describedby="body-required word-count-message"></textarea>
+        <textarea class="form-control" id="samples" name="samples" rows="5"></textarea>
       </div>
       <!-- Submit-->
       <div>


### PR DESCRIPTION
# Summary | Résumé

Small issue with the sample url text area. Despite it being optional, there was still a validation error. The error was caused by the validation classes on the text area that were turning it into a required field. Fix was to remove them