### PR TITLE
Redesign/partnerships page

### DIFF
--- a/assets/sass/cds/_components.scss
+++ b/assets/sass/cds/_components.scss
@@ -503,3 +503,12 @@
     background-color: black;
   }
 }
+
+.partnerships-contact {
+  display: flex;
+  justify-content: center;
+
+  div {
+    margin-right: 4rem;
+  }
+}

--- a/assets/sass/cds/_components.scss
+++ b/assets/sass/cds/_components.scss
@@ -508,8 +508,3 @@
     background-color: black;
   }
 }
-
-.partnership-title{
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-}

--- a/assets/sass/cds/_components.scss
+++ b/assets/sass/cds/_components.scss
@@ -508,3 +508,8 @@
     background-color: black;
   }
 }
+
+.partnership-title{
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}

--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -1387,15 +1387,20 @@ article.post {
 }
 
 .partnerships-info {
-  margin: 6rem 0 4rem 0;
-
   h2 {
-    margin: 2rem 0 1rem 0;
+    margin: 2rem 0 3rem 0;
+  }
+  p {
+    width: 80%;
   }
 }
 
 .partnership-products {
   padding: 5rem 0;
+
+  h2 {
+    margin: 1rem 0 4rem 0;
+  }
 }
 
 .border-discovery,

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -159,7 +159,7 @@ partnerships-partner-for-beta:
 partnerships-partner-for-live:
   other: "A full time autonomous multi-disciplinary team to continuously improve the service (for the <span class='term'>Live</span> phase)"
 partnerships-interested-in-chatting:
-  other: "Interested in chatting about a potential partnership?"
+  other: "Want to work with us?"
 partnerships-partner-overview:
   other: "Check out the overview of CDS partnerships below! To learn how we choose our partnerships, read this"
 partnerships-past:

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -87,9 +87,43 @@ partnerships-contact-us:
 partnerships-contact-us-link:
     other: "https://forms-formulaires.alpha.canada.ca/id/3"
 partnerships-intro:
-  other: "At the Canadian Digital Service (CDS), we partner up with federal departments to design, test and build simple, easy to use services. Our goal is to improve the experience – for people who deliver government services and people who use those services."
+  other: "We provide free support for federal public servants to improve their public facing services. Through advice and feedback, we enable your team to design, develop, buy, and maintain a service on their own. Instead of building the products for you, we empower you to build them."
 partnerships-how-it-works:
   other: "How it works"
+partnerships-what-we-can-help-title:
+  other: "What we can help your team with"
+partnerships-what-we-can-help-1st:
+  other: "We can work together on things like:"
+partnerships-what-we-can-help-list-1:
+  other: "Improving usability and accessibility of your service."
+partnerships-what-we-can-help-list-2:
+  other: "Optimizing service delivery and change management processes."
+partnerships-what-we-can-help-list-3:
+  other: "Setting up effective procurements for services or software."
+partnerships-what-we-can-help-list-4:
+  other: "Hiring digital practitioners."
+partnerships-three-ways-heading:
+  other: "The three different ways we can work together"
+partnerships-time-commitment:
+  other: "Time commitment"
+partnerships-consultation:
+  other: "Consultation"
+partnerships-consultation-time-commitment:
+  other: "1-hour meetings as needed"
+partnerships-consultation-description:
+  other: "We’ll meet with you to learn more about your specific service delivery challenges. We’ll share knowledge and documentation from our past work to help you solve similar problems." 
+partnerships-exploration:
+  other: "Exploration" 
+partnerships-exploration-time-commitment:
+  other: "About 4 weeks"
+partnerships-exploration-description:
+  other: "We’ll conduct a deep dive into your team to learn about your current service delivery conditions. From there, we’ll create a roadmap and final report with recommended next steps to improve your service and processes." 
+partnerships-embedded-team:
+  other: "Embedded team"
+partnerships-embedded-team-time-commitment:
+  other: "4 months – 1.5 years"
+partnerships-embedded-team-description:
+  other: "One of our teams will work alongside you, full-time, coaching your team to optimize practices and remove delivery obstacles. To inform how we do that, we’ll first run an Exploration to learn more about your current service delivery conditions."       
 partnerships-how-we-do-it-1st:
   other: "We work with our partners in the open, regularly sharing progress via public platforms. This creates a culture of learning and fosters best practices. It means non-partner departments can apply our work and <a href=\"https://digital.canada.ca/tools-and-resources/\">use our resources</a> to develop their own services."
 partnerships-how-we-do-it-2nd:
