### PR TITLE
added text for screen reader

### DIFF
--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -109,6 +109,11 @@
     
 
   }
+
+  .visually-hidden {
+    color: transparent;
+    font-size: 0.01px;
+  }
 }
 
 .homepage--blog-posts {

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -371,4 +371,8 @@ join-our-team-description:
 job-postings:
   other: "Job postings"
 read-our-blog-posts:
-  other: "Read our blog posts"                       
+  other: "Read our blog posts"   
+about-partnerships:
+  other: " about Partnerships"
+about-tools-and-resources:
+  other: " about Tools and Resources"                        

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -374,3 +374,7 @@ job-postings:
   other: "Offres d’emploi"
 read-our-blog-posts:
   other: "Lire tous les billets"
+about-partnerships:
+  other: " sur les Partenariats"
+about-tools-and-resources:
+  other: " plus sur les Outils et les Ressources"   

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -22,7 +22,10 @@
           <div class="cta-wrapper" style="margin-top: auto;">
             <div class="cta cta--orange">
               <div class="cta__link">
-                <a href="/partnerships/">{{ i18n "learn-more" }}<svg width="16" height="16" viewBox="0 0 16 16"
+                <a href="/partnerships/">{{ i18n "learn-more" }}
+                  <!-- visually hidden text is for screen readers -->
+                  <span class="visually-hidden">{{ i18n "about-partnerships" }}</span>
+                  <svg width="16" height="16" viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg">
                     <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
                   </svg></a>
@@ -38,7 +41,10 @@
           <div class="cta-wrapper" style="margin-top: auto;">
             <div class="cta cta--resources-green">
               <div class="cta__link">
-                <a href="/tools-and-resources/">{{ i18n "learn-more" }}<svg width="16" height="16"
+                <a href="/tools-and-resources/">{{ i18n "learn-more" }}
+                  <!-- visually hidden text is for screen readers -->
+                  <span class="visually-hidden">{{ i18n "about-tools-and-resources" }}</span>
+                  <svg width="16" height="16"
                     viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
                     <path d="M8 9H0V7H8V0L16 8L8 16V9Z" />
                   </svg></a>


### PR DESCRIPTION
# Summary | Résumé

Regarding [Github Issue](https://github.com/cds-snc/digital-canada-ca/issues/2780), where the "Learn More" buttons could cause some accessibility issues for screen readers.

Fix just adds a visually hidden text "Learn More (about partnerships)"