### PR TITLE
refactor: discuss rules of engagement before reporting instructions

### DIFF
--- a/content/en/legal/security-notice.html
+++ b/content/en/legal/security-notice.html
@@ -29,25 +29,7 @@ layout: page
               <li>scan-files.alpha.canada.ca</li>
               <li>scan-websites.alpha.canada.ca</li>
             </ul>
-            <!-- How to report a vulnerability -->
-            <h2>How to report a vulnerability</h2>
-            <p>CDS is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, we would like to know so we can fix it.</p>
-            <h3>In your report:</h3>
-            <ul>
-                <li>You can remain anonymous.</li>
-                <li>Only submit reports about exploitable vulnerability. Do not submit reports detailing non-exploitable vulnerabilities, or reports indicating that the services do not fully align with “best practice”. For example, missing security headers, or a high volume of low-quality reports (for example, from an automated scanner).</li>
-                <li>Do not communicate any vulnerabilities or associated details other than by means described in this notice.</li>
-                <li>Do not expect or demand financial compensation for your research and testing to disclose vulnerabilities.</li>
-            </ul>
-            <div class="button-arrow">
-                <p><strong><a href="https://forms-formulaires.alpha.canada.ca/id/105">Report a vulnerability<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path d="M8 9H0V7H8V0L16 8L8 16V9Z"/></svg></a></strong></p> 
-            </div>
-            <p style="padding-top: 3rem;">You can reach out via email at <a href="mailto:security+securite@cds-snc.ca">security+securite@cds-snc.ca</a> if you are not sure if the vulnerability is genuine and exploitable, or you have found:</p>
-            <ul>
-                <li>A non-exploitable vulnerability.</li>
-                <li>Something you think could be improved - for example, missing security headers.</li>
-                <li>TLS configuration weaknesses - for example weak cipher suite support or the presence of TLS1.0 support.</li>
-            </ul>
+
             <h3>When you are investigating and reporting the vulnerability you <strong>must not:</strong></h3>
             <ul>
                 <li>Break the law.</li>
@@ -67,6 +49,26 @@ layout: page
 
             <h3>Bug bounty</h3>
             <p>Unfortunately, CDS doesn't offer a paid bug bounty program. CDS will make efforts to show appreciation to people who take the time and effort to disclose vulnerabilities responsibly. We do have an acknowledgements page for legitimate issues found by researchers.</p>
+
+            <!-- How to report a vulnerability -->
+            <h2>How to report a vulnerability</h2>
+            <p>CDS is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, we would like to know so we can fix it.</p>
+            <h3>In your report:</h3>
+            <ul>
+                <li>You can remain anonymous.</li>
+                <li>Only submit reports about exploitable vulnerability. Do not submit reports detailing non-exploitable vulnerabilities, or reports indicating that the services do not fully align with “best practice”. For example, missing security headers, or a high volume of low-quality reports (for example, from an automated scanner).</li>
+                <li>Do not communicate any vulnerabilities or associated details other than by means described in this notice.</li>
+                <li>Do not expect or demand financial compensation for your research and testing to disclose vulnerabilities.</li>
+            </ul>
+            <div class="button-arrow">
+                <p><strong><a href="https://forms-formulaires.alpha.canada.ca/id/105">Report a vulnerability<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path d="M8 9H0V7H8V0L16 8L8 16V9Z"/></svg></a></strong></p> 
+            </div>
+            <p style="padding-top: 3rem;">You can reach out via email at <a href="mailto:security+securite@cds-snc.ca">security+securite@cds-snc.ca</a> if you are not sure if the vulnerability is genuine and exploitable, or you have found:</p>
+            <ul>
+                <li>A non-exploitable vulnerability.</li>
+                <li>Something you think could be improved - for example, missing security headers.</li>
+                <li>TLS configuration weaknesses - for example weak cipher suite support or the presence of TLS1.0 support.</li>
+            </ul>
             
             <!-- After you’ve reported the vulnerability -->
             <h2>After you’ve reported the vulnerability</h2>

--- a/content/fr/legal/security-notice.html
+++ b/content/fr/legal/security-notice.html
@@ -29,25 +29,7 @@ url: /transparence/avis-de-securite
               <li>scan-files.alpha.canada.ca</li>
               <li>scan-websites.alpha.canada.ca</li>
             </ul>