@@ -201,7 +235,7 @@ view-product:
 careers:
   other: "Careers"  
 what-were-working-on:
-  other: "What we're working on"
+  other: "What we’ve worked on"
 partnerships:
   other: "Partnerships"
 featured-post:

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -85,9 +85,43 @@ partnerships-contact-us:
 partnerships-contact-us-link:
     other: "https://forms-formulaires.alpha.canada.ca/fr/id/3"
 partnerships-intro:
-  other: "Au Service numérique canadien (SNC), nous établissons des partenariats avec les ministères fédéraux pour concevoir, tester et bâtir des services simples et faciles à utiliser. Notre objectif est d’améliorer l’expérience des personnes qui fournissent les services gouvernementaux tout comme celle des personnes qui les utilisent."
+  other: "Nous offrons un soutien gratuit aux fonctionnaires fédéraux afin d’améliorer les services qu’ils proposent au public. Nous misons sur les conseils et sur la rétroaction pour permettre à votre équipe de concevoir, de développer, d’acheter et d’entretenir un service par elle-même. Au lieu de construire les produits pour vous, nous vous donnons les moyens d’y parvenir."
 partnerships-how-it-works:
   other: "Fonctionnement"
+partnerships-what-we-can-help-title:
+  other: "L’aide que nous pouvons apporter à votre équipe"
+partnerships-what-we-can-help-1st:
+  other: "Nous pouvons collaborer sur les points suivants :"
+partnerships-what-we-can-help-list-1:
+  other: "Amélioration de la convivialité et de l’accessibilité de votre service."
+partnerships-what-we-can-help-list-2:
+  other: "Optimisation des processus de prestation de service et de gestion du changement."
+partnerships-what-we-can-help-list-3:
+  other: "Mise en place d’approvisionnements efficaces pour les services ou pour les logiciels."
+partnerships-what-we-can-help-list-4:
+  other: "Recrutement de praticiens du numérique. "
+partnerships-three-ways-heading:
+  other: "Les trois modes de collaboration possibles"
+partnerships-time-commitment:
+  other: "Durée"
+partnerships-consultation:
+  other: "Consultation"
+partnerships-consultation-time-commitment:
+  other: "Réunions d’une heure en fonction de vos besoins"
+partnerships-consultation-description:
+  other: "Nous vous rencontrons pour en apprendre davantage sur les défis spécifiques que vous rencontrez en matière de prestation de services. Nous partageons avec vous les connaissances et la documentation issues de nos travaux antérieurs pour vous aider à résoudre des problèmes similaires."
+partnerships-exploration:
+  other: "Exploration" 
+partnerships-exploration-time-commitment:
+  other: "Environ 4 semaines"
+partnerships-exploration-description:
+  other: "Nous étudions le fonctionnement de votre équipe en détail pour en apprendre davantage sur l’état actuel de vos prestations de services. Nous créons ensuite une feuille de route et un rapport final détaillant les prochaines étapes recommandées pour améliorer votre service et vos processus."
+partnerships-embedded-team:
+  other: "Équipe intégrée"
+partnerships-embedded-team-time-commitment:
+  other: "4 à 18 mois"
+partnerships-embedded-team-description:
+  other: "L’une de nos équipes vous accompagne à temps plein et forme vos membres afin d’optimiser vos pratiques et d’éliminer tout obstacle à vos prestations. Pour ce faire, nous commençons par une étape d’exploration afin d’en apprendre davantage sur l’état actuel de vos prestations de services."
 partnerships-how-we-do-it-1st:
   other: "Nous travaillons avec nos partenaires de façon ouverte, en partageant régulièrement nos progrès sur des plateformes publiques. Cette démarche crée une culture de l’apprentissage et favorise des pratiques exemplaires. Elle permet par le fait même aux ministères non partenaires de recourir à notre travail et d’<a href=\"https://numerique.canada.ca/outils-et-ressources/\">utiliser nos ressources</a> pour développer leurs propres services. "
 partnerships-how-we-do-it-2nd:
@@ -289,7 +323,7 @@ product-impact:
 apply-now:
   other: "Soumettre votre candidature"
 what-were-working-on:
-  other: "Sur quoi travaillons-nous?"
+  other: "Nos projets précédents"
 who-is-on-the-team:
   other: "Qui est dans l'équipe"
 options-below:

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -81,7 +81,7 @@ partner:
 partnerships:
   other: "Partenariats"
 partnerships-contact-us:
-  other: "Communiquez avec nous"
+  other: "Contactez-nous"
 partnerships-contact-us-link:
     other: "https://forms-formulaires.alpha.canada.ca/fr/id/3"
 partnerships-intro:
@@ -157,7 +157,7 @@ partnerships-partner-for-beta:
 partnerships-partner-for-live:
   other: "Une équipe multidisciplinaire autonome à temps plein dédiée à améliorer de façon continue le service (pour la phase de <span class=\"term\">mise en service</span>)"
 partnerships-interested-in-chatting:
-  other: "Vous aimeriez discuter d’un partenariat potentiel?"
+  other: "Vous souhaitez collaborer?"
 partnerships-partner-overview:
   other: "Voici un aperçu des produits sur lesquels le SNC travaille! Pour savoir comment nous choisissons nos partenariats, lisez ce"
 partnerships-past:

--- a/layouts/partials/partnerships_product_item.html
+++ b/layouts/partials/partnerships_product_item.html
@@ -6,9 +6,9 @@
     <div class="col-sm-10 col-sm-offset-1 col-xs-12">
       <div class="title-container">
         <div>
-          <h4 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
+          <h3 class='{{ .Params.phase }}{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
             {{ .Params.title }}
-          </h4>
+          </h3>
         </div>
       </div>
     </div>

--- a/layouts/section/partnerships.html
+++ b/layouts/section/partnerships.html
@@ -8,46 +8,40 @@
         <p>{{ i18n "partnerships-intro" | safeHTML }}</p>
       </div>
     </div>
-    <!-- How it works -->
-    <div class="row">
-      <div class="col-xs-12">
-        <h2>{{ i18n "partnerships-how-it-works" | safeHTML }}</h2>
-        <p>{{ i18n "partnerships-how-we-do-it-1st" | safeHTML }}</p>
-        <p>{{ i18n "partnerships-how-we-do-it-2nd" | safeHTML }}</p>
-        <p>{{ i18n "partnerships-how-we-do-it-3d" | safeHTML }}</p>
-        <p>{{ i18n "partnerships-how-we-do-it-4th" | safeHTML }}</p>
-      </div>
-    </div>
   </div>
 </section>
+<section class="bg-med-grey">
+<div class="container">
+  <div class="row">
+    <div class="col-xs-12">
+      <h2 class="partnership-title">{{i18n "partnerships-what-we-can-help-title" | safeHTML}}</h2>
+      <p> {{i18n "partnerships-what-we-can-help-1st" | safeHTML }}</p>
+      <ul>
+        <li>{{i18n "partnerships-what-we-can-help-list-1" | safeHTML }}</li>
+        <li>{{i18n "partnerships-what-we-can-help-list-2" | safeHTML }}</li>
+        <li>{{i18n "partnerships-what-we-can-help-list-3" | safeHTML }}</li>
+        <li>{{i18n "partnerships-what-we-can-help-list-4" | safeHTML }}</li>
+      </ul>
 
