### PR TITLE
changed management name

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -44,8 +44,8 @@ in-flight:
   other: "In flight products"
 key-contacts:
   other: "Key contacts"
-senior_management:
-  other: "Senior Management"
+leadership:
+  other: "Leadership"
 design:
   other: "Design"
 design_research:

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -40,8 +40,8 @@ in-flight:
   other: "Produits en cours"
 key-contacts:
   other: "Contacts principaux"
-senior_management:
-  other: "Équipe de la direction"
+leadership:
+  other: "Direction"
 design:
   other: "Conception"
 design_research:

--- a/layouts/section/meet-the-team.html
+++ b/layouts/section/meet-the-team.html
@@ -4,7 +4,7 @@
 
   <div class="meet-us-container container">
     <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-      <h2 class="heading">{{ i18n "senior_management" }}</h2>
+      <h2 class="heading">{{ i18n "leadership" }}</h2>
     </div>
     <div class="row team-listing wb-eqht ">
     {{ range $member := .Site.Data.team.exec }}


### PR DESCRIPTION
# Summary | Résumé

Updated heading for Senior Management to "Leadership" for EN and FR
<img width="1331" alt="Screen Shot 2021-09-23 at 11 29 49 AM" src="https://user-images.githubusercontent.com/33768337/134537776-62a41b6c-8a50-4977-b909-e6fec8e556de.png">

<img width="1257" alt="Screen Shot 2021-09-23 at 11 29 37 AM" src="https://user-images.githubusercontent.com/33768337/134537784-1db8276c-b526-4e27-b42c-278644d7146c.png">


