### PR TITLE
fixed cds fr logo, aria label and fip

### DIFF
--- a/assets/sass/cds/_layout.scss
+++ b/assets/sass/cds/_layout.scss
@@ -14,7 +14,6 @@
   }
 
   .logo {
-    background-image: url("../img/cds/goc--header-logo.svg");
     background-repeat: no-repeat;
     background-size: contain;
     display: block;
@@ -22,7 +21,10 @@
     height : 1.5rem;
 
     // BILINGUAL SPECIFIC CDS LOGO
-    .fr & {
+    &.en {
+      background-image: url("../img/cds/goc--header-logo.svg");
+    }
+    &.fr {
       background-image: url("../img/cds/goc--header-logo-fr.svg");
     }
 

--- a/assets/sass/cds/_nav.scss
+++ b/assets/sass/cds/_nav.scss
@@ -33,8 +33,6 @@
 ////////////////////////////////////////////////////////////
 
 .cds-logo {
-
-  // background-image: url("../img/cds/cds-lockup-ko-en.svg");
   background-position: center center;
   background-repeat: no-repeat;
   background-size: contain;

--- a/assets/sass/cds/_nav.scss
+++ b/assets/sass/cds/_nav.scss
@@ -33,7 +33,8 @@
 ////////////////////////////////////////////////////////////
 
 .cds-logo {
-  background-image: url("../img/cds/cds-lockup-ko-en.svg");
+
+  // background-image: url("../img/cds/cds-lockup-ko-en.svg");
   background-position: center center;
   background-repeat: no-repeat;
   background-size: contain;
@@ -62,13 +63,16 @@
   }
 
   // BILINGUAL SPECIFIC CDS LOGO
-  .fr & {
+  &.en {
+    background-image: url("../img/cds/cds-lockup-ko-en.svg");
+  }
+  &.fr {
     background-image: url("../img/cds/cds-lockup-ko-fr.svg");
   }
 }
 
 .cds-logo-mobile {
-    background-image: url("../img/cds/cds-logo-en-v2.svg");
+    
     background-position: center center;
     background-repeat: no-repeat;
     background-size: contain;
@@ -82,7 +86,10 @@
     }
 
   // BILINGUAL SPECIFIC CDS LOGO - MOBILE SCREEN
-  .fr & {
+  &.en {
+    background-image: url("../img/cds/cds-logo-en-v2.svg");
+  }
+  &.fr {
     background-image: url("../img/cds/cds-logo-fr-v2.svg") !important;
   }
 }

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -9,7 +9,7 @@ about-this-site:
 aria-canada-website:
   other: "Government of Canada"
 aria-cds-website:
-  other: "Accéder à la page d'accueil"
+  other: "Go to the homepage"
 blog:
   other: "Read the blog"
 canada-ca:

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -8,6 +8,8 @@ about-this-site:
   other: "À propos du site"
 aria-canada-website:
   other: "Gouvernement du Canada"
+aria-cds-website:
+  other: "Accéder à la page d'accueil"  
 blog:
   other: "Lire notre blogue"
 canada-ca-link:

--- a/layouts/partials/fip.html
+++ b/layouts/partials/fip.html
@@ -3,7 +3,7 @@
         <div class="row">
             <div class="col-xs-4">
                 <a href="https://www.canada.ca/{{ string (.Site.Language) }}.html" class="fip-logo gl-FIP" aria-label="{{ i18n "aria-canada-website" }}">
-                    <object type="image/svg+xml" tabindex="-1" role="img" aria-label="{{ i18n "goc-symbol" }}" class="logo"></object>
+                    <object type="image/svg+xml" tabindex="-1" role="img" aria-label="{{ i18n "goc-symbol" }}" class="logo {{.Site.Language.Lang}}"></object>
                 </a>
             </div>
             <div class="col-xs-8">

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -3,10 +3,10 @@
   <div class="container topbar" id="site--topbar">
     <div class="row">
       <div class="col-xs-4 col-sm-3">
-        <a href={{ .Site.BaseURL | absLangURL }} class="cds-logo" 
+        <a href={{ .Site.BaseURL | absLangURL }} class="cds-logo {{.Site.Language.Lang}}" 
            aria-label="{{ i18n "aria-cds-website" }}"></a>
         <!-- mobile screen wordless logo -->
-        <a href={{ .Site.BaseURL | absLangURL }} class="cds-logo-mobile"
+        <a href={{ .Site.BaseURL | absLangURL }} class="cds-logo-mobile {{.Site.Language.Lang}}"
         aria-label="{{ i18n "aria-cds-website" }}"></a>
       </div>
 


### PR DESCRIPTION
# Summary | Résumé

FR website was displaying the incorrect version of the CDS and GoC logo, this has been fixed. Also fixed aria-label for the CDS logo