-<section class='bg-dark-full'>
-  <!-- Who is on the team -->
-  <div class='container'>
-    <div class='row'>
-      <div class='col-xs-12'>
-        <h2>{{ i18n "partnerships-team" | safeHTML }}</h2>
-        <p>{{ i18n "partnerships-team-blurb" | safeHTML }}</p>
+      <h2>{{i18n "partnerships-three-ways-heading" | safeHTML }}</h2>
+      <!-- Consultation -->
+      <p><strong>{{i18n "partnerships-consultation" | safeHTML }}</strong></p>
+      <p>{{i18n "partnerships-time-commitment" | safeHTML }}<br> {{i18n "partnerships-consultation-time-commitment" | safeHTML }}</p>
+      <p>{{i18n "partnerships-how-it-works" | safeHTML }}<br> {{i18n "partnerships-consultation-description" | safeHTML }}</p>
 
-        <p>{{ i18n "partnerships-cds" | safeHTML }}</p>
-        <ul>
-          <li>{{ i18n "partnerships-cds-pm" | safeHTML }}</li>
-          <li>{{ i18n "partnerships-cds-researcher" | safeHTML }}</li>
-          <li>{{ i18n "partnerships-cds-designers" | safeHTML }}</li>
-          <li>{{ i18n "partnerships-cds-developers" | safeHTML }}</li>
-          <li>{{ i18n "partnerships-cds-support" | safeHTML }}</li>
-        </ul>
+      <!-- Exploration -->
+      <p><strong>{{i18n "partnerships-exploration" | safeHTML }}</strong></p>
+      <p>{{i18n "partnerships-time-commitment" | safeHTML }}<br>{{i18n "partnerships-exploration-time-commitment" | safeHTML }}</p>
+      <p>{{i18n "partnerships-how-it-works" | safeHTML }}<br>{{i18n "partnerships-exploration-description" | safeHTML }}</p>
 
-        <p>{{ i18n "partnerships-from-partner" }}:</p>
-        <ul>
-          <li>{{ i18n "partnerships-partner-owner" | safeHTML }}</li>
-          <li>{{ i18n "partnerships-partner-experts" | safeHTML }}</li>
-          <li>{{ i18n "partnerships-partner-for-beta" | safeHTML }}</li>
-          <li>{{ i18n "partnerships-partner-for-live" | safeHTML }}</li>
-        </ul>
-      </div>
+      <!-- Embedded Teams -->
+      <p><strong>{{i18n "partnerships-embedded-team" | safeHTML }}</strong></p>
+      <p>{{i18n "partnerships-time-commitment" | safeHTML }}<br>{{i18n "partnerships-embedded-team-time-commitment" | safeHTML }}</p>
+      <p>{{i18n "partnerships-how-it-works" | safeHTML }}<br>{{i18n "partnerships-embedded-team-description" | safeHTML }}</p>
+
     </div>
   </div>
+</div>
 </section>
 
 <section class='bg-yellow-full'>
@@ -68,52 +62,14 @@
     <div class='row'>
       <div class='col-xs-12'>
         <h2>{{ i18n "what-were-working-on" }}</h2>
-        <p>{{ i18n "partnerships-partner-overview" }}
-
-          {{ $blog_url := "picking-our-projects" }}
-          {{ if eq $.Site.Language.Lang "fr" }}
-          {{ $blog_url = "choisir-nos-projets" }}
-          {{ end }}
-          <a href="{{with $.Site.GetPage $blog_url}}{{.Permalink}}{{ end }}">
-            {{ i18n "blog-post" }}.
-          </a>
-        </p>
       </div>
     </div>
   </div>
 
-  <!-- In-flight partnerships -->
   {{ $products := where .Site.Pages ".File.Dir" "==" "products/products/" }}
   <div class='container'>
