### PR TITLE
feat: security notice in-scope domains

### DIFF
--- a/content/en/legal/security-notice.html
+++ b/content/en/legal/security-notice.html
@@ -10,14 +10,28 @@ layout: page
 <section class="page-legal page--outer-container-padding">
     <div class="row">
         <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12">
+            <p>This is the security notice for all Canadian Digital Service (CDS) repositories. If you're here because you found a vulnerability on a domain not on the list below, please contact the <a href="https://cyber.gc.ca/en/incident-management">Canadian Centre for Cyber Security</a>.</p>
             <p>
-                This is the security notice for all Canadian Digital Service (CDS) repositories. 
                 The notice explains how vulnerabilities should be reported to CDS. 
                 At CDS there is a cyber security team, as well as security-conscious people within the organization, that assess and triage all reported vulnerabilities.
             </p>
+            <h3>The following domains are in-scope of this notice:</h3>
+            <ul>
+              <li>*.digital.canada.ca</li>
+              <li>*.numerique.canada.ca</li>
+              <li>*.notification.canada.ca</li>
+              <li>*.cdssandbox.xyz</li>
+              <li>articles.alpha.canada.ca</li>
+              <li>covid-alert-portal.alpha.canada.ca</li>
+              <li>covid-notification.alpha.canada.ca</li>
+              <li>forms-formulaires.alpha.canada.ca</li>
+              <li>list-manager.alpha.canada.ca</li>
+              <li>scan-files.alpha.canada.ca</li>
+              <li>scan-websites.alpha.canada.ca</li>
+            </ul>
             <!-- How to report a vulnerability -->
             <h2>How to report a vulnerability</h2>
-            <p>CDS is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, we would like to know so we can fix it.</p>            
+            <p>CDS is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, we would like to know so we can fix it.</p>
             <h3>In your report:</h3>
             <ul>
                 <li>You can remain anonymous.</li>

--- a/content/fr/legal/security-notice.html
+++ b/content/fr/legal/security-notice.html
@@ -10,11 +10,25 @@ url: /transparence/avis-de-securite
 <section class="page-legal page--outer-container-padding">
     <div class="row">
         <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12">
+            <p> Voici l’avis de sécurité pour tous les référentiels de données du Service numérique canadien (SNC). Si vous êtes ici car vous avez constaté une vulnérabilité pour un domaine n’apparaissant pas dans la liste ci-dessous, veuillez contacter le <a href="https://cyber.gc.ca/fr/cyberincidents">Centre canadien pour la cybersécurité</a>.</p>
             <p>
-                Voici l’avis de sécurité pour tous les référentiels de données du Service numérique canadien (SNC). 
                 Cet avis explique la procédure à suivre pour signaler toute vulnérabilité au SNC. 
                 Le SNC est doté d’une équipe de cybersécurité et d’employés soucieux de la sécurité, qui évaluent et traitent tout incident signalé.
             </p>
+            <h3>Le présent avis concerne les domaines suivants:</h3>
+            <ul>
+              <li>*.digital.canada.ca</li>
+              <li>*.numerique.canada.ca</li>
+              <li>*.notification.canada.ca</li>
+              <li>*.cdssandbox.xyz</li>
+              <li>articles.alpha.canada.ca</li>
+              <li>covid-alert-portal.alpha.canada.ca</li>
+              <li>covid-notification.alpha.canada.ca</li>
+              <li>forms-formulaires.alpha.canada.ca</li>
+              <li>list-manager.alpha.canada.ca</li>
+              <li>scan-files.alpha.canada.ca</li>
+              <li>scan-websites.alpha.canada.ca</li>
+            </ul>
             <!-- How to report a vulnerability -->
             <h2>Comment signaler une vulnérabilité </h2>
             <p>Le SNC est un défenseur de la divulgation responsable des vulnérabilités. Si vous avez repéré une vulnérabilité, nous aimerions le savoir afin de la corriger.</p>


### PR DESCRIPTION
We've received 2 reports so far unrelated to CDS so we're updating our security notice to reduce this from happening.

- Updated the security notice to include a list of in-scope domains
- Referring users to the Canadian Centre for Cyber Security (CCCS) if they're in search of a way to submit a vulnerability unrelated to CDS.

![image](https://user-images.githubusercontent.com/85885638/172909537-35cfa181-88c6-48f4-b4e7-d11cf5363fa9.png)
