### PR TITLE
security notice fr and en

### DIFF
--- a/content/en/legal/security-notice.html
+++ b/content/en/legal/security-notice.html
@@ -1,0 +1,71 @@
+---
+title: 'Security Notice'
+description: "This is the security notice for all Canadian Digital Service (CDS) repositories"
+image: contact.jpg
+url: /legal/security-notice/
+type: section
+layout: page
+---
+
+<section class="page-legal page--outer-container-padding">
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12">
+            <p>
+                This is the security notice for all Canadian Digital Service (CDS) repositories. 
+                The notice explains how vulnerabilities should be reported to CDS. 
+                At CDS there is a cyber security team, as well as security-conscious people within the organization, that assess and triage all reported vulnerabilities.
+            </p>
+            <!-- How to report a vulnerability -->
+            <h2>How to report a vulnerability</h2>
+            <p>CDS is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, we would like to know so we can fix it.</p>
+            <p><strong>You can report a vulnerability by sending an email to <a href="mailto:security+securite@cds-snc.ca">security+securite@cds-snc.ca</a></strong>. You can submit reports anonymously. We do not support PGP-encrypted emails at this time.</p>
+            <h3>In your report:</h3>
+            <ul>
+                <li>Write in English or French.</li>
+                <li>Describe the vulnerability, where it was discovered, and the potential impact of exploitation.</li>
+                <li>Offer a detailed description of the steps to reproduce the vulnerability (proof of concept scripts or screenshots are helpful). These should be benign, non-destructive, proofs of concept so we can triage your report quickly and accurately.</li>
+                <li>Only submit reports about exploitable vulnerability</li>
+                <li>Do not submit reports detailing non-exploitable vulnerabilities, or reports indicating that the services do not fully align with “best practice”. For example, missing security headers, or a high volume of low-quality reports (for example, from an automated scanner).</li>
+                <li>Do not communicate any vulnerabilities or associated details other than by means described in this notice.</li>
+                <li>Do not expect or demand financial compensation for your research and testing to disclose vulnerabilities.</li>
+            </ul>
+            <p>You can still reach out via email at <a href="mailto:security+securite@cds-snc.ca">security+securite@cds-snc.ca</a> if you are not sure if the vulnerability is genuine and exploitable, or you have found:</p>
+            <ul>
+                <li>A non-exploitable vulnerability.</li>
+                <li>Something you think could be improved - for example, missing security headers.</li>
+                <li>TLS configuration weaknesses - for example weak cipher suite support or the presence of TLS1.0 support.</li>
+            </ul>
+            <h3>When you are investigating and reporting the vulnerability you <strong>must not:</strong></h3>
+            <ul>
+                <li>Break the law.</li>
+                <li>Access unnecessary or excessive amounts of data.</li>
+                <li>Modify data.</li>
+                <li>Use high-intensity invasive or destructive scanning tools to find vulnerabilities.</li>
+                <li>Try a denial of service - for example overwhelming a service on canada.ca with a high volume of requests.</li>
+                <li>Disrupt Government of Canada’s services or systems.</li>
+                <li>Tell other people about the vulnerability you have found until we have disclosed it.</li>
+                <li>Social engineer, phish or physically attack our staff or infrastructure.</li>
+                <li>Demand money to disclose a vulnerability.</li>
+            </ul>
+
+            <!-- Code of Conduct -->
+            <h2>Code of Conduct</h2>
+            <p>Please view our contributors <a href="https://github.com/cds-snc/.github/blob/main/CODE_OF_CONDUCT.md">code of conduct</a> for more information on how to contribute in an open and welcoming way. </p>
+
+            <h3>Bug bounty</h3>
+            <p>Unfortunately, CDS doesn't offer a paid bug bounty program. CDS will make efforts to show appreciation to people who take the time and effort to disclose vulnerabilities responsibly. We do have an acknowledgements page for legitimate issues found by researchers.</p>
+            
+            <!-- After you’ve reported the vulnerability -->
+            <h2>After you’ve reported the vulnerability</h2>
+            <p>When you choose to share your contact information with us, we commit to communicating with you as openly and as quickly as possible.</p>
+            <ul>
+                <li>Within 3 business days, we will acknowledge that your report has been received.</li>
+                <li>To the best of our ability, we will confirm the existence of the vulnerability to you and be as transparent as possible about what steps we are taking during the remediation process, including on issues or challenges that may delay resolution.</li>
+                <li>We will prioritize fixing the vulnerability by looking at the impact, severity and exploit complexity. Vulnerability reports might take some time to triage or address. You’re welcome to ask the status but please no more than once every 14 days. That way, our teams can focus on the remediation.</li>
+                <li>We will do our best to maintain an open dialogue with you to discuss issues and will work with you to determine whether and how the flaw reported will be made public.</li>
+                <li>We will treat your report in accordance with the <em>Access to Information Act</em> and the <em>Privacy Act</em>.</li>
+                <li>We will notify you when the reported vulnerability is remediated, and you may be invited to confirm that the solution covers the vulnerability adequately.</li>
+            </ul>
+        </div>
+    </div>
+</section>