-    <div class='row'>
-      <div class='col-xs-12'>
-        <h3>{{ i18n "partnerships-inflight" }}</h3>
-      </div>
-    </div>
     <div class='row equal'>
-      {{ $inflight := where .Site.Pages ".Params.status" "==" "in-flight" }}
-      {{ range $elem_index, $elem_val := $inflight | intersect $products }}
-        {{ if and (ne $elem_index 0) (eq (mod $elem_index 2) 0) }}
-          </div>
-          <div class='row equal'>
-        {{ end }}
-        <div class='col-md-6 col-xs-12'>
-          {{ partial "partnerships_product_item" $elem_val }}
-        </div>
-      {{ end }}
-    </div>
-  </div>
-
-  <!-- Past partnerships -->
-  <div class='container'>
-    <div class='row'>
-      <div class='col-xs-12'>
-        <h3>{{ i18n "partnerships-past" }}</h3>
-      </div>
-    </div>
-    <div class='row equal'>
-      {{ $past := where .Site.Pages ".Params.status" "==" "past" }}
-      {{ range $elem_index, $elem_val := $past | intersect $products }}
+      {{ range $elem_index, $elem_val := $products }}
         {{ if and (ne $elem_index 0) (eq (mod $elem_index 2) 0) }}
           </div>
           <div class='row equal'>

--- a/layouts/section/partnerships.html
+++ b/layouts/section/partnerships.html
@@ -14,36 +14,36 @@
   <div class="container">
     <div class="row">
       <div class="col-xs-12">
-        <h2 class="partnership-title">{{i18n "partnerships-what-we-can-help-title" | safeHTML}}</h2>
-        <p> {{i18n "partnerships-what-we-can-help-1st" | safeHTML }}</p>
+        <h2 class="partnership-title">{{i18n "partnerships-what-we-can-help-title"}}</h2>
+        <p> {{i18n "partnerships-what-we-can-help-1st"}}</p>
         <ul>
-          <li>{{i18n "partnerships-what-we-can-help-list-1" | safeHTML }}</li>
-          <li>{{i18n "partnerships-what-we-can-help-list-2" | safeHTML }}</li>
-          <li>{{i18n "partnerships-what-we-can-help-list-3" | safeHTML }}</li>
-          <li>{{i18n "partnerships-what-we-can-help-list-4" | safeHTML }}</li>
+          <li>{{i18n "partnerships-what-we-can-help-list-1"}}</li>
+          <li>{{i18n "partnerships-what-we-can-help-list-2"}}</li>
+          <li>{{i18n "partnerships-what-we-can-help-list-3"}}</li>
+          <li>{{i18n "partnerships-what-we-can-help-list-4"}}</li>
         </ul>
 
-        <h2>{{i18n "partnerships-three-ways-heading" | safeHTML }}</h2>
+        <h2>{{i18n "partnerships-three-ways-heading"}}</h2>
         <!-- Consultation -->
-        <h3><strong>{{i18n "partnerships-consultation" | safeHTML }}</strong></h3>
-        <h4>{{i18n "partnerships-time-commitment" | safeHTML }}</h4>
-        <p>{{i18n "partnerships-consultation-time-commitment" | safeHTML }}</p>
-        <h4>{{i18n "partnerships-how-it-works" | safeHTML }}</h4>
-        <p>{{i18n "partnerships-consultation-description" | safeHTML }}</p>
+        <h3><strong>{{i18n "partnerships-consultation"}}</strong></h3>
+        <h4>{{i18n "partnerships-time-commitment"}}</h4>
+        <p>{{i18n "partnerships-consultation-time-commitment"}}</p>
+        <h4>{{i18n "partnerships-how-it-works"}}</h4>
+        <p>{{i18n "partnerships-consultation-description"}}</p>
 
         <!-- Exploration -->
