### PR TITLE
fixed h3 accessibility issue

### DIFF
--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -1509,6 +1509,16 @@ article.post {
 // PRODUCT SUITE
 //
 ////////////////////////////////////////////////////
+.card-title {
+  div {
+    padding: 2rem 0 2rem 0;
+  }
+  h2 {
+    font-weight: 400;
+    font-size: 3.75rem;
+  }
+
+}
 
 .product-suite {
   ul {

--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -1540,5 +1540,9 @@ article.post {
       right: 0;
     }
   }
+  .guides-title {
+    font-weight: 400;
+    font-size: 3.75rem;
+  }
   // padding: 10px 10px 20px 10px;
 }

--- a/layouts/partials/product-suite-items.html
+++ b/layouts/partials/product-suite-items.html
@@ -1,9 +1,12 @@
 <section class="product-resources-cards" style="position: relative; border-bottom: 3px solid #066169;">
   <div class="row">
-      <div class="col-sm-10 col-sm-offset-1 col-xs-12" >
-          <h3 class='{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
-              {{ .Params.title }}
-            </h3>
+      <div class="col-sm-10 col-sm-offset-1 col-xs-12 card-title" >
+        <div>
+          <h2 class='{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
+            {{ .Params.title }}
+          </h2>
+        </div>
+
       </div>
       <div class="col-sm-10 col-sm-offset-1 col-xs-12">
         <div >

--- a/layouts/partials/resources-items.html
+++ b/layouts/partials/resources-items.html
@@ -1,8 +1,8 @@
 <section class="product-resources-cards" style="position: relative; border-bottom: 3px solid #004986;">
     <div class="row">
-        <div class="col-sm-10 col-sm-offset-1 col-xs-12" >
-          <div style="padding: 2rem 0 2rem 0;">
-            <h2 class='{{ if eq (string (.Site.Language)) "fr" }}fr{{end}} guides-title'>
+        <div class="col-sm-10 col-sm-offset-1 col-xs-12 card-title" >
+          <div>
+            <h2 class='{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
               {{ .Params.title }}
             </h2>
           </div>

--- a/layouts/partials/resources-items.html
+++ b/layouts/partials/resources-items.html
@@ -1,9 +1,12 @@
 <section class="product-resources-cards" style="position: relative; border-bottom: 3px solid #004986;">
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-xs-12" >
-            <h3 class='{{ if eq (string (.Site.Language)) "fr" }}fr{{end}}'>
-                {{ .Params.title }}
-              </h3>
+          <div style="padding: 2rem 0 2rem 0;">
+            <h2 class='{{ if eq (string (.Site.Language)) "fr" }}fr{{end}} guides-title'>
+              {{ .Params.title }}
+            </h2>
+          </div>
+
         </div>
         <div class="col-sm-10 col-sm-offset-1 col-xs-12" >
             <p>{{ .Params.description }}</p>


### PR DESCRIPTION
# Summary | Résumé

Our accessibility tracker was giving us an issue for the Guides page since our card titles were h3, there was no h2 on the page which was causing the issue.