--- a/content/fr/legal/security-notice.html
+++ b/content/fr/legal/security-notice.html
@@ -50,7 +50,7 @@ url: /transparence/avis-de-securite
 
             <!-- Code of Conduct -->
             <h2>Code de conduite</h2>
-            <p>Veuillez consulter le Code de conduite des contributeurs pour obtenir de plus amples renseignements sur la façon de contribuer de manière ouverte et accueillante.</a> for more information on how to contribute in an open and welcoming way. </p>
+            <p>Veuillez consulter le <a href="https://github.com/cds-snc/.github/blob/main/CODE_OF_CONDUCT.md">Code de conduite</a> des contributeurs pour obtenir de plus amples renseignements sur la façon de contribuer de manière ouverte et accueillante.</a> for more information on how to contribute in an open and welcoming way. </p>
 
             <h3>Prime aux bogues</h3>
             <p>Malheureusement, le SNC n’offre pas de programme de prime aux bogues rémunéré, mais fera des efforts pour être reconnaissant envers les personnes qui prennent le temps et l’effort de divulguer des vulnérabilités de manière responsable. Nous disposons en fait d’une page de remerciements pour les problèmes légitimes découverts par les chercheurs.</p>

--- a/content/fr/legal/security-notice.html
+++ b/content/fr/legal/security-notice.html
@@ -1,0 +1,71 @@
+---
+title: 'Avis de sécurité'
+description: "Voici l’avis de sécurité pour tous les référentiels de données du Service numérique canadien (SNC)."
+image: contact.jpg
+type: section
+layout: page
+url: /transparence/avis-de-securite
+---
+
+<section class="page-legal page--outer-container-padding">
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12">
+            <p>
+                Voici l’avis de sécurité pour tous les référentiels de données du Service numérique canadien (SNC). 
+                Cet avis explique la procédure à suivre pour signaler toute vulnérabilité au SNC. 
+                Le SNC est doté d’une équipe de cybersécurité et d’employés soucieux de la sécurité, qui évaluent et traitent tout incident signalé.
+            </p>
+            <!-- How to report a vulnerability -->
+            <h2>Comment signaler une vulnérabilité </h2>
+            <p>Le SNC est un défenseur de la divulgation responsable des vulnérabilités. Si vous avez repéré une vulnérabilité, nous aimerions le savoir afin de la corriger.</p>
+            <p><strong>Vous pouvez signaler une vulnérabilité en écrivant à <a href="mailto:security+securite@cds-snc.ca">security+securite@cds-snc.ca</a></strong>. Vous pouvez également signaler un problème de manière anonyme. Pour l’instant, nous ne prenons pas en charge les courriels chiffrés avec clé PGP.</p>
+            <h3>Votre rapport de vulnérabilité :</h3>
+            <ul>
+                <li>doit être rédigé en anglais ou en français;</li>
+                <li>doit décrire la vulnérabilité, l’endroit où elle a été repérée et l’incidence potentielle de son exploitation;</li>
+                <li>doit offrir une description détaillée des étapes permettant de reproduire la vulnérabilité (des scripts de démonstration ou des captures d’écran sont utiles). Ces preuves doivent être bénignes et non destructives, afin que nous puissions acheminer votre rapport rapidement et avec précision;</li>
+                <li>doit comporter seulement des renseignements sur des vulnérabilités exploitables;</li>
+                <li>ne doit pas comporter de vulnérabilités non exploitables ou des signalements de services qui ne sont pas entièrement conformes aux « meilleures pratiques » (p. ex., des en-têtes de sécurité manquants ou un volume élevé de rapports de mauvaise qualité pouvant provenir d’un outil de diagnostic automatisé);</li>
+                <li>ne doit communiquer aucune vulnérabilité ni aucun détail associé autre que par les moyens décrits dans cet avis;</li>
+                <li>ne donnera lieu à aucune rémunération pour vos recherches et tests réalisés en vue de divulguer des vulnérabilités.</li>
+            </ul>
+            <p>Vous pouvez toujours nous contacter par courriel à l’adresse <a href="mailto:security+securite@cds-snc.ca">security+securite@cds-snc.ca</a> si vous n’êtes pas sûr que la vulnérabilité soit authentique et exploitable ou bien s’il s’agit :</p>
+            <ul>
+                <li>d’une vulnérabilité non exploitable;</li>
+                <li>d’un élément quelconque qui peut être amélioré (p. ex., des en-têtes de sécurité manquants);</li>
+                <li>d’une faille dans la configuration du protocole TLS (p. ex., une faible prise en charge des suites de chiffrement ou la prise en charge de la version 1.0 du protocole TLS).</li>
+            </ul>
+            <h3>Lorsque vous examinez et signalez une vulnérabilité, vous <strong>ne devez pas :</strong></h3>
+            <ul>
+                <li>enfreindre la loi;</li>
+                <li>accéder à des quantités inutiles ou excessives de données;</li>
+                <li>modifier les données;</li>
+                <li>utiliser d’outils d’analyse invasifs ou destructeurs de haute intensité pour trouver des vulnérabilités;</li>
+                <li>tenter un déni de service (p. ex., saturer un service de canada.ca avec un volume élevé de demandes);</li>
+                <li>perturber les services ou les systèmes du gouvernement du Canada;</li>
+                <li>parler à quiconque de la vulnérabilité que vous avez trouvée jusqu’à ce que nous la divulguions;</li>
+                <li>faire de l’ingénierie sociale, de l’hameçonnage ou attaquer physiquement notre personnel ou causer des dommages à notre infrastructure;</li>
+                <li>demander de l’argent en échange d’une divulgation.</li>
+            </ul>
+
+            <!-- Code of Conduct -->
+            <h2>Code de conduite</h2>
+            <p>Veuillez consulter le Code de conduite des contributeurs pour obtenir de plus amples renseignements sur la façon de contribuer de manière ouverte et accueillante.</a> for more information on how to contribute in an open and welcoming way. </p>
+
+            <h3>Prime aux bogues</h3>
+            <p>Malheureusement, le SNC n’offre pas de programme de prime aux bogues rémunéré, mais fera des efforts pour être reconnaissant envers les personnes qui prennent le temps et l’effort de divulguer des vulnérabilités de manière responsable. Nous disposons en fait d’une page de remerciements pour les problèmes légitimes découverts par les chercheurs.</p>
+            
+            <!-- After you’ve reported the vulnerability -->
+            <h2>Après avoir signalé la vulnérabilité</h2>
+            <p>Si vous choisissez de partager vos coordonnées avec nous, nous nous engageons à communiquer avec vous aussi ouvertement et rapidement que possible.</p>
+            <ul>
+                <li>Nous accuserons réception de votre rapport dans un délai de trois jours ouvrables.</li>
+                <li>Dans la mesure du possible, nous vous confirmerons l’existence de la vulnérabilité et serons aussi transparents que possible sur les mesures que nous prenons au cours du processus de correction, ainsi que sur les problèmes ou les difficultés pouvant retarder la résolution.</li>
+                <li>Nous donnerons priorité à la correction de la vulnérabilité en examinant l’incidence, la gravité et la complexité de l’exploitation. L’acheminement et le traitement des rapports de vulnérabilité peuvent prendre un certain temps. Nous vous renseignerons avec plaisir sur l’état de votre demande, mais seulement une fois tous les 14 jours. Nos équipes pourront ainsi se concentrer sur les mesures correctives.</li>
+                <li>Nous ferons de notre mieux pour maintenir un dialogue ouvert avec vous afin de discuter des problèmes. Nous tâcherons également de déterminer avec vous de la pertinence de divulguer la faille et, le cas échéant, de la façon de le faire.</li>
+                <li>Nous traiterons votre rapport conformément à la <em>Loi sur l’accès à l’information</em> et à la <em>Loi sur la protection des renseignements personnels</em>.</li>
+                <li>Nous vous informerons lorsque la vulnérabilité signalée est corrigée. Vous pourriez aussi être invité à confirmer que la mesure corrige adéquatement la vulnérabilité.</li>
+            </ul>
+        </div>
+    </div>
+</section>

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -216,6 +216,10 @@ our-values-link:
   other: "/our-values/"
 roadmap-link:
   other: "/roadmap-2025/"