-            <!-- How to report a vulnerability -->
-            <h2>Comment signaler une vulnérabilité </h2>
-            <p>Le SNC est un défenseur de la divulgation responsable des vulnérabilités. Si vous avez repéré une vulnérabilité, nous aimerions le savoir afin de la corriger.</p>
-            <h3>Votre rapport de vulnérabilité :</h3>
-            <ul>
-                <li>vous pouvez signaler un problème de manière anonyme;</li>
-                <li>doit comporter seulement des renseignements sur des vulnérabilités exploitables. Ne doit pas comporter de vulnérabilités non exploitables ou des signalements de services qui ne sont pas entièrement conformes aux « meilleures pratiques » (p. ex., des en-têtes de sécurité manquants ou un volume élevé de rapports de mauvaise qualité pouvant provenir d’un outil de diagnostic automatisé);</li>
-                <li>ne doit communiquer aucune vulnérabilité ni aucun détail associé autre que par les moyens décrits dans cet avis;</li>
-                <li>ne donnera lieu à aucune rémunération pour vos recherches et tests réalisés en vue de divulguer des vulnérabilités.</li>
-            </ul>
-            <div class="button-arrow">
-                <p><strong><a href="https://forms-formulaires.alpha.canada.ca/fr/id/105">Signaler une vulnérabilité<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path d="M8 9H0V7H8V0L16 8L8 16V9Z"/></svg></a></strong></p>
-            </div>
-            <p style="padding-top: 3rem;">Vous pouvez nous contacter par courriel à l’adresse <a href="mailto:security+securite@cds-snc.ca">security+securite@cds-snc.ca</a> si vous n’êtes pas sûr que la vulnérabilité soit authentique et exploitable ou bien s’il s’agit :</p>
-            <ul>
-                <li>d’une vulnérabilité non exploitable;</li>
-                <li>d’un élément quelconque qui peut être amélioré (p. ex., des en-têtes de sécurité manquants);</li>
-                <li>d’une faille dans la configuration du protocole TLS (p. ex., une faible prise en charge des suites de chiffrement ou la prise en charge de la version 1.0 du protocole TLS).</li>
-            </ul>
+
             <h3>Lorsque vous examinez et signalez une vulnérabilité, vous <strong>ne devez pas :</strong></h3>
             <ul>
                 <li>enfreindre la loi;</li>
@@ -68,6 +50,25 @@ url: /transparence/avis-de-securite
             <h3>Prime aux bogues</h3>
             <p>Malheureusement, le SNC n’offre pas de programme de prime aux bogues rémunéré, mais fera des efforts pour être reconnaissant envers les personnes qui prennent le temps et l’effort de divulguer des vulnérabilités de manière responsable. Nous disposons en fait d’une page de remerciements pour les problèmes légitimes découverts par les chercheurs.</p>
             
+            <!-- How to report a vulnerability -->
+            <h2>Comment signaler une vulnérabilité </h2>
+            <p>Le SNC est un défenseur de la divulgation responsable des vulnérabilités. Si vous avez repéré une vulnérabilité, nous aimerions le savoir afin de la corriger.</p>
+            <h3>Votre rapport de vulnérabilité :</h3>
+            <ul>
+                <li>vous pouvez signaler un problème de manière anonyme;</li>
+                <li>doit comporter seulement des renseignements sur des vulnérabilités exploitables. Ne doit pas comporter de vulnérabilités non exploitables ou des signalements de services qui ne sont pas entièrement conformes aux « meilleures pratiques » (p. ex., des en-têtes de sécurité manquants ou un volume élevé de rapports de mauvaise qualité pouvant provenir d’un outil de diagnostic automatisé);</li>
+                <li>ne doit communiquer aucune vulnérabilité ni aucun détail associé autre que par les moyens décrits dans cet avis;</li>
+                <li>ne donnera lieu à aucune rémunération pour vos recherches et tests réalisés en vue de divulguer des vulnérabilités.</li>
+            </ul>
+            <div class="button-arrow">
+                <p><strong><a href="https://forms-formulaires.alpha.canada.ca/fr/id/105">Signaler une vulnérabilité<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path d="M8 9H0V7H8V0L16 8L8 16V9Z"/></svg></a></strong></p>
+            </div>
+            <p style="padding-top: 3rem;">Vous pouvez nous contacter par courriel à l’adresse <a href="mailto:security+securite@cds-snc.ca">security+securite@cds-snc.ca</a> si vous n’êtes pas sûr que la vulnérabilité soit authentique et exploitable ou bien s’il s’agit :</p>
+            <ul>
+                <li>d’une vulnérabilité non exploitable;</li>
+                <li>d’un élément quelconque qui peut être amélioré (p. ex., des en-têtes de sécurité manquants);</li>
+                <li>d’une faille dans la configuration du protocole TLS (p. ex., une faible prise en charge des suites de chiffrement ou la prise en charge de la version 1.0 du protocole TLS).</li>
+            </ul>
             <!-- After you’ve reported the vulnerability -->
             <h2>Après avoir signalé la vulnérabilité</h2>
             <p>Si vous choisissez de partager vos coordonnées avec nous, nous nous engageons à communiquer avec vous aussi ouvertement et rapidement que possible.</p>


### PR DESCRIPTION
We'd like users to be aware of the rules of engagement before we go into how vulnerabilities can be reported.