### PR TITLE
adding form to Security Notice - EN

### DIFF
--- a/content/en/legal/security-notice.html
+++ b/content/en/legal/security-notice.html
@@ -18,18 +18,15 @@ layout: page
             <!-- How to report a vulnerability -->
             <h2>How to report a vulnerability</h2>
             <p>CDS is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, we would like to know so we can fix it.</p>
-            <p><strong>You can report a vulnerability by sending an email to <a href="mailto:security+securite@cds-snc.ca">security+securite@cds-snc.ca</a></strong>. You can submit reports anonymously. We do not support PGP-encrypted emails at this time.</p>
+            <p><strong><a href="https://forms-formulaires.alpha.canada.ca/id/105">Report a vulnerability</a></strong></p> 
             <h3>In your report:</h3>
             <ul>
-                <li>Write in English or French.</li>
-                <li>Describe the vulnerability, where it was discovered, and the potential impact of exploitation.</li>
-                <li>Offer a detailed description of the steps to reproduce the vulnerability (proof of concept scripts or screenshots are helpful). These should be benign, non-destructive, proofs of concept so we can triage your report quickly and accurately.</li>
-                <li>Only submit reports about exploitable vulnerability</li>
-                <li>Do not submit reports detailing non-exploitable vulnerabilities, or reports indicating that the services do not fully align with “best practice”. For example, missing security headers, or a high volume of low-quality reports (for example, from an automated scanner).</li>
+                <li>You can remain anonymous.</li>
+                <li>Only submit reports about exploitable vulnerability. Do not submit reports detailing non-exploitable vulnerabilities, or reports indicating that the services do not fully align with “best practice”. For example, missing security headers, or a high volume of low-quality reports (for example, from an automated scanner).</li>
                 <li>Do not communicate any vulnerabilities or associated details other than by means described in this notice.</li>
                 <li>Do not expect or demand financial compensation for your research and testing to disclose vulnerabilities.</li>
             </ul>
-            <p>You can still reach out via email at <a href="mailto:security+securite@cds-snc.ca">security+securite@cds-snc.ca</a> if you are not sure if the vulnerability is genuine and exploitable, or you have found:</p>
+            <p>You can reach out via email at <a href="mailto:security+securite@cds-snc.ca">security+securite@cds-snc.ca</a> if you are not sure if the vulnerability is genuine and exploitable, or you have found:</p>
             <ul>
                 <li>A non-exploitable vulnerability.</li>
                 <li>Something you think could be improved - for example, missing security headers.</li>


### PR DESCRIPTION
- removed the email option to report a vulnerability, and replaced with a form. 
- took away some redundant bullets that are now captured in form.
- added "anonymous" point to bulleted list
- since first instance of email was replaced with form, removed "still" from second mention of it

# Summary | Résumé

> 1-3 sentence description of the changed you're proposing, including a link to
> a GitHub Issue # or Trello card if applicable.

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
