### PR TITLE
fixed logo issue

### DIFF
--- a/assets/sass/cds/_components.scss
+++ b/assets/sass/cds/_components.scss
@@ -534,7 +534,6 @@
   &.show-modal-container{
     pointer-events: auto;
     opacity: 1;
-    position: relative;
     background-color: rgba(0, 0, 0, 0.3);
     display: flex;
     flex-direction: row;

--- a/assets/sass/cds/_nav.scss
+++ b/assets/sass/cds/_nav.scss
@@ -13,6 +13,9 @@
   }
 
   .nav-container {
+    width: max-content;
+    margin-left: auto;
+    margin-right: 0;
     @include tablet {
       padding-right: 0;
 


### PR DESCRIPTION
# Summary | Résumé

Fixed the issue causing only the top half of the CDS Logo to be clickable. The issue was caused by the nav container blocking the bottom half of the logo. Solution was to limit the width and aligning div to the right.