### PR TITLE
Embedded Teams Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Powered by [Strapi](https://strapi.io/). The Strapi instance for this website ca
 
 Please visit our [contribution guidelines](CONTRIBUTING.md) to learn how to best make updates to CMS managed content.
 
-## ---------------------------------------------------------------------
+## --------------------------------------------------------------------
 
 # Site Web du Service numérique canadien : [numerique.canada.ca](https://numerique.canada.ca)
 

--- a/assets/sass/cds/_base.scss
+++ b/assets/sass/cds/_base.scss
@@ -269,4 +269,11 @@ ol ul, ol ol, ul ul, ul ol {
 	margin-top: 1rem;
 }
 
-
+.example_box {
+	background: $medium-grey;
+	padding-top: 30px;
+	padding-bottom: 5px;
+	padding-left: 30px;
+	padding-right: 30px;
+	margin-bottom: 30px;
+}

--- a/content/en/partnerships-birch.html
+++ b/content/en/partnerships-birch.html
@@ -1,0 +1,10 @@
+---
+type: section
+layout: page
+title: CDS Partnerships - Embedded Team - Birch
+aliases: [/partenariats-bouleau/]
+url: /partnerships-birch/
+---
+<section>
+  <p>Birch Page</p>
+</section>

--- a/content/en/partnerships-embedded-teams.html
+++ b/content/en/partnerships-embedded-teams.html
@@ -7,7 +7,7 @@ url: /partnerships-embedded-teams/
 ---
 <section>
   <p>
-    Embedded Teams aim to change how your organization designs and delivers services through hands-on, co-creation with your teams. We coach by delivering with you, not for you. In other words, we're full-time coaches and consultants, not staff augmentation.
+    Embedded Teams change how your organization designs and delivers services through hands-on, co-creation with your teams. We coach by delivering with you, not for you. In other words, we're full-time coaches and consultants, not staff augmentation.
   </p>
   <p>
     Our teams are staffed with experienced people holding practical knowledge in UX design, user research, software development, product management, operations (i.e. devops, change management, gov ops, etc.). Prior to and during their CDS tenure, they've shipped digital services at scale in the private sector and within government.
@@ -37,19 +37,24 @@ url: /partnerships-embedded-teams/
   </ul>
 
   <div class="bg-med-grey">
-    <h2>Example</h2>
+    <h2>Example Engagement</h2>
     <p>
-      The Department of Widgets Canada (or, Widgets Canada) wants to encourage gizmo buying for the betterment of society. They've decided to launch a grant program that gives money to families to purchase their first gizmo. They'd like to allow people to register for the Gizmo Grant online, but last time they did something like this for contraption grants, it went very poorly. The site went down often, users had trouble using it, and they wound up with an unmanagable backlog of grant applications and emails to process.
+      The Department of Widgets Canada (or, Widgets Canada) wants to encourage gizmo buying for the betterment of society. They are launching a grant program that gives money to families to purchase their first gizmo. They want people to register for the Gizmo Grant online, but last time they did something like this for the Contraption Grant, it went very poorly. The site went down often, users had trouble using it, and they wound up with an unmanagable backlog of grant applications and emails to process.
     </p>
 
     <p>
-      Within WC, the program office and the IT group approach CDS to see if they can get some experts to help. CDS has a one hour intake meeting to understand the request. Then later that month, an Embedded Team conducts a discovery sprint to better understand the goals and challenges to delivery of the Gizmo Grant.
+      Widgets Canada's Gizmo Program Office reaches out to CDS to get expert help. Together, CDS and Widgets Canada have a one hour <strong>Intake Meeting</strong> to better understand the request, define desired outcomes, and what Widget Canada's current capacity and capabilities are. Later that week, CDS decides to help out with an Embedded Team.
+    </p>
+    
+    <p>
+      The Embedded Team begins by doing a two week <strong>Discovery Sprint</strong> (note: calling this by a common term rather than the branded Exploration). This allows the team to understand where the service is today, what challenges exist, and form an informed hypothesis on how to improve the service and ways of working.
+    </p>
+
+    <p>
+      The discovery report finds that the proposed website isn't accessible, may not be able to handle the traffic to it, and that the program and IT offices are having trouble working together. This is communicated back to Widgets Canada leadership and CDS asks if help is desired working on one or more of these challenges. Widgets Canada does want help, and agrees to CDS's conditions to provide program and IT individual contributors to work side-by-side with CDS and to clear blockers that may arise while trying new approaches. This arrangement is outlined in a short <strong>Partnerships Agreement</strong> document, which creates a unified Widget Canada and CDS team to work the defined scope. This joint team is able to make decisions and implement new processes and code for the Gizmo Grant.
     </p>
     <p>
-      The discovery report finds that the proposed website isn't accessible, may not be able to handle the traffic to it, and that the program and IT officer are having trouble working together. This is communicated back to Widgets Canada and CDS asks if they would like help working on one or more of these challenges. WC does want help, and agrees to CDS's conditions to provide program and IT individual contributors to work side-by-side with CDS and clear blockers. This simultaneously helps get new skills to the individual contributors and creates rapid progress against the program challenges.
-    </p>
-    <p>
-      CDS's Embedded Team starts off working for 10-20 hours a week with Widgets (MORE COMING).
+      During this next phase, Widgets Canada and CDS <strong>Co-create New Processes and Software</strong>. By working together hands-on, Gizmo Grant program officers learn how to design a web page better from a CDS designer and members from the IT group learn how to deploy the grant application software to the cloud from a CDS software developer. Co-creating together not only teaches new technical skills and collaborative tactics, but the Gizmo Grant program's challenges are addressed and risk of failure are reduced.
     </p>
   </div>
 

--- a/content/en/partnerships-embedded-teams.html
+++ b/content/en/partnerships-embedded-teams.html
@@ -7,31 +7,40 @@ url: /partnerships-embedded-teams/
 ---
 <section>
   <p>
-    Embedded Teams aim to change how your organization designs and delivers services through hands-on, co-creation with
-    your teams. These teams are staffed with experienced people holding practical knowledge in UX design, user research,
-    software development, technical operations (i.e. devops), and product management. Prior to and during their CDS
-    tenure, they've shipped digital services at scale in the private sector and within government.
+    Embedded Teams aim to change how your organization designs and delivers services through hands-on, co-creation with your teams. We coach by delivering with you, not for you. In other words, we're full-time coaches and consultants, not staff augmentation.
+  </p>
+  <p>
+    Our teams are staffed with experienced people holding practical knowledge in UX design, user research, software development, technical operations (i.e. devops), and product management. Prior to and during their CDS tenure, they've shipped digital services at scale in the private sector and within government.
   </p>
 
-  <h2>How do these teams work?</h2>
+    <div class="cta-wrapper">
+      <div class="cta cta--grey-bg cta--brown col-sm-12">
+        <div class="cta__content">
+          <h2 class="cta__content-title">Want an Embedded Team to help?</h2>
+        </div>
+        <div class="cta__link">
+          <a href="https://forms-formulaires.alpha.canada.ca/id/3">Contact us<svg width="16" height="16" viewBox="0 0 16 16"
+              xmlns="http://www.w3.org/2000/svg">
+              <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+            </svg></a>
+        </div>
+      </div>
+    </div>
+
+  <h2>How do Embedded Teams work?</h2>
   <ol>
     <li>
-      Either your contacted us or we contacted you, but either way we'll chat to establish interest in partnering and on
-      what service.
+      <strong>Intake:</strong> Either you contacted us or we contacted you, but either way we'll establish interest in partnering and on what service.
     </li>
     <li>
-      We'll conduct a discovery sprint for a week or two to learn more about your service and how your organization is
-      setup to deliver it. This will give us a better idea of if and how we can help, who we'd have to work with, and
-      how to measure progress.
+      <strong>Discovery:</strong> We'll conduct a discovery sprint for a week or two to learn more about your service and how your organization is setup to deliver it. This will give us a better idea of if and how we can help, who we'd have to work with, and how to measure progress.
     </li>
     <li>
-      Based on the discovery sprint we'll decide whether or not we can meaningfully improve your service. If so, we'll
-      figure out how to work together longer. If not, we'll leave you with a recommendations report on how your service
+      <strong>Decide how to partner:</strong> Based on the discovery sprint we'll decide whether or not we can meaningfully improve your service. If so, we'll figure out how to work together longer. If not, we'll leave you with a recommendations report on how your service
       might be improved.
     </li>
     <li>
-      Assuming we're working together longer, we'll start working side-by-side folks your program and IT groups to teach
-      what we know.
+      <strong>Co-create:</strong> Assuming we're working together longer, we'll start working side-by-side folks your program and IT groups to teach what we know in a hands-on way. Because our work is optimized to leave you and your team with new ways of working, co-creation is the optimal way of working here. 
     </li>
   </ol>
 
@@ -49,50 +58,63 @@ url: /partnerships-embedded-teams/
       The discovery report finds that the proposed website isn't accessible, may not be able to handle the traffic to it, and that the program and IT officer are having trouble working together. This is communicated back to Widgets Canada and CDS asks if they would like help working on one or more of these challenges. WC does want help, and agrees to CDS's conditions to provide program and IT individual contributors to work side-by-side with CDS and clear blockers. This simultaneously helps get new skills to the individual contributors and creates rapid progress against the program challenges.
     </p>
     <p>
-      CDS's Embedded Team starts off working for 10-20 hours a week with Widgets
+      CDS's Embedded Team starts off working for 10-20 hours a week with Widgets (MORE COMING).
     </p>
   </div>
 
-  <div class="cta-wrapper">
-    <div class="cta cta--grey-bg cta--brown col-sm-12">
-      <div class="cta__content">
-        <h2 class="cta__content-title">Interested in joining us?</h2>
-      </div>
-      <div class="cta__link">
-        <a href="/careers/">Current openings<svg width="16" height="16" viewBox="0 0 16 16"
-            xmlns="http://www.w3.org/2000/svg">
-            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
-          </svg></a>
-      </div>
-    </div>
+  <h2>What Embedded Teams do</h2>
+  <p>
+    (MORE COMING)
+  </p>
+
+  <h2>What Embedded Teams do <em>not</em> do?</h2>
+  <p>
+    (MORE COMING)
+  </p>
 
 
+    <h2>Teams</h2>
     <div class="cta-row">
-      <div class="cta cta--grey-bg cta--pink col-sm-12 col-md-6">
-        <div class="cta__content">
-          <h2 class="cta__content-title">Learn more about how we work</h2>
-          <p>Visit our blog, where we share stories and learnings from our work.</p>
-        </div>
-        <div class="cta__link">
-          <a href="/blog/">Visit our blog<svg width="16" height="16" viewBox="0 0 16 16"
-              xmlns="http://www.w3.org/2000/svg">
-              <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
-            </svg></a>
-        </div>
-      </div>
-
       <div class="cta cta--grey-bg cta--green col-sm-12 col-md-6">
         <div class="cta__content">
-          <h2 class="cta__content-title">Looking for ways to work better?</h2>
-          <p>Check out our resources for designers, developers, product managers and researchers working on agile,
-            multi-disciplinary teams.</p>
+          <h2 class="cta__content-title">Birch</h2>
+          <p>
+            (BUZZWORDS BIRCH IS GOOD AT)
+          </p>
         </div>
         <div class="cta__link">
-          <a href="/tools-and-resources/">Resources<svg width="16" height="16" viewBox="0 0 16 16"
+          <a href="/partnerships-birch">Meet Birch<svg width="16" height="16" viewBox="0 0 16 16"
+              xmlns="http://www.w3.org/2000/svg">
+              <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+            </svg></a>
+        </div>
+      </div>
+      <div class="cta cta--grey-bg cta--pink col-sm-12 col-md-6">
+        <div class="cta__content">
+          <h2 class="cta__content-title">Red Pine</h2>
+          <p>
+            (BUZZWORDS RED PINE IS GOOD AT)
+          </p>
+        </div>
+        <div class="cta__link">
+          <a href="/partnerships-red-pine/">Meet Red Pine<svg width="16" height="16" viewBox="0 0 16 16"
               xmlns="http://www.w3.org/2000/svg">
               <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
             </svg></a>
         </div>
       </div>
     </div>
-  </div>
+
+    <div class="cta-wrapper">
+      <div class="cta cta--grey-bg cta--brown col-sm-12">
+        <div class="cta__content">
+          <h2 class="cta__content-title">Want an Embedded Team to help?</h2>
+        </div>
+        <div class="cta__link">
+          <a href="https://forms-formulaires.alpha.canada.ca/id/3">Contact us<svg width="16" height="16" viewBox="0 0 16 16"
+              xmlns="http://www.w3.org/2000/svg">
+              <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+            </svg></a>
+        </div>
+      </div>
+    </div>

--- a/content/en/partnerships-embedded-teams.html
+++ b/content/en/partnerships-embedded-teams.html
@@ -36,7 +36,7 @@ url: /partnerships-embedded-teams/
     <li>(OTHER THINGS?)</li>
   </ul>
 
-  <div class="bg-med-grey">
+  <div class="example_box">
     <h2>Example Engagement</h2>
     <p>
       The Department of Widgets Canada (or, Widgets Canada) wants to encourage gizmo buying for the betterment of society. They are launching a grant program that gives money to families to purchase their first gizmo. They want people to register for the Gizmo Grant online, but last time they did something like this for the Contraption Grant, it went very poorly. The site went down often, users had trouble using it, and they wound up with an unmanagable backlog of grant applications and emails to process.
@@ -87,6 +87,20 @@ url: /partnerships-embedded-teams/
     <li><strong>Participation:</strong> Since we're working with you, not building for you -- we'll need half-to-full-time participation of a cross functional set of staff. This is how we coach and help. This means empowering a small groups of folks across multiple groups that is empowered to make decisions and perform relevant actions.</li>
   </ul>
 
+  <div class="cta-wrapper">
+    <div class="cta cta--grey-bg cta--brown col-sm-12">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Want our help?</h2>
+      </div>
+      <div class="cta__link">
+        <a href="https://forms-formulaires.alpha.canada.ca/id/3">Contact us<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
+      </div>
+    </div>
+  </div>
+  
   <h2>Teams</h2>
   <div class="cta-row">
     <div class="cta cta--grey-bg cta--green col-sm-12 col-md-6">
@@ -112,20 +126,6 @@ url: /partnerships-embedded-teams/
       </div>
       <div class="cta__link">
         <a href="/partnerships-red-pine/">Meet Red Pine<svg width="16" height="16" viewBox="0 0 16 16"
-            xmlns="http://www.w3.org/2000/svg">
-            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
-          </svg></a>
-      </div>
-    </div>
-  </div>
-  
-  <div class="cta-wrapper">
-    <div class="cta cta--grey-bg cta--brown col-sm-12">
-      <div class="cta__content">
-        <h2 class="cta__content-title">Want our help?</h2>
-      </div>
-      <div class="cta__link">
-        <a href="https://forms-formulaires.alpha.canada.ca/id/3">Contact us<svg width="16" height="16" viewBox="0 0 16 16"
             xmlns="http://www.w3.org/2000/svg">
             <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
           </svg></a>

--- a/content/en/partnerships-embedded-teams.html
+++ b/content/en/partnerships-embedded-teams.html
@@ -1,87 +1,98 @@
 ---
 type: section
 layout: page
-title: Partnerships Embedded Teams
+title: Partnerships - Embedded Teams
 aliases: [/partenariats-equipes-integrees/]
 url: /partnerships-embedded-teams/
 ---
-<section class="page--outer-container-padding our-values">
-  <p>Our mission is to change government to serve people better. We work with
-    federal partners to build better services for the public and to help public
-    servants doing this important work.</p>
+<section>
+  <p>
+    Embedded Teams aim to change how your organization designs and delivers services through hands-on, co-creation with
+    your teams. These teams are staffed with experienced people holding practical knowledge in UX design, user research,
+    software development, technical operations (i.e. devops), and product management. Prior to and during their CDS
+    tenure, they've shipped digital services at scale in the private sector and within government.
+  </p>
 
-  <p>We strive to live these values in everything we do at CDS. They guide our
-    work, shape our decisions, our behaviour, and our hiring.</p>
+  <h2>How do these teams work?</h2>
+  <ol>
+    <li>
+      Either your contacted us or we contacted you, but either way we'll chat to establish interest in partnering and on
+      what service.
+    </li>
+    <li>
+      We'll conduct a discovery sprint for a week or two to learn more about your service and how your organization is
+      setup to deliver it. This will give us a better idea of if and how we can help, who we'd have to work with, and
+      how to measure progress.
+    </li>
+    <li>
+      Based on the discovery sprint we'll decide whether or not we can meaningfully improve your service. If so, we'll
+      figure out how to work together longer. If not, we'll leave you with a recommendations report on how your service
+      might be improved.
+    </li>
+    <li>
+      Assuming we're working together longer, we'll start working side-by-side folks your program and IT groups to teach
+      what we know.
+    </li>
+  </ol>
 
-  <h2>Put people at the heart of our services</h2>
-  <p>Our work is fundamentally about people, not technology. We’re driven by
-    empathy and put people’s needs first. We build inclusivity, diversity, and
-    accessibility into everything we do — from the start, not as an
-    afterthought. We work hand in hand with the people who use and operate
-    services.</p>
 
-  <h2>Deliver measurable outcomes</h2>
-  <p>We work to achieve the greatest impact for the greatest number of people in
-    the greatest need. That means we focus on measuring how we help people and
-    create lasting change in government, not project milestones. We believe
-    hands-on delivery &mdash; actually designing and building services with
-    partners &mdash; develops skills and gets results.</p>
+  <div class="bg-med-grey">
+    <h2>Example</h2>
+    <p>
+      The Department of Widgets Canada (or, Widgets Canada) wants to encourage gizmo buying for the betterment of society. They've decided to launch a grant program that gives money to families to purchase their first gizmo. They'd like to allow people to register for the Gizmo Grant online, but last time they did something like this for contraption grants, it went very poorly. The site went down often, users had trouble using it, and they wound up with an unmanagable backlog of grant applications and emails to process.
+    </p>
 
-  <h2>Do the hard work to make things easier</h2>
-  <p>Making change in government is hard, but we love a good challenge. We do
-    not shy away from hard conversations but approach them with courage,
-    humility, compassion, and integrity. We untangle complexity so the people
-    using government services do not have to.</p>
-
-  <h2>Build for learning and iteration</h2>
-  <p>We believe that good services are built in small steps and with modular
-    parts that make it easier to pivot and course correct. The best way to find
-    out if a service works well is to put it in front of the people who use it,
-    so we continuously test, learn, document, and adjust.</p>
-
-  <h2>Work in the open to help clear a path</h2>
-  <p>We share our work, progress, and failures to help others learn from what we
-    do. We want to show what is possible and empower public servants to make it
-    a reality. We welcome the contributions and critiques that make our work
-    better.</p>
-
-  <h2>Take care of each other</h2>
-  <p>We’ve got each other’s backs — and those of our partners. We treat
-    resilience and wellness as organizational responsibilities, not just
-    character traits. We work to create a space where people feel they belong,
-    take risks, learn from mistakes, and speak openly.</p>
-</section>
-
-<div class="cta-wrapper">
-  <div class="cta cta--grey-bg cta--brown col-sm-12">
-    <div class="cta__content">
-      <h2 class="cta__content-title">Interested in joining us?</h2>
-    </div>
-    <div class="cta__link">
-      <a href="/careers/">Current openings<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M8 9H0V7H8V0L16 8L8 16V9Z"/></svg></a>
-    </div>
+    <p>
+      Within WC, the program office and the IT group approach CDS to see if they can get some experts to help. CDS has a one hour intake meeting to understand the request. Then later that month, an Embedded Team conducts a discovery sprint to better understand the goals and challenges to delivery of the Gizmo Grant.
+    </p>
+    <p>
+      The discovery report finds that the proposed website isn't accessible, may not be able to handle the traffic to it, and that the program and IT officer are having trouble working together. This is communicated back to Widgets Canada and CDS asks if they would like help working on one or more of these challenges. WC does want help, and agrees to CDS's conditions to provide program and IT individual contributors to work side-by-side with CDS and clear blockers. This simultaneously helps get new skills to the individual contributors and creates rapid progress against the program challenges.
+    </p>
+    <p>
+      CDS's Embedded Team starts off working for 10-20 hours a week with Widgets
+    </p>
   </div>
 
-
-  <div class="cta-row">
-    <div class="cta cta--grey-bg cta--pink col-sm-12 col-md-6">
+  <div class="cta-wrapper">
+    <div class="cta cta--grey-bg cta--brown col-sm-12">
       <div class="cta__content">
-        <h2 class="cta__content-title">Learn more about how we work</h2>
-        <p>Visit our blog, where we share stories and learnings from our work.</p>
+        <h2 class="cta__content-title">Interested in joining us?</h2>
       </div>
       <div class="cta__link">
-        <a href="/blog/">Visit our blog<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M8 9H0V7H8V0L16 8L8 16V9Z"/></svg></a>
+        <a href="/careers/">Current openings<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
       </div>
     </div>
 
-    <div class="cta cta--grey-bg cta--green col-sm-12 col-md-6">
-      <div class="cta__content">
-        <h2 class="cta__content-title">Looking for ways to work better?</h2>
-        <p>Check out our resources for designers, developers, product managers and researchers working on agile, multi-disciplinary teams.</p>
+
+    <div class="cta-row">
+      <div class="cta cta--grey-bg cta--pink col-sm-12 col-md-6">
+        <div class="cta__content">
+          <h2 class="cta__content-title">Learn more about how we work</h2>
+          <p>Visit our blog, where we share stories and learnings from our work.</p>
+        </div>
+        <div class="cta__link">
+          <a href="/blog/">Visit our blog<svg width="16" height="16" viewBox="0 0 16 16"
+              xmlns="http://www.w3.org/2000/svg">
+              <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+            </svg></a>
+        </div>
       </div>
-      <div class="cta__link">
-        <a href="/tools-and-resources/">Resources<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M8 9H0V7H8V0L16 8L8 16V9Z"/></svg></a>
+
+      <div class="cta cta--grey-bg cta--green col-sm-12 col-md-6">
+        <div class="cta__content">
+          <h2 class="cta__content-title">Looking for ways to work better?</h2>
+          <p>Check out our resources for designers, developers, product managers and researchers working on agile,
+            multi-disciplinary teams.</p>
+        </div>
+        <div class="cta__link">
+          <a href="/tools-and-resources/">Resources<svg width="16" height="16" viewBox="0 0 16 16"
+              xmlns="http://www.w3.org/2000/svg">
+              <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+            </svg></a>
+        </div>
       </div>
     </div>
   </div>
-</div>

--- a/content/en/partnerships-embedded-teams.html
+++ b/content/en/partnerships-embedded-teams.html
@@ -1,7 +1,7 @@
 ---
 type: section
 layout: page
-title: Partnerships - Embedded Teams
+title: CDS Partnerships - Embedded Teams
 aliases: [/partenariats-equipes-integrees/]
 url: /partnerships-embedded-teams/
 ---
@@ -15,6 +15,72 @@ url: /partnerships-embedded-teams/
   <p>
     Our services are free to other Government of Canada departments (i.e. we are <em>not</em> cost recoverable), but we <em>will</em> need access to your time, people, data, and service users AND an open mind to try new things.
   </p>
+
+  <h2>What might we do with you?</h2>
+  <ul>
+    <li>Map out your service to understand user touchpoints, challenges, bottlenecks, etc.</li>
+    <li>Redesign your web application, website, or interactions with users based on those users needs</li>
+    <li>Introduce modern product and project management tactics</li>
+    <li>Migrate to the cloud and adopt DevOps culture</li>
+    <li>Revise your security processes to decrease risk and be helpful rather than just blindly blocking everything</li>
+    <li>Hire or train your upcoming digital service team</li>
+    <li>Examine how your org structure is impacting delivery</li>
+    <li>Meet and get to know the users of your service</li>
+    <li>Rescue a distressed service</li>
+    <li>Make your services more accessible and inclusive</li>
+  </ul>
+
+  <h2>What will we not do?</h2>
+  <ul>
+    <li>Code an app <em>for</em>, not with you</li>
+    <li>(OTHER THINGS?)</li>
+  </ul>
+
+  <div class="bg-med-grey">
+    <h2>Example</h2>
+    <p>
+      The Department of Widgets Canada (or, Widgets Canada) wants to encourage gizmo buying for the betterment of society. They've decided to launch a grant program that gives money to families to purchase their first gizmo. They'd like to allow people to register for the Gizmo Grant online, but last time they did something like this for contraption grants, it went very poorly. The site went down often, users had trouble using it, and they wound up with an unmanagable backlog of grant applications and emails to process.
+    </p>
+
+    <p>
+      Within WC, the program office and the IT group approach CDS to see if they can get some experts to help. CDS has a one hour intake meeting to understand the request. Then later that month, an Embedded Team conducts a discovery sprint to better understand the goals and challenges to delivery of the Gizmo Grant.
+    </p>
+    <p>
+      The discovery report finds that the proposed website isn't accessible, may not be able to handle the traffic to it, and that the program and IT officer are having trouble working together. This is communicated back to Widgets Canada and CDS asks if they would like help working on one or more of these challenges. WC does want help, and agrees to CDS's conditions to provide program and IT individual contributors to work side-by-side with CDS and clear blockers. This simultaneously helps get new skills to the individual contributors and creates rapid progress against the program challenges.
+    </p>
+    <p>
+      CDS's Embedded Team starts off working for 10-20 hours a week with Widgets (MORE COMING).
+    </p>
+  </div>
+
+  <h2>How do Embedded Teams work?</h2>
+  <ol>
+    <li>
+      <strong>Intake:</strong> Either you contacted us or we contacted you, but either way we'll establish interest in partnering and on what service.
+    </li>
+    <li>
+      <strong>Discovery:</strong> We'll conduct a discovery sprint for a week or two to learn more about your service and how your organization is setup to deliver it. This will give us a better idea of if and how we can help, who we'd have to work with, and how to measure progress.
+    </li>
+    <li>
+      <strong>Decide how to partner:</strong> Based on the discovery sprint we'll decide whether or not we can meaningfully improve your service and ways of working. If so, we'll figure out how to work together longer. If not, we'll leave you with a recommendations report on how your service
+      might be improved.
+    </li>
+    <li>
+      <strong>Co-create:</strong> Assuming we're working together longer, we'll start working side-by-side with your program and IT groups. This enables us to teach what we know in a hands-on way, and to ship improvements to your service iteratively.
+    </li>
+  </ol>
+
+  <h2>What do we need to work with you?</h2>
+  <p>
+    Currently, we have a small number of people to partner with departments. To make the best use of their time, we prioritize partners who have the following conditions around their service.
+  </p>
+  <ul>
+    <li><strong>Readiness and willingness:</strong> Clear leadership on a service and an open mind to trying new methods, technologies, and org structures. Additionally, the ability to unblock commons barriers to trying new things.</li>
+    <li><strong>Reach and impact:</strong> Your service is used by many people and/or very important to a vulnerable populations.</li>
+    <li><strong>Priority of service:</strong> If a service is not a priority within your department, it's unlikely to get the buy-in to try new things.</li>
+    <li><strong>Access:</strong> To department staff, leadership, and users of your service.</li>
+    <li><strong>Participation:</strong> Since we're working with you, not building for you -- we'll need half-to-full-time participation of a cross functional set of staff. This is how we coach and help. This means empowering a small groups of folks across multiple groups that is empowered to make decisions and perform relevant actions.</li>
+  </ul>
 
   <h2>Teams</h2>
   <div class="cta-row">
@@ -48,87 +114,6 @@ url: /partnerships-embedded-teams/
     </div>
   </div>
   
-  <div class="cta-wrapper">
-    <div class="cta cta--grey-bg cta--brown col-sm-12">
-      <div class="cta__content">
-        <h2 class="cta__content-title">Want our help?</h2>
-      </div>
-      <div class="cta__link">
-        <a href="https://forms-formulaires.alpha.canada.ca/id/3">Contact us<svg width="16" height="16" viewBox="0 0 16 16"
-            xmlns="http://www.w3.org/2000/svg">
-            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
-          </svg></a>
-      </div>
-    </div>
-  </div>
-
-  <h2>How do Embedded Teams work?</h2>
-  <ol>
-    <li>
-      <strong>Intake:</strong> Either you contacted us or we contacted you, but either way we'll establish interest in partnering and on what service.
-    </li>
-    <li>
-      <strong>Discovery:</strong> We'll conduct a discovery sprint for a week or two to learn more about your service and how your organization is setup to deliver it. This will give us a better idea of if and how we can help, who we'd have to work with, and how to measure progress.
-    </li>
-    <li>
-      <strong>Decide how to partner:</strong> Based on the discovery sprint we'll decide whether or not we can meaningfully improve your service and ways of working. If so, we'll figure out how to work together longer. If not, we'll leave you with a recommendations report on how your service
-      might be improved.
-    </li>
-    <li>
-      <strong>Co-create:</strong> Assuming we're working together longer, we'll start working side-by-side with your program and IT groups. This enables us to teach what we know in a hands-on way, and to ship improvements to your service iteratively.
-    </li>
-  </ol>
-
-
-  <div class="bg-med-grey">
-    <h2>Example</h2>
-    <p>
-      The Department of Widgets Canada (or, Widgets Canada) wants to encourage gizmo buying for the betterment of society. They've decided to launch a grant program that gives money to families to purchase their first gizmo. They'd like to allow people to register for the Gizmo Grant online, but last time they did something like this for contraption grants, it went very poorly. The site went down often, users had trouble using it, and they wound up with an unmanagable backlog of grant applications and emails to process.
-    </p>
-
-    <p>
-      Within WC, the program office and the IT group approach CDS to see if they can get some experts to help. CDS has a one hour intake meeting to understand the request. Then later that month, an Embedded Team conducts a discovery sprint to better understand the goals and challenges to delivery of the Gizmo Grant.
-    </p>
-    <p>
-      The discovery report finds that the proposed website isn't accessible, may not be able to handle the traffic to it, and that the program and IT officer are having trouble working together. This is communicated back to Widgets Canada and CDS asks if they would like help working on one or more of these challenges. WC does want help, and agrees to CDS's conditions to provide program and IT individual contributors to work side-by-side with CDS and clear blockers. This simultaneously helps get new skills to the individual contributors and creates rapid progress against the program challenges.
-    </p>
-    <p>
-      CDS's Embedded Team starts off working for 10-20 hours a week with Widgets (MORE COMING).
-    </p>
-  </div>
-
-  <h2>What might we do with you?</h2>
-  <ul>
-    <li>Map out your service to understand user touchpoints, challenges, bottlenecks, etc.</li>
-    <li>Redesign your web application, website, or interactions with users based on those users needs</li>
-    <li>Introduce modern product and project management tactics</li>
-    <li>Migrate to the cloud and adopt DevOps culture</li>
-    <li>Revise your security processes to decrease risk and be helpful rather than just blindly blocking everything</li>
-    <li>Hire or train your upcoming digital service team</li>
-    <li>Examine how your org structure is impacting delivery</li>
-    <li>Meet and get to know the users of your service</li>
-    <li>Rescue a distressed service</li>
-    <li>Make your services more accessible and inclusive</li>
-  </ul>
-
-  <h2>What will we not do?</h2>
-  <ul>
-    <li>Code an app <em>for</em>, not with you</li>
-    <li>(OTHER THINGS?)</li>
-  </ul>
-
-  <h2>What do we need to work with you?</h2>
-  <p>
-    Currently, we have a small number of people to partner with departments. To make the best use of their time, we prioritize partners who have the following conditions around their service.
-  </p>
-  <ul>
-    <li><strong>Readiness and willingness:</strong> Clear leadership on a service and an open mind to trying new methods, technologies, and org structures. Additionally, the ability to unblock commons barriers to trying new things.</li>
-    <li><strong>Reach and impact:</strong> Your service is used by many people and/or very important to a vulnerable populations.</li>
-    <li><strong>Priority of service:</strong> If a service is not a priority within your department, it's unlikely to get the buy-in to try new things.</li>
-    <li><strong>Access:</strong> To department staff, leadership, and users of your service.</li>
-    <li><strong>Participation:</strong> Since we're working with you, not building for you -- we'll need half-to-full-time participation of a cross functional set of staff. This is how we coach and help. This means empowering a small groups of folks across multiple groups that is empowered to make decisions and perform relevant actions.</li>
-  </ul>
-
   <div class="cta-wrapper">
     <div class="cta cta--grey-bg cta--brown col-sm-12">
       <div class="cta__content">

--- a/content/en/partnerships-embedded-teams.html
+++ b/content/en/partnerships-embedded-teams.html
@@ -10,22 +10,57 @@ url: /partnerships-embedded-teams/
     Embedded Teams aim to change how your organization designs and delivers services through hands-on, co-creation with your teams. We coach by delivering with you, not for you. In other words, we're full-time coaches and consultants, not staff augmentation.
   </p>
   <p>
-    Our teams are staffed with experienced people holding practical knowledge in UX design, user research, software development, technical operations (i.e. devops), and product management. Prior to and during their CDS tenure, they've shipped digital services at scale in the private sector and within government.
+    Our teams are staffed with experienced people holding practical knowledge in UX design, user research, software development, product management, operations (i.e. devops, change management, gov ops, etc.). Prior to and during their CDS tenure, they've shipped digital services at scale in the private sector and within government.
+  </p>
+  <p>
+    Our services are free to other Government of Canada departments (i.e. we are <em>not</em> cost recoverable), but we <em>will</em> need access to your time, people, data, and service users AND an open mind to try new things.
   </p>
 
-    <div class="cta-wrapper">
-      <div class="cta cta--grey-bg cta--brown col-sm-12">
-        <div class="cta__content">
-          <h2 class="cta__content-title">Want an Embedded Team to help?</h2>
-        </div>
-        <div class="cta__link">
-          <a href="https://forms-formulaires.alpha.canada.ca/id/3">Contact us<svg width="16" height="16" viewBox="0 0 16 16"
-              xmlns="http://www.w3.org/2000/svg">
-              <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
-            </svg></a>
-        </div>
+  <h2>Teams</h2>
+  <div class="cta-row">
+    <div class="cta cta--grey-bg cta--green col-sm-12 col-md-6">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Birch</h2>
+        <p>
+          (BUZZWORDS BIRCH IS GOOD AT)
+        </p>
+      </div>
+      <div class="cta__link">
+        <a href="/partnerships-birch">Meet Birch<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
       </div>
     </div>
+    <div class="cta cta--grey-bg cta--pink col-sm-12 col-md-6">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Red Pine</h2>
+        <p>
+          (BUZZWORDS RED PINE IS GOOD AT)
+        </p>
+      </div>
+      <div class="cta__link">
+        <a href="/partnerships-red-pine/">Meet Red Pine<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
+      </div>
+    </div>
+  </div>
+  
+  <div class="cta-wrapper">
+    <div class="cta cta--grey-bg cta--brown col-sm-12">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Want our help?</h2>
+      </div>
+      <div class="cta__link">
+        <a href="https://forms-formulaires.alpha.canada.ca/id/3">Contact us<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
+      </div>
+    </div>
+  </div>
 
   <h2>How do Embedded Teams work?</h2>
   <ol>
@@ -36,11 +71,11 @@ url: /partnerships-embedded-teams/
       <strong>Discovery:</strong> We'll conduct a discovery sprint for a week or two to learn more about your service and how your organization is setup to deliver it. This will give us a better idea of if and how we can help, who we'd have to work with, and how to measure progress.
     </li>
     <li>
-      <strong>Decide how to partner:</strong> Based on the discovery sprint we'll decide whether or not we can meaningfully improve your service. If so, we'll figure out how to work together longer. If not, we'll leave you with a recommendations report on how your service
+      <strong>Decide how to partner:</strong> Based on the discovery sprint we'll decide whether or not we can meaningfully improve your service and ways of working. If so, we'll figure out how to work together longer. If not, we'll leave you with a recommendations report on how your service
       might be improved.
     </li>
     <li>
-      <strong>Co-create:</strong> Assuming we're working together longer, we'll start working side-by-side folks your program and IT groups to teach what we know in a hands-on way. Because our work is optimized to leave you and your team with new ways of working, co-creation is the optimal way of working here. 
+      <strong>Co-create:</strong> Assuming we're working together longer, we'll start working side-by-side with your program and IT groups. This enables us to teach what we know in a hands-on way, and to ship improvements to your service iteratively.
     </li>
   </ol>
 
@@ -62,59 +97,49 @@ url: /partnerships-embedded-teams/
     </p>
   </div>
 
-  <h2>What Embedded Teams do</h2>
+  <h2>What might we do with you?</h2>
+  <ul>
+    <li>Map out your service to understand user touchpoints, challenges, bottlenecks, etc.</li>
+    <li>Redesign your web application, website, or interactions with users based on those users needs</li>
+    <li>Introduce modern product and project management tactics</li>
+    <li>Migrate to the cloud and adopt DevOps culture</li>
+    <li>Revise your security processes to decrease risk and be helpful rather than just blindly blocking everything</li>
+    <li>Hire or train your upcoming digital service team</li>
+    <li>Examine how your org structure is impacting delivery</li>
+    <li>Meet and get to know the users of your service</li>
+    <li>Rescue a distressed service</li>
+    <li>Make your services more accessible and inclusive</li>
+  </ul>
+
+  <h2>What will we not do?</h2>
+  <ul>
+    <li>Code an app <em>for</em>, not with you</li>
+    <li>(OTHER THINGS?)</li>
+  </ul>
+
+  <h2>What do we need to work with you?</h2>
   <p>
-    (MORE COMING)
+    Currently, we have a small number of people to partner with departments. To make the best use of their time, we prioritize partners who have the following conditions around their service.
   </p>
+  <ul>
+    <li><strong>Readiness and willingness:</strong> Clear leadership on a service and an open mind to trying new methods, technologies, and org structures. Additionally, the ability to unblock commons barriers to trying new things.</li>
+    <li><strong>Reach and impact:</strong> Your service is used by many people and/or very important to a vulnerable populations.</li>
+    <li><strong>Priority of service:</strong> If a service is not a priority within your department, it's unlikely to get the buy-in to try new things.</li>
+    <li><strong>Access:</strong> To department staff, leadership, and users of your service.</li>
+    <li><strong>Participation:</strong> Since we're working with you, not building for you -- we'll need half-to-full-time participation of a cross functional set of staff. This is how we coach and help. This means empowering a small groups of folks across multiple groups that is empowered to make decisions and perform relevant actions.</li>
+  </ul>
 
-  <h2>What Embedded Teams do <em>not</em> do?</h2>
-  <p>
-    (MORE COMING)
-  </p>
-
-
-    <h2>Teams</h2>
-    <div class="cta-row">
-      <div class="cta cta--grey-bg cta--green col-sm-12 col-md-6">
-        <div class="cta__content">
-          <h2 class="cta__content-title">Birch</h2>
-          <p>
-            (BUZZWORDS BIRCH IS GOOD AT)
-          </p>
-        </div>
-        <div class="cta__link">
-          <a href="/partnerships-birch">Meet Birch<svg width="16" height="16" viewBox="0 0 16 16"
-              xmlns="http://www.w3.org/2000/svg">
-              <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
-            </svg></a>
-        </div>
+  <div class="cta-wrapper">
+    <div class="cta cta--grey-bg cta--brown col-sm-12">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Want our help?</h2>
       </div>
-      <div class="cta cta--grey-bg cta--pink col-sm-12 col-md-6">
-        <div class="cta__content">
-          <h2 class="cta__content-title">Red Pine</h2>
-          <p>
-            (BUZZWORDS RED PINE IS GOOD AT)
-          </p>
-        </div>
-        <div class="cta__link">
-          <a href="/partnerships-red-pine/">Meet Red Pine<svg width="16" height="16" viewBox="0 0 16 16"
-              xmlns="http://www.w3.org/2000/svg">
-              <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
-            </svg></a>
-        </div>
+      <div class="cta__link">
+        <a href="https://forms-formulaires.alpha.canada.ca/id/3">Contact us<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
       </div>
     </div>
-
-    <div class="cta-wrapper">
-      <div class="cta cta--grey-bg cta--brown col-sm-12">
-        <div class="cta__content">
-          <h2 class="cta__content-title">Want an Embedded Team to help?</h2>
-        </div>
-        <div class="cta__link">
-          <a href="https://forms-formulaires.alpha.canada.ca/id/3">Contact us<svg width="16" height="16" viewBox="0 0 16 16"
-              xmlns="http://www.w3.org/2000/svg">
-              <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
-            </svg></a>
-        </div>
-      </div>
-    </div>
+  </div>
+</section>

--- a/content/en/partnerships-embedded-teams.html
+++ b/content/en/partnerships-embedded-teams.html
@@ -1,0 +1,87 @@
+---
+type: section
+layout: page
+title: Partnerships Embedded Teams
+aliases: [/partenariats-equipes-integrees/]
+url: /partnerships-embedded-teams/
+---
+<section class="page--outer-container-padding our-values">
+  <p>Our mission is to change government to serve people better. We work with
+    federal partners to build better services for the public and to help public
+    servants doing this important work.</p>
+
+  <p>We strive to live these values in everything we do at CDS. They guide our
+    work, shape our decisions, our behaviour, and our hiring.</p>
+
+  <h2>Put people at the heart of our services</h2>
+  <p>Our work is fundamentally about people, not technology. We’re driven by
+    empathy and put people’s needs first. We build inclusivity, diversity, and
+    accessibility into everything we do — from the start, not as an
+    afterthought. We work hand in hand with the people who use and operate
+    services.</p>
+
+  <h2>Deliver measurable outcomes</h2>
+  <p>We work to achieve the greatest impact for the greatest number of people in
+    the greatest need. That means we focus on measuring how we help people and
+    create lasting change in government, not project milestones. We believe
+    hands-on delivery &mdash; actually designing and building services with
+    partners &mdash; develops skills and gets results.</p>
+
+  <h2>Do the hard work to make things easier</h2>
+  <p>Making change in government is hard, but we love a good challenge. We do
+    not shy away from hard conversations but approach them with courage,
+    humility, compassion, and integrity. We untangle complexity so the people
+    using government services do not have to.</p>
+
+  <h2>Build for learning and iteration</h2>
+  <p>We believe that good services are built in small steps and with modular
+    parts that make it easier to pivot and course correct. The best way to find
+    out if a service works well is to put it in front of the people who use it,
+    so we continuously test, learn, document, and adjust.</p>
+
+  <h2>Work in the open to help clear a path</h2>
+  <p>We share our work, progress, and failures to help others learn from what we
+    do. We want to show what is possible and empower public servants to make it
+    a reality. We welcome the contributions and critiques that make our work
+    better.</p>
+
+  <h2>Take care of each other</h2>
+  <p>We’ve got each other’s backs — and those of our partners. We treat
+    resilience and wellness as organizational responsibilities, not just
+    character traits. We work to create a space where people feel they belong,
+    take risks, learn from mistakes, and speak openly.</p>
+</section>
+
+<div class="cta-wrapper">
+  <div class="cta cta--grey-bg cta--brown col-sm-12">
+    <div class="cta__content">
+      <h2 class="cta__content-title">Interested in joining us?</h2>
+    </div>
+    <div class="cta__link">
+      <a href="/careers/">Current openings<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M8 9H0V7H8V0L16 8L8 16V9Z"/></svg></a>
+    </div>
+  </div>
+
+
+  <div class="cta-row">
+    <div class="cta cta--grey-bg cta--pink col-sm-12 col-md-6">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Learn more about how we work</h2>
+        <p>Visit our blog, where we share stories and learnings from our work.</p>
+      </div>
+      <div class="cta__link">
+        <a href="/blog/">Visit our blog<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M8 9H0V7H8V0L16 8L8 16V9Z"/></svg></a>
+      </div>
+    </div>
+
+    <div class="cta cta--grey-bg cta--green col-sm-12 col-md-6">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Looking for ways to work better?</h2>
+        <p>Check out our resources for designers, developers, product managers and researchers working on agile, multi-disciplinary teams.</p>
+      </div>
+      <div class="cta__link">
+        <a href="/tools-and-resources/">Resources<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M8 9H0V7H8V0L16 8L8 16V9Z"/></svg></a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/content/en/partnerships-embedded-teams.html
+++ b/content/en/partnerships-embedded-teams.html
@@ -93,7 +93,7 @@ url: /partnerships-embedded-teams/
       <div class="cta__content">
         <h2 class="cta__content-title">Birch</h2>
         <p>
-          (BUZZWORDS BIRCH IS GOOD AT)
+          This talented team can help you with (BUZZWORDS BIRCH IS GOOD AT)
         </p>
       </div>
       <div class="cta__link">
@@ -107,7 +107,7 @@ url: /partnerships-embedded-teams/
       <div class="cta__content">
         <h2 class="cta__content-title">Red Pine</h2>
         <p>
-          (BUZZWORDS RED PINE IS GOOD AT)
+          This versatile team can help you design internal and external parts of your service, consider how your org structure and policies impact delivery, migrate to the cloud and use modern tech, improve your change management and prioritization processes, measure how your service is helping people, and/or rescue your distressed service.
         </p>
       </div>
       <div class="cta__link">

--- a/content/en/partnerships-embedded-teams.html
+++ b/content/en/partnerships-embedded-teams.html
@@ -58,23 +58,6 @@ url: /partnerships-embedded-teams/
     </p>
   </div>
 
-  <h2>How do Embedded Teams work?</h2>
-  <ol>
-    <li>
-      <strong>Intake:</strong> Either you contacted us or we contacted you, but either way we'll establish interest in partnering and on what service.
-    </li>
-    <li>
-      <strong>Discovery:</strong> We'll conduct a discovery sprint for a week or two to learn more about your service and how your organization is setup to deliver it. This will give us a better idea of if and how we can help, who we'd have to work with, and how to measure progress.
-    </li>
-    <li>
-      <strong>Decide how to partner:</strong> Based on the discovery sprint we'll decide whether or not we can meaningfully improve your service and ways of working. If so, we'll figure out how to work together longer. If not, we'll leave you with a recommendations report on how your service
-      might be improved.
-    </li>
-    <li>
-      <strong>Co-create:</strong> Assuming we're working together longer, we'll start working side-by-side with your program and IT groups. This enables us to teach what we know in a hands-on way, and to ship improvements to your service iteratively.
-    </li>
-  </ol>
-
   <h2>What do we need to work with you?</h2>
   <p>
     Currently, we have a small number of people to partner with departments. To make the best use of their time, we prioritize partners who have the following conditions around their service.
@@ -100,7 +83,7 @@ url: /partnerships-embedded-teams/
       </div>
     </div>
   </div>
-  
+
   <h2>Teams</h2>
   <div class="cta-row">
     <div class="cta cta--grey-bg cta--green col-sm-12 col-md-6">

--- a/content/en/partnerships-red-pine.html
+++ b/content/en/partnerships-red-pine.html
@@ -6,5 +6,44 @@ aliases: [/partenariats-pin-rouge/]
 url: /partnerships-red-pine/
 ---
 <section>
-  <p>Red Pine Page</p>
+  <p>This versatile <a href="/partnerships-embedded-teams">Embedded Team</a> can help you:</p>
+    
+  <ul>
+    <li>Meet and measure the outcomes of your service using modern technology and design practices</li>
+    <li>Understand where your service is falling short today and how it can improve</li>
+    <li>Redesign or prototype your service, website, app, digital delivery operations, and internal processes</li>
+    <li>Develop a roadmap for how to better help the people you serve digitally</li>
+    <li>Hire your next software developers, designers, and product managers</li>
+    <li>Make your services and software more accessible and inclusive</li>
+    <li>Migration to the cloud</li>
+    <li>Improve your security and DevOps processes to reduce risk and make your service more resilient</li>
+    <li>Tune your change management processes around desired outcomes</li>
+    <li>Rescue a distressed, priority service</li>
+  </ul>
+  
+  <p>Our team brings experience from both the public and private sectors, and has delivered digital services that reliably serve millions of people. Their skills sets include (alphabetically):</p>
+
+  <ul>
+    <li>Bureaucracy busting and conflict resolution</li>
+    <li>Case management and CRM development</li>
+    <li>Change management</li>
+    <li>Content design</li>
+    <li>Data analysis</li>
+    <li>Data management</li>
+    <li>DevOps (or DevSecOps)</li>
+    <li>Discovery</li>
+    <li>Hiring</li>
+    <li>Org design</li>
+    <li>People management</li>
+    <li>Product management</li>
+    <li>Project management</li>
+    <li>Release management</li>
+    <li>Service design</li>
+    <li>Security and Privacy</li>
+    <li>Strategic guidance</li>
+    <li>User research (or design research)</li>
+  </ul>
+
+
+
 </section>

--- a/content/en/partnerships-red-pine.html
+++ b/content/en/partnerships-red-pine.html
@@ -1,0 +1,10 @@
+---
+type: section
+layout: page
+title: CDS Partnerships - Embedded Team - Red Pine
+aliases: [/partenariats-pin-rouge/]
+url: /partnerships-red-pine/
+---
+<section>
+  <p>Red Pine Page</p>
+</section>

--- a/content/en/partnerships-red-pine.html
+++ b/content/en/partnerships-red-pine.html
@@ -45,5 +45,66 @@ url: /partnerships-red-pine/
   </ul>
 
 
+  <h2>Team Members</h2>
+  <div class="cta-row">
+    <div class="cta cta--grey-bg cta--green col-sm-12 col-md-6">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Caitlin Tuba</h2>
+        <p>
+          (BIO IN 1 PARAGAPH)
+        </p>
+      </div>
+      <div class="cta__link">
+        <a href="/partnerships-birch">More...<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
+      </div>
+    </div>
+    <div class="cta cta--grey-bg cta--pink col-sm-12 col-md-6">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Gillian Massel</h2>
+        <p>
+          (BIO IN 1 PARAGRAPH)
+        </p>
+      </div>
+      <div class="cta__link">
+        <a href="/partnerships-red-pine/">More...<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
+      </div>
+    </div>
+  </div>
+  <div class="cta-row">
+    <div class="cta cta--grey-bg cta--green col-sm-12 col-md-6">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Jeff Maher</h2>
+        <p>
+          (BIO IN 1 PARAGAPH)
+        </p>
+      </div>
+      <div class="cta__link">
+        <a href="/partnerships-birch">More...<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
+      </div>
+    </div>
+    <div class="cta cta--grey-bg cta--pink col-sm-12 col-md-6">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Kaira Bakkestad-Legare </h2>
+        <p>
+          (BIO IN 1 PARAGRAPH)
+        </p>
+      </div>
+      <div class="cta__link">
+        <a href="/partnerships-red-pine/">More...<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
+      </div>
+    </div>
+  </div>
 
 </section>

--- a/content/fr/partnerships-birch.html
+++ b/content/fr/partnerships-birch.html
@@ -1,0 +1,10 @@
+---
+type: section
+layout: page
+title: CDS Partnerships - Embedded Team - Birch
+aliases: [/partnerships-birch/]
+url: /partenariats-bouleau/
+---
+<section>
+  <p>Birch Page</p>
+</section>

--- a/content/fr/partnerships-embedded-teams.html
+++ b/content/fr/partnerships-embedded-teams.html
@@ -1,0 +1,118 @@
+---
+type: section
+layout: page
+title: CDS Partnerships - Embedded Teams
+aliases: [/partnerships-embedded-teams/]
+url: /partenariats-equipes-integrees/
+---
+<section>
+  <p>
+    Embedded Teams change how your organization designs and delivers services through hands-on, co-creation with your teams. We coach by delivering with you, not for you. In other words, we're full-time coaches and consultants, not staff augmentation.
+  </p>
+  <p>
+    Our teams are staffed with experienced people holding practical knowledge in UX design, user research, software development, product management, operations (i.e. devops, change management, gov ops, etc.). Prior to and during their CDS tenure, they've shipped digital services at scale in the private sector and within government.
+  </p>
+  <p>
+    Our services are free to other Government of Canada departments (i.e. we are <em>not</em> cost recoverable), but we <em>will</em> need access to your time, people, data, and service users AND an open mind to try new things.
+  </p>
+
+  <h2>What might we do with you?</h2>
+  <ul>
+    <li>Map out your service to understand user touchpoints, challenges, bottlenecks, etc.</li>
+    <li>Redesign your web application, website, or interactions with users based on those users needs</li>
+    <li>Introduce modern product and project management tactics</li>
+    <li>Migrate to the cloud and adopt DevOps culture</li>
+    <li>Revise your security processes to decrease risk and be helpful rather than just blindly blocking everything</li>
+    <li>Hire or train your upcoming digital service team</li>
+    <li>Examine how your org structure is impacting delivery</li>
+    <li>Meet and get to know the users of your service</li>
+    <li>Rescue a distressed service</li>
+    <li>Make your services more accessible and inclusive</li>
+  </ul>
+
+  <h2>What will we not do?</h2>
+  <ul>
+    <li>Code an app <em>for</em>, not with you</li>
+    <li>(OTHER THINGS?)</li>
+  </ul>
+
+  <div class="example_box">
+    <h2>Example Engagement</h2>
+    <p>
+      The Department of Widgets Canada (or, Widgets Canada) wants to encourage gizmo buying for the betterment of society. They are launching a grant program that gives money to families to purchase their first gizmo. They want people to register for the Gizmo Grant online, but last time they did something like this for the Contraption Grant, it went very poorly. The site went down often, users had trouble using it, and they wound up with an unmanagable backlog of grant applications and emails to process.
+    </p>
+
+    <p>
+      Widgets Canada's Gizmo Program Office reaches out to CDS to get expert help. Together, CDS and Widgets Canada have a one hour <strong>Intake Meeting</strong> to better understand the request, define desired outcomes, and what Widget Canada's current capacity and capabilities are. Later that week, CDS decides to help out with an Embedded Team.
+    </p>
+    
+    <p>
+      The Embedded Team begins by doing a two week <strong>Discovery Sprint</strong> (note: calling this by a common term rather than the branded Exploration). This allows the team to understand where the service is today, what challenges exist, and form an informed hypothesis on how to improve the service and ways of working.
+    </p>
+
+    <p>
+      The discovery report finds that the proposed website isn't accessible, may not be able to handle the traffic to it, and that the program and IT offices are having trouble working together. This is communicated back to Widgets Canada leadership and CDS asks if help is desired working on one or more of these challenges. Widgets Canada does want help, and agrees to CDS's conditions to provide program and IT individual contributors to work side-by-side with CDS and to clear blockers that may arise while trying new approaches. This arrangement is outlined in a short <strong>Partnerships Agreement</strong> document, which creates a unified Widget Canada and CDS team to work the defined scope. This joint team is able to make decisions and implement new processes and code for the Gizmo Grant.
+    </p>
+    <p>
+      During this next phase, Widgets Canada and CDS <strong>Co-create New Processes and Software</strong>. By working together hands-on, Gizmo Grant program officers learn how to design a web page better from a CDS designer and members from the IT group learn how to deploy the grant application software to the cloud from a CDS software developer. Co-creating together not only teaches new technical skills and collaborative tactics, but the Gizmo Grant program's challenges are addressed and risk of failure are reduced.
+    </p>
+  </div>
+
+  <h2>What do we need to work with you?</h2>
+  <p>
+    Currently, we have a small number of people to partner with departments. To make the best use of their time, we prioritize partners who have the following conditions around their service.
+  </p>
+  <ul>
+    <li><strong>Readiness and willingness:</strong> Clear leadership on a service and an open mind to trying new methods, technologies, and org structures. Additionally, the ability to unblock commons barriers to trying new things.</li>
+    <li><strong>Reach and impact:</strong> Your service is used by many people and/or very important to a vulnerable populations.</li>
+    <li><strong>Priority of service:</strong> If a service is not a priority within your department, it's unlikely to get the buy-in to try new things.</li>
+    <li><strong>Access:</strong> To department staff, leadership, and users of your service.</li>
+    <li><strong>Participation:</strong> Since we're working with you, not building for you -- we'll need half-to-full-time participation of a cross functional set of staff. This is how we coach and help. This means empowering a small groups of folks across multiple groups that is empowered to make decisions and perform relevant actions.</li>
+  </ul>
+
+  <div class="cta-wrapper">
+    <div class="cta cta--grey-bg cta--brown col-sm-12">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Want our help?</h2>
+      </div>
+      <div class="cta__link">
+        <a href="https://forms-formulaires.alpha.canada.ca/id/3">Contact us<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
+      </div>
+    </div>
+  </div>
+
+  <h2>Teams</h2>
+  <div class="cta-row">
+    <div class="cta cta--grey-bg cta--green col-sm-12 col-md-6">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Birch</h2>
+        <p>
+          This talented team can help you with (BUZZWORDS BIRCH IS GOOD AT)
+        </p>
+      </div>
+      <div class="cta__link">
+        <a href="/partnerships-birch">Meet Birch<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
+      </div>
+    </div>
+    <div class="cta cta--grey-bg cta--pink col-sm-12 col-md-6">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Red Pine</h2>
+        <p>
+          This versatile team can help you design internal and external parts of your service, consider how your org structure and policies impact delivery, migrate to the cloud and use modern tech, improve your change management and prioritization processes, measure how your service is helping people, and/or rescue your distressed service.
+        </p>
+      </div>
+      <div class="cta__link">
+        <a href="/partnerships-red-pine/">Meet Red Pine<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/content/fr/partnerships-red-pine.html
+++ b/content/fr/partnerships-red-pine.html
@@ -1,0 +1,110 @@
+---
+type: section
+layout: page
+title: CDS Partnerships - Embedded Team - Red Pine
+aliases: [/partnerships-red-pine/]
+url: /partenariats-pin-rouge/
+---
+<section>
+  <p>This versatile <a href="/partnerships-embedded-teams">Embedded Team</a> can help you:</p>
+    
+  <ul>
+    <li>Meet and measure the outcomes of your service using modern technology and design practices</li>
+    <li>Understand where your service is falling short today and how it can improve</li>
+    <li>Redesign or prototype your service, website, app, digital delivery operations, and internal processes</li>
+    <li>Develop a roadmap for how to better help the people you serve digitally</li>
+    <li>Hire your next software developers, designers, and product managers</li>
+    <li>Make your services and software more accessible and inclusive</li>
+    <li>Migration to the cloud</li>
+    <li>Improve your security and DevOps processes to reduce risk and make your service more resilient</li>
+    <li>Tune your change management processes around desired outcomes</li>
+    <li>Rescue a distressed, priority service</li>
+  </ul>
+  
+  <p>Our team brings experience from both the public and private sectors, and has delivered digital services that reliably serve millions of people. Their skills sets include (alphabetically):</p>
+
+  <ul>
+    <li>Bureaucracy busting and conflict resolution</li>
+    <li>Case management and CRM development</li>
+    <li>Change management</li>
+    <li>Content design</li>
+    <li>Data analysis</li>
+    <li>Data management</li>
+    <li>DevOps (or DevSecOps)</li>
+    <li>Discovery</li>
+    <li>Hiring</li>
+    <li>Org design</li>
+    <li>People management</li>
+    <li>Product management</li>
+    <li>Project management</li>
+    <li>Release management</li>
+    <li>Service design</li>
+    <li>Security and Privacy</li>
+    <li>Strategic guidance</li>
+    <li>User research (or design research)</li>
+  </ul>
+
+
+  <h2>Team Members</h2>
+  <div class="cta-row">
+    <div class="cta cta--grey-bg cta--green col-sm-12 col-md-6">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Caitlin Tuba</h2>
+        <p>
+          (BIO IN 1 PARAGAPH)
+        </p>
+      </div>
+      <div class="cta__link">
+        <a href="/partnerships-birch">More...<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
+      </div>
+    </div>
+    <div class="cta cta--grey-bg cta--pink col-sm-12 col-md-6">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Gillian Massel</h2>
+        <p>
+          (BIO IN 1 PARAGRAPH)
+        </p>
+      </div>
+      <div class="cta__link">
+        <a href="/partnerships-red-pine/">More...<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
+      </div>
+    </div>
+  </div>
+  <div class="cta-row">
+    <div class="cta cta--grey-bg cta--green col-sm-12 col-md-6">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Jeff Maher</h2>
+        <p>
+          (BIO IN 1 PARAGAPH)
+        </p>
+      </div>
+      <div class="cta__link">
+        <a href="/partnerships-birch">More...<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
+      </div>
+    </div>
+    <div class="cta cta--grey-bg cta--pink col-sm-12 col-md-6">
+      <div class="cta__content">
+        <h2 class="cta__content-title">Kaira Bakkestad-Legare </h2>
+        <p>
+          (BIO IN 1 PARAGRAPH)
+        </p>
+      </div>
+      <div class="cta__link">
+        <a href="/partnerships-red-pine/">More...<svg width="16" height="16" viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
+          </svg></a>
+      </div>
+    </div>
+  </div>
+
+</section>

--- a/layouts/section/partnerships.html
+++ b/layouts/section/partnerships.html
@@ -39,11 +39,12 @@
         <p>{{i18n "partnerships-exploration-description"}}</p>
 
         <!-- Embedded Teams -->
-        <h3><strong>{{i18n "partnerships-embedded-team"}}</strong></h3>
+        <h3><a href="/partnerships-embedded-teams"><strong>{{i18n "partnerships-embedded-team"}}</strong></a></h3>
         <h4>{{i18n "partnerships-time-commitment"}}</h4>
         <p>{{i18n "partnerships-embedded-team-time-commitment"}}</p>
         <h4>{{i18n "partnerships-how-it-works"}}</h4>
         <p>{{i18n "partnerships-embedded-team-description"}}</p>
+        <p><a href="/partnerships-embedded-teams">More information</a></p>
 
       </div>
     </div>


### PR DESCRIPTION
# Summary | Résumé

The Red Pine Embedded Team is seeking out new partners to coach and co-create with, but our web presence is non-existent and partners are regularly confused on what we do. We'd like to add some pages that explain what Embedded Teams do and who they are, starting with Red Pine.

# Test instructions | Instructions pour tester la modification

Using the preview link GitHub will generate, navigate to "Partnerships" from the main navigation, then choose "More information" under the "Embedded teams" section.

To get the preview link, scroll down:
![image](https://user-images.githubusercontent.com/91141781/139856146-3ee9e056-fa93-4947-ab21-90decdec0979.png)

# Help requested | Aide requise

- Seeking review from Embedded Teams leads, cc @AndreanneTrudeau , @caitlintuba , @gabesawhney 
- Seeking review from Embedded Teams members
- Thoughts from the website team on how to navigate to this section
- French translation