### PR TITLE
Capitalize "P" in WordPress in dev posting

### DIFF
--- a/content/en/careers/positions/full-stack-software-developer-mvp.md
+++ b/content/en/careers/positions/full-stack-software-developer-mvp.md
@@ -26,7 +26,7 @@ Based on your level of experience developers are classified as [CS-03, CS-04 or 
 
 **We’ll evaluate you based on:**
 
-- Creating and delivering software using modern web technologies and platforms such as React, Typescript, PHP, Wordpress, CSS. Nice-to-haves include Docker, Terraform, AWS. 
+- Creating and delivering software using modern web technologies and platforms such as React, Typescript, PHP, WordPress, CSS. Nice-to-haves include Docker, Terraform, AWS. 
 - Creating and delivering inclusive and accessible (WCAG) software
 - Employing or promoting site reliability/devops practices
 - Championing, defining and improving team standards for code style, test automation, maintainability, and best practices for a distributed, cloud-based system

--- a/content/fr/careers/positions/développeur-ou-développeuse-généraliste-mvp.md
+++ b/content/fr/careers/positions/développeur-ou-développeuse-généraliste-mvp.md
@@ -26,7 +26,7 @@ Selon votre niveau d’expérience, les postes de développeur et développeuse 
 
 **Votre candidature sera évaluée en fonction des compétences suivantes :**
 
-- Création et livraison de logiciels à l’aide des technologies et des plateformes Web modernes comme React, Typescript, PHP, Wordpress, CSS. Une connaissance des technologies Docker, Terraform et AWS est un atout. 
+- Création et livraison de logiciels à l’aide des technologies et des plateformes Web modernes comme React, Typescript, PHP, WordPress, CSS. Une connaissance des technologies Docker, Terraform et AWS est un atout. 
 - Création et livraison de logiciels inclusifs et accessibles (WCAG).
 - Mise en pratique ou promotion des pratiques de fiabilité des sites ou des opérations de développement.
 - Promotion, établissement et amélioration de normes d’équipe pour le style de codage, l’automatisation des tests, la facilité d’entretien et les meilleures pratiques en matière de systèmes d’infonuagique décentralisés.


### PR DESCRIPTION
This is a _whole thing_ in the WordPress community :) There's even [a function to automate this fix built-in to any WordPress sites](https://developer.wordpress.org/reference/functions/capital_p_dangit/).