### PR TITLE
Bug/search close url

### DIFF
--- a/assets/sass/cds/_nav.scss
+++ b/assets/sass/cds/_nav.scss
@@ -114,7 +114,7 @@
   border: 2px solid white;
   background-color: transparent;
   padding: 1rem 1rem;
-  #search-icon {
+  .search-button-icon {
     color: white;
   }
 }

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -27,7 +27,7 @@
                   <a href="{{ .URL | absLangURL }}" id="{{.Identifier}}-nav-tag">{{ .Name }}</a>
                 </li>
               {{end}}
-              <li class="top-nav--link" >
+              <li class="top-nav--link" id="search-button-id">
                 <button type="button" class="search-button" id="open" aria-label="{{ i18n "search" }}"><i class="fa fa-search" id="search-icon"></i></button>
               </li>
               

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -27,8 +27,8 @@
                   <a href="{{ .URL | absLangURL }}" id="{{.Identifier}}-nav-tag">{{ .Name }}</a>
                 </li>
               {{end}}
-              <li class="top-nav--link" id="search-button-id">
-                <button type="button" class="search-button" id="open" aria-label="{{ i18n "search" }}"><i class="fa fa-search" id="search-icon"></i></button>
+              <li class="top-nav--link">
+                <button type="button" class="search-button" id="open" aria-label="{{ i18n "search" }}"><i class="fa fa-search search-button-icon"></i></button>
               </li>
               
             </ul>

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -223,7 +223,7 @@ close.addEventListener("click", () => {
   keysForDel.forEach((k) => {
     url.searchParams.delete(k);
   });
-  window.history.pushState({}, "", location.origin);
+  window.history.pushState({}, "", location.origin + location.pathname);
   searchedResults = results;
   results = searchSite(getQueryVariable());
   renderSearchResult(results);

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -364,12 +364,8 @@ function renderSearchResult(items) {
     resultList += `<li>
     <div class="rendered-list">
       <div style="margin: 1rem 0 1rem 0">
-        <a href='${
-          paginatedItems[i].href
-        }' target="_blank" class="render-list-title" aria-label='${
-      paginatedItems[i].title
-    }'>
-          <span>${paginatedItems[i].title}<span>
+        <a href='${paginatedItems[i].href}' target="_blank" class="render-list-title" aria-label='${paginatedItems[i].title}'>
+          ${paginatedItems[i].title}
         </a>
       </div>
       <div class="filter-number-${


### PR DESCRIPTION
# Summary | Résumé

Couple fixes. When closing the search modal, the URL pathname would also clear, this is fixed.

Updated search icon class name.