### PR TITLE
a11y fix

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -27,9 +27,9 @@
                   <a href="{{ .URL | absLangURL }}">{{ .Name }}</a>
                 </li>
               {{end}}
-              <div class="top-nav--link" >
+              <li class="top-nav--link" >
                 <button type="button" class="search-button" id="open" aria-label="{{ i18n "search" }}"><i class="fa fa-search" id="search-icon"></i></button>
-              </div>
+              </li>
               
             </ul>
           </div>


### PR DESCRIPTION
# Summary | Résumé

Noticed a spike in issues on our A11y tracker, likely has to do with putting the search icon in a `<div>` instead of an `<li>`

oops