### PR TITLE
tools and resources tab fix

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -26,7 +26,7 @@ languages:
           name: Partnerships
           url: /partnerships/
           weight: 2
-        - identifier: tools
+        - identifier: Tools and resources
           name: Tools and resources
           url: /tools-and-resources/
           weight: 3

--- a/content/en/tools-and-resources/_index.html
+++ b/content/en/tools-and-resources/_index.html
@@ -1,6 +1,6 @@
 ---
 type: section
-title: tools
+title: Tools and resources
 layout: tools-and-resources
 aliases: [/outils-et-ressources/]
 ---

--- a/content/fr/tools-and-resources/_index.html
+++ b/content/fr/tools-and-resources/_index.html
@@ -1,6 +1,6 @@
 ---
 type: section
-title: outils
+title: Outils et ressources
 layout: tools-and-resources
 aliases: [/tools-and-resources/]
 url: /outils-et-ressources/


### PR DESCRIPTION
# Summary | Résumé

Quick fix for Tools and resources tab. When Active the tab title only said: 'tools'