-        <h3><strong>{{i18n "partnerships-exploration" | safeHTML }}</strong></h3>
-        <h4>{{i18n "partnerships-time-commitment" | safeHTML }}</h4>
-        <p>{{i18n "partnerships-exploration-time-commitment" | safeHTML }}</p>
-        <h4>{{i18n "partnerships-how-it-works" | safeHTML }}</h4>
-        <p>{{i18n "partnerships-exploration-description" | safeHTML}}</p>
+        <h3><strong>{{i18n "partnerships-exploration"}}</strong></h3>
+        <h4>{{i18n "partnerships-time-commitment"}}</h4>
+        <p>{{i18n "partnerships-exploration-time-commitment"}}</p>
+        <h4>{{i18n "partnerships-how-it-works"}}</h4>
+        <p>{{i18n "partnerships-exploration-description"}}</p>
 
         <!-- Embedded Teams -->
-        <h3><strong>{{i18n "partnerships-embedded-team" | safeHTML }}</strong></h3>
-        <h4>{{i18n "partnerships-time-commitment" | safeHTML }}</h4>
-        <p>{{i18n "partnerships-embedded-team-time-commitment" | safeHTML }}</p>
-        <h4>{{i18n "partnerships-how-it-works" | safeHTML }}</h4>
-        <p>{{i18n "partnerships-embedded-team-description" | safeHTML }}</p>
+        <h3><strong>{{i18n "partnerships-embedded-team"}}</strong></h3>
+        <h4>{{i18n "partnerships-time-commitment"}}</h4>
+        <p>{{i18n "partnerships-embedded-team-time-commitment"}}</p>
+        <h4>{{i18n "partnerships-how-it-works"}}</h4>
+        <p>{{i18n "partnerships-embedded-team-description"}}</p>
 
       </div>
     </div>

--- a/layouts/section/partnerships.html
+++ b/layouts/section/partnerships.html
@@ -25,23 +25,25 @@
 
         <h2>{{i18n "partnerships-three-ways-heading" | safeHTML }}</h2>
         <!-- Consultation -->
-        <p>
-          <strong>{{i18n "partnerships-consultation" | safeHTML }}</strong><br>
-          {{i18n "partnerships-time-commitment" | safeHTML }}<br> 
-          {{i18n "partnerships-consultation-time-commitment" | safeHTML }}
-        </p>
-    
-        <p>{{i18n "partnerships-how-it-works" | safeHTML }}<br> {{i18n "partnerships-consultation-description" | safeHTML }}</p>
+        <h3><strong>{{i18n "partnerships-consultation" | safeHTML }}</strong></h3>
+        <h4>{{i18n "partnerships-time-commitment" | safeHTML }}</h4>
+        <p>{{i18n "partnerships-consultation-time-commitment" | safeHTML }}</p>
+        <h4>{{i18n "partnerships-how-it-works" | safeHTML }}</h4>
+        <p>{{i18n "partnerships-consultation-description" | safeHTML }}</p>
 
         <!-- Exploration -->
-        <p><strong>{{i18n "partnerships-exploration" | safeHTML }}</strong></p>
-        <p>{{i18n "partnerships-time-commitment" | safeHTML }}<br>{{i18n "partnerships-exploration-time-commitment" | safeHTML }}</p>
-        <p>{{i18n "partnerships-how-it-works" | safeHTML }}<br>{{i18n "partnerships-exploration-description" | safeHTML}}</p>
+        <h3><strong>{{i18n "partnerships-exploration" | safeHTML }}</strong></h3>
+        <h4>{{i18n "partnerships-time-commitment" | safeHTML }}</h4>
+        <p>{{i18n "partnerships-exploration-time-commitment" | safeHTML }}</p>
+        <h4>{{i18n "partnerships-how-it-works" | safeHTML }}</h4>
+        <p>{{i18n "partnerships-exploration-description" | safeHTML}}</p>
 
         <!-- Embedded Teams -->
