### PR TITLE
changed button positioning, fixed alignment

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -51,28 +51,32 @@
         </article>
         <div class="previous-next-nav">
           <div class="container">
-            <div class="pull-left text-left">
+            <div class="row">
+              <div class="col-md-6 pull-left text-left">
+                {{with .NextInSection }}
+                <a href="{{ .RelPermalink }}"><span class="wb-inv">:</span>
+                  <span class="fas fa-arrow-circle-left"></span>
+                  {{i18n "next-post"}}
+                  <div class="nav-post-title nav-post-title-right">{{ .Params.title | markdownify }}</div>
+                </a>
+                {{ end }}
+              </div>
+    
+              <div class="col-md-6 pull-right text-right">
                 {{with .PrevInSection }}
                 <a href="{{ .RelPermalink }}">
-                  <span class="fas fa-arrow-circle-left"></span>
-                  {{i18n "previous-post"}}<span class="wb-inv">:</span>
+                  {{i18n "previous-post"}}
+                  <span class="fas fa-arrow-circle-right"></span>
+                  <span class="wb-inv">:</span>
                   <div class="nav-post-title nav-post-title-left">{{ .Params.title | markdownify }}</div>
                 </a>
                 {{end}}
               </div>
-
-              <div class="pull-right text-right">
-                {{with .NextInSection }}
-                <a href="{{ .RelPermalink }}">{{i18n "next-post"}}<span class="wb-inv">:</span>
-                  <span class="fas fa-arrow-circle-right"></span>
-                  <div class="nav-post-title nav-post-title-right">{{ .Params.title | markdownify }}</div>
-                </a>
-                {{ end }}
-                </div>
-              </div>
-              </div>
             </div>
+  
+  
           </div>
+        </div>
         </section>
   <!-- </div> -->
 {{ end }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -52,7 +52,7 @@
         <div class="previous-next-nav">
           <div class="container">
             <div class="row">
-              <div class="col-md-6 pull-left text-left">
+              <div class="col-xs-6 pull-left text-left">
                 {{with .NextInSection }}
                 <a href="{{ .RelPermalink }}"><span class="wb-inv">:</span>
                   <span class="fas fa-arrow-circle-left"></span>
@@ -62,7 +62,7 @@
                 {{ end }}
               </div>
     
-              <div class="col-md-6 pull-right text-right">
+              <div class="col-xs-6 pull-right text-right">
                 {{with .PrevInSection }}
                 <a href="{{ .RelPermalink }}">
                   {{i18n "previous-post"}}


### PR DESCRIPTION
# Summary | Résumé

Repositioned the buttons so now previous post appears on the right, next post appears on the left.
![Screen Shot 2021-11-30 at 11 58 42 AM](https://user-images.githubusercontent.com/33768337/144273839-da25202f-31ab-45cf-b343-91cce0112af0.png)
![Screen Shot 2021-11-30 at 11 58 35 AM](https://user-images.githubusercontent.com/33768337/144273843-ba0afb6d-2e7b-41c3-b4d2-cf6ac873f7b8.png)

Fixed alignment issue:


![Screen Shot 2021-12-01 at 10 38 10 AM](https://user-images.githubusercontent.com/33768337/144283964-0474404e-bb2e-4052-bdb2-3876208d13ce.png)