+security-notice-link:
+  other: /legal/security-notice
+security-notice:
+  other: "Security Notice"  
 beginning-the-conversation-link:
   other: "/beginning-the-conversation/"
 top-of-page:

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -190,6 +190,10 @@ rss-feed-url:
   other: "/blogue/index.xml"
 skip-to-content:
   other: "Passer au contenu principal"
+security-notice-link:
+  other: "/transparence/avis-de-securite"
+security-notice:
+  other: "Avis de sécurité"    
 terms-and-conditions:
   other: "Modalités"
 resources:

--- a/layouts/partials/footer-links.html
+++ b/layouts/partials/footer-links.html
@@ -1,5 +1,6 @@
 <ul>
   <li><a href="{{ i18n "terms-link" }}">{{ i18n "terms-and-conditions" }}</a></li>
   <li><a href="{{ i18n "privacy-link" }}">{{ i18n "privacy" }}</a></li>
+  <li><a href="{{ i18n "security-notice-link"}}">{{ i18n "security-notice" }}</a></li>
   <li><a href="{{ i18n "canada-ca-link" }}">{{ i18n "canada-ca" }}</a></li>
 </ul>


### PR DESCRIPTION
# Summary | Résumé

Added security notice documentation for both EN and FR.

There might be trouble viewing the deployment link in FR, so here are the screenshots:
![Screen Shot 2022-01-13 at 11 12 39 AM](https://user-images.githubusercontent.com/33768337/149367047-a475d41c-351c-417d-80c5-a56b12b104f0.png)
![Screen Shot 2022-01-13 at 11 12 48 AM](https://user-images.githubusercontent.com/33768337/149367057-833c5cc2-7236-417b-aafc-53fc43078597.png)
![Screen Shot 2022-01-13 at 11 13 09 AM](https://user-images.githubusercontent.com/33768337/149367100-4fcaddbd-5005-4c46-91ab-3690dc7a605e.png)
![Screen Shot 2022-01-13 at 11 13 24 AM](https://user-images.githubusercontent.com/33768337/149367109-4eee95e7-cc6d-4a0a-a577-b10d77b79253.png)
![Screen Shot 2022-01-13 at 11 13 37 AM](https://user-images.githubusercontent.com/33768337/149367118-f52bc234-f7de-4e3f-9ea3-966d612edf79.png)
![Screen Shot 2022-01-13 at 11 13 46 AM](https://user-images.githubusercontent.com/33768337/149367134-2b2382f1-a986-40de-b558-1965a10a0ea5.png)