-        <p><strong>{{i18n "partnerships-embedded-team" | safeHTML }}</strong></p>
-        <p>{{i18n "partnerships-time-commitment" | safeHTML }}<br>{{i18n "partnerships-embedded-team-time-commitment" | safeHTML }}</p>
-        <p>{{i18n "partnerships-how-it-works" | safeHTML }}<br>{{i18n "partnerships-embedded-team-description" | safeHTML }}</p>
+        <h3><strong>{{i18n "partnerships-embedded-team" | safeHTML }}</strong></h3>
+        <h4>{{i18n "partnerships-time-commitment" | safeHTML }}</h4>
+        <p>{{i18n "partnerships-embedded-team-time-commitment" | safeHTML }}</p>
+        <h4>{{i18n "partnerships-how-it-works" | safeHTML }}</h4>
+        <p>{{i18n "partnerships-embedded-team-description" | safeHTML }}</p>
 
       </div>
     </div>
@@ -49,11 +51,11 @@
 </section>
 
 <section class='bg-yellow-full'>
-  <div class='row container'>
-    <div class='col-md-7 col-xs-12'>
+  <div class="partnerships-contact">
+    <div>
       <p>{{ i18n "partnerships-interested-in-chatting" }}</p>
     </div>
-    <div class='col-md-5 col-xs-12'>
+    <div>
       <a href={{ i18n "partnerships-contact-us-link" }} id="partnerships-contact-us-link">
         {{ i18n "partnerships-contact-us" }}
       </a>

--- a/layouts/section/partnerships.html
+++ b/layouts/section/partnerships.html
@@ -10,38 +10,42 @@
     </div>
   </div>
 </section>
-<section class="bg-med-grey">
-<div class="container">
-  <div class="row">
-    <div class="col-xs-12">
-      <h2 class="partnership-title">{{i18n "partnerships-what-we-can-help-title" | safeHTML}}</h2>
-      <p> {{i18n "partnerships-what-we-can-help-1st" | safeHTML }}</p>
-      <ul>
-        <li>{{i18n "partnerships-what-we-can-help-list-1" | safeHTML }}</li>
-        <li>{{i18n "partnerships-what-we-can-help-list-2" | safeHTML }}</li>
-        <li>{{i18n "partnerships-what-we-can-help-list-3" | safeHTML }}</li>
-        <li>{{i18n "partnerships-what-we-can-help-list-4" | safeHTML }}</li>
-      </ul>
+<section class="partnerships-info bg-med-grey">
+  <div class="container">
+    <div class="row">
+      <div class="col-xs-12">
+        <h2 class="partnership-title">{{i18n "partnerships-what-we-can-help-title" | safeHTML}}</h2>
+        <p> {{i18n "partnerships-what-we-can-help-1st" | safeHTML }}</p>
+        <ul>
+          <li>{{i18n "partnerships-what-we-can-help-list-1" | safeHTML }}</li>
+          <li>{{i18n "partnerships-what-we-can-help-list-2" | safeHTML }}</li>
+          <li>{{i18n "partnerships-what-we-can-help-list-3" | safeHTML }}</li>
+          <li>{{i18n "partnerships-what-we-can-help-list-4" | safeHTML }}</li>
+        </ul>
 
-      <h2>{{i18n "partnerships-three-ways-heading" | safeHTML }}</h2>
-      <!-- Consultation -->
-      <p><strong>{{i18n "partnerships-consultation" | safeHTML }}</strong></p>
-      <p>{{i18n "partnerships-time-commitment" | safeHTML }}<br> {{i18n "partnerships-consultation-time-commitment" | safeHTML }}</p>
-      <p>{{i18n "partnerships-how-it-works" | safeHTML }}<br> {{i18n "partnerships-consultation-description" | safeHTML }}</p>
+        <h2>{{i18n "partnerships-three-ways-heading" | safeHTML }}</h2>
+        <!-- Consultation -->
+        <p>
+          <strong>{{i18n "partnerships-consultation" | safeHTML }}</strong><br>
+          {{i18n "partnerships-time-commitment" | safeHTML }}<br> 
+          {{i18n "partnerships-consultation-time-commitment" | safeHTML }}
+        </p>
+    
+        <p>{{i18n "partnerships-how-it-works" | safeHTML }}<br> {{i18n "partnerships-consultation-description" | safeHTML }}</p>
 
