### PR TITLE
A11y fix nav tab dropdown

### DIFF
--- a/assets/sass/cds/_nav.scss
+++ b/assets/sass/cds/_nav.scss
@@ -168,14 +168,19 @@
       @include tablet {
         margin-right: 2rem;
       }
-      
+
+      transition: outline 0.3s ease-in-out;
       background-color: inherit;
       border: none;
+      border-top: 2px solid transparent;
       outline: none;
       color: $white;
       font-size: 2rem;
       @include mobile_only {
         display: none;
+      }
+      &:focus {
+        border-top-color: $primary-color;
       }
     }
     .dropdown-content {
@@ -225,7 +230,7 @@
       }
     }
   }
-  .dropdown:hover .dropdown-content {display: block;}
+  .dropdown:hover .dropdown-content, .dropdown:focus-within .dropdown-content {display: block;}
 }
 
 .top-nav {

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -20,9 +20,9 @@
           <div class="mobile-lang">{{ partial "langSwitch.html" . }}</div>
           <div class="menu-items">
             <div class="dropdown">
-              <button>{{ i18n "how-we-can-help"}} <i class="fa fa-caret-down"></i></button>
+              <button id="how-can-we-help-button" aria-controls="how-we-can-help-dropdown">{{ i18n "how-we-can-help"}} <i class="fa fa-caret-down"></i></button>
                 
-                <div class="dropdown-content">
+                <div class="dropdown-content" id="how-we-can-help-dropdown" aria-labelledby="how-can-we-help-button">
                   {{ range $dropdown := .Site.Menus.dropdown}}
                   <a href="{{ .URL | absLangURL }}" id="{{.Identifier}}-nav-tag">{{ .Name }}</a>
                   {{ end }}


### PR DESCRIPTION
## Summary 

The current navigation menu can not be accessed by keyboard. 

If you try to tab through the navigation menu in the desktop viewport the focus indicator goes from the CDS Logo to no focus indicator to "Careers". It is impossible by keyboard to access the "How can we help" dropdown menu. 

### Current

https://user-images.githubusercontent.com/9325038/169877370-902ce4af-be75-45ad-a083-05e2433678f4.mov

The video above shows how I am trying to tab to the "how can we help" section but I can't gain focus to activate the dropdown menu. 

This PR will:

* Leverage `focus-within` CSS property to show the dropdown menu when the dropdown title ("How can we help") is in focus
* To illustrate the menu is in focus a `$primary-color` line is drawn above the menu item
* Make the sub menu items accessible by keyboard 
* Add


### Proposed 

https://user-images.githubusercontent.com/9325038/169878644-1eb2a38c-56e8-4da3-a09d-58f6c7a8b684.mov

The video above shows how you can now tab through the "how can we help" dropdown content. 

The yellow line at the top of the menu button isn't the sexiest but I needed to show users they were tabbed onto the object. This is because the button receives focus and then the dropdown menu is displayed. 


## Test instructions

* Grab the branch 'a11y-fix-tab-dropdown` from the fork I made
* Run `hugo serve -D`
* Visit either French or English dev servers
* Start tabbing through the page using the tab key 
* When you tab on the "How can we help" button you will notice a yellow border at the top and the dropdown menu appear
* You should be able to tab through the rest of the "How can we help" menu items 
* Mobile mode is not impacted by these changes 
* Using your mouse on desktop is also not impacted by these changes 

## Notes

* A lot of this was inspired by https://moderncss.dev/css-only-accessible-dropdown-navigation-menu/
* The secret sauce to this working is `focus-within` pseudo class and of course this doesn't work with IE11 https://caniuse.com/?search=focus-within
