### PR TITLE
fixed spacing issue

### DIFF
--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -1,7 +1,7 @@
 not-found:
   other: "Oups, désolé!"
 all-newsletter-link:
-  other: "Lire l'infolettre"
+  other: "Lire l’infolettre"
 all-newsletter-past:
   other: "https://us15.campaign-archive.com/home/?u=729a207773f7324e217a1d945&id=5fe89f4d28"
 about-this-site:

--- a/layouts/partials/mailing-list.html
+++ b/layouts/partials/mailing-list.html
@@ -39,10 +39,15 @@
               </div>
             </div>
             <div class="row">
-              <div class="mce-privacy col-xs-12">
-                <a href={{ i18n "all-newsletter-past" }}>{{ i18n "all-newsletter-link" }}</a>
-                <a href="#privacy-notice-modal" aria-controls="privacy-notice-modal"
+              <div class="mce-privacy">
+                <div class="col-xs-6">
+                  <a href={{ i18n "all-newsletter-past" }}>{{ i18n "all-newsletter-link" }}</a>
+                </div>
+                <div class="col-xs-6">
+                  <a href="#privacy-notice-modal" aria-controls="privacy-notice-modal"
                   class="overlay-lnk light-link wb-lbx" aria-label="Privacy Statement Link">{{ i18n "view-privacy-notice" }}</a>
+                </div>
+
               </div>
             </div>
           </form>

--- a/layouts/partials/mailing-list.html
+++ b/layouts/partials/mailing-list.html
@@ -40,7 +40,7 @@
             </div>
             <div class="row">
               <div class="mce-privacy">
-                <div class="col-xs-6">
+                <div class="col-xs-6" style="padding-left: 0;">
                   <a href={{ i18n "all-newsletter-past" }}>{{ i18n "all-newsletter-link" }}</a>
                 </div>
                 <div class="col-xs-6">


### PR DESCRIPTION
# Summary | Résumé

French newsletter banner fix:

Fixed issue causing part of the privacy notice to go underneath "Read Newsletter"

Fixed apostrophe issue.
<img width="643" alt="Screen Shot 2022-03-15 at 2 35 53 PM" src="https://user-images.githubusercontent.com/33768337/158448163-025b18bb-2247-4eb1-8edc-8c2b4c7656e1.png">