-      <!-- Exploration -->
-      <p><strong>{{i18n "partnerships-exploration" | safeHTML }}</strong></p>
-      <p>{{i18n "partnerships-time-commitment" | safeHTML }}<br>{{i18n "partnerships-exploration-time-commitment" | safeHTML }}</p>
-      <p>{{i18n "partnerships-how-it-works" | safeHTML }}<br>{{i18n "partnerships-exploration-description" | safeHTML }}</p>
+        <!-- Exploration -->
+        <p><strong>{{i18n "partnerships-exploration" | safeHTML }}</strong></p>
+        <p>{{i18n "partnerships-time-commitment" | safeHTML }}<br>{{i18n "partnerships-exploration-time-commitment" | safeHTML }}</p>
+        <p>{{i18n "partnerships-how-it-works" | safeHTML }}<br>{{i18n "partnerships-exploration-description" | safeHTML}}</p>
 
-      <!-- Embedded Teams -->
-      <p><strong>{{i18n "partnerships-embedded-team" | safeHTML }}</strong></p>
-      <p>{{i18n "partnerships-time-commitment" | safeHTML }}<br>{{i18n "partnerships-embedded-team-time-commitment" | safeHTML }}</p>
-      <p>{{i18n "partnerships-how-it-works" | safeHTML }}<br>{{i18n "partnerships-embedded-team-description" | safeHTML }}</p>
+        <!-- Embedded Teams -->
+        <p><strong>{{i18n "partnerships-embedded-team" | safeHTML }}</strong></p>
+        <p>{{i18n "partnerships-time-commitment" | safeHTML }}<br>{{i18n "partnerships-embedded-team-time-commitment" | safeHTML }}</p>
+        <p>{{i18n "partnerships-how-it-works" | safeHTML }}<br>{{i18n "partnerships-embedded-team-description" | safeHTML }}</p>
 
+      </div>
     </div>
   </div>
-</div>
 </section>
 
 <section class='bg-yellow-full'>
@@ -50,7 +54,7 @@
       <p>{{ i18n "partnerships-interested-in-chatting" }}</p>
     </div>
     <div class='col-md-5 col-xs-12'>
-      <a href={{ i18n "partnerships-contact-us-link"}} id="partnerships-contact-us-link">
+      <a href={{ i18n "partnerships-contact-us-link" }} id="partnerships-contact-us-link">
         {{ i18n "partnerships-contact-us" }}
       </a>
     </div>
@@ -70,13 +74,13 @@
   <div class='container'>
     <div class='row equal'>
       {{ range $elem_index, $elem_val := $products }}
-        {{ if and (ne $elem_index 0) (eq (mod $elem_index 2) 0) }}
-          </div>
-          <div class='row equal'>
-        {{ end }}
-        <div class='col-md-6 col-xs-12'>
-          {{ partial "partnerships_product_item" $elem_val }}
-        </div>
+      {{ if and (ne $elem_index 0) (eq (mod $elem_index 2) 0) }}
+    </div>
+    <div class='row equal'>
+      {{ end }}
+      <div class='col-md-6 col-xs-12'>
+        {{ partial "partnerships_product_item" $elem_val }}
+      </div>
       {{ end }}
     </div>
   </div>


### PR DESCRIPTION
# Summary | Résumé

Partnerships page redesign after usability testing.

This includes content changes and styling tweaks. There's also been a change to the partnership cards. "In flight" and "Past" partnerships have been removed and are all consolidated together.

[Figma](https://www.figma.com/file/LW1JsT0h3IY2trMHdIVDQc/CDS-Website-Revamp-(Work-in-Progress)?node-id=1616%3A11873)