### PR TITLE
fix: preview teardown

### DIFF
--- a/.github/workflows/remove-staging.yaml
+++ b/.github/workflows/remove-staging.yaml
@@ -31,9 +31,12 @@ jobs:
 
       - name: Delete lambda function
         run: |
-          aws lambda wait function-active --function-name $FUNCTION_NAME-$PR_NUMBER-${{ matrix.lang }}
+          for run in {1..6}; do 
+            aws lambda wait function-exists --function-name $FUNCTION_NAME-$PR_NUMBER-${{ matrix.lang }}
+          done
           aws lambda delete-function-url-config --function-name $FUNCTION_NAME-$PR_NUMBER-${{ matrix.lang }}
           aws lambda delete-function --function-name $FUNCTION_NAME-$PR_NUMBER-${{ matrix.lang }}
+          aws logs delete-log-group --log-group-name /aws/lambda/$FUNCTION_NAME-$PR_NUMBER-${{ matrix.lang }}
 
   delete-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds some better logic to tear down the preview environment. The problem happened when PRs opened and closed too quickly and functions did not yet exist. This changes the check to `function-exists` and will check for 120 seconds before timing out.