### PR TITLE
feat: checks if all active positions are in Lever

### DIFF
--- a/.github/tasks/positions_public_check/index.js
+++ b/.github/tasks/positions_public_check/index.js
@@ -1,0 +1,54 @@
+import fetch from "node-fetch";
+import fs from "fs";
+import { parse } from "node-html-parser";
+import yaml from "js-yaml";
+
+const publicURL = "https://jobs.lever.co/tbs-sct";
+const directory = "../../../content/en/careers/positions/";
+
+const parseFile = (fileName) => {
+  try {
+    const fileContents = fs.readFileSync(fileName, "utf8");
+    const data = fileContents.toString().split("---")[1];
+    const metadata = yaml.load(data);
+
+    if (!metadata["archived"]) return metadata["leverId"];
+
+    return false;
+  } catch (e) {
+    console.log(e);
+    return false;
+  }
+};
+
+const parseActivePositions = () => {
+  const files = fs.readdirSync(directory);
+  const ids = files
+    .map((file) => parseFile(`${directory}/${file}`))
+    .filter((value) => !!value);
+  return ids;
+};
+
+const getActivePositions = async () => {
+  const response = await fetch(publicURL);
+  const body = await response.text();
+  const root = parse(body);
+  const postings = root.querySelectorAll("div[data-qa-posting-id]");
+  return postings.map((posting) => posting.getAttribute("data-qa-posting-id"));
+};
+
+const run = async () => {
+  const ids = parseActivePositions();
+  const active = await getActivePositions();
+  const diff = ids.filter((id) => !active.includes(id));
+
+  if (diff.length > 0) {
+    console.log(`${diff} positions are not listed as active in Lever`);
+    process.exit(1);
+  } else {
+    console.log("All positions are listed as active");
+    process.exit(0);
+  }
+};
+
+run();

--- a/.github/tasks/positions_public_check/package-lock.json
+++ b/.github/tasks/positions_public_check/package-lock.json
@@ -1,0 +1,139 @@
+{
+  "name": "positions_public_check",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "css-select": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^5.0.0",
+        "domhandler": "^4.2.0",
+        "domutils": "^2.6.0",
+        "nth-check": "^2.0.0"
+      }
+    },
+    "css-what": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
+      "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw=="
+    },
+    "data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
+    },
+    "dom-serializer": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+    },
+    "domhandler": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+      "requires": {
+        "domelementtype": "^2.2.0"
+      }
+    },
+    "domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "requires": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      }
+    },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
+    "fetch-blob": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.3.tgz",
+      "integrity": "sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==",
+      "requires": {
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "node-fetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.0.tgz",
+      "integrity": "sha512-QU0WbIfMUjd5+MUzQOYhenAazakV7Irh1SGkWCsRzBwvm4fAhzEUaHMJ6QLP7gWT6WO9/oH2zhKMMGMuIrDyKw==",
+      "requires": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.2",
+        "formdata-polyfill": "^4.0.10"
+      }
+    },
+    "node-html-parser": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-5.1.0.tgz",
+      "integrity": "sha512-l6C1Gf1o7YuxeMGa17PypEez/rj+ii3q4/NZG37nRmWSLDjHyB0WNrlE4h2UW92D0JSfUSfu+lOvxThttVe7Jw==",
+      "requires": {
+        "css-select": "^4.1.3",
+        "he": "1.2.0"
+      }
+    },
+    "nth-check": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+      "requires": {
+        "boolbase": "^1.0.0"
+      }
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
+    }
+  }
+}

--- a/.github/tasks/positions_public_check/package.json
+++ b/.github/tasks/positions_public_check/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "positions_public_check",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "type": "module",
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "js-yaml": "^4.1.0",
+    "node-fetch": "^3.1.0",
+    "node-html-parser": "^5.1.0"
+  }
+}

--- a/.github/workflows/validates-positions-active.yaml
+++ b/.github/workflows/validates-positions-active.yaml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: npm install
-      working-directory: .github/tasks/positions_public_check
-      run: |
-        npm install
+        working-directory: .github/tasks/positions_public_check
+        run: |
+          npm install
 
       - name: Validate all positions are active
-      working-directory: .github/tasks/positions_public_check
-      run: |
-        node index.js
+        working-directory: .github/tasks/positions_public_check
+        run: |
+          node index.js

--- a/.github/workflows/validates-positions-active.yaml
+++ b/.github/workflows/validates-positions-active.yaml
@@ -1,0 +1,20 @@
+name: Posted positions active in Lever
+
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: npm install
+      working-directory: .github/tasks/positions_public_check
+      run: |
+        npm install
+
+      - name: Validate all positions are active
+      working-directory: .github/tasks/positions_public_check
+      run: |
+        node index.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/*
+node_modules
 static/admin/bundle.js
 public/*
 resources/*


### PR DESCRIPTION
This PR adds a CI check that parses out all the positions listed as `archived: false` in the source files. It then compares the LeverId to those listed publicly here, https://jobs.lever.co/tbs-sct, which is a reflection of "public" postings at CDS. If any of those listed as `archived: false` are not on the lever site, it will throw an error exit code with the missing UUIDs.