### PR TITLE
changed guides contact us email address

### DIFF
--- a/layouts/section/guides.html
+++ b/layouts/section/guides.html
@@ -28,7 +28,7 @@
         <p>{{ i18n "guides-help" }}</p>
       </div>
       <div>
-        <a href="mailto:learning-resources@cds-snc.ca" id="guides-contact-us-id" aria-label="{{ i18n "guides-contact-us" }}">
+        <a href="mailto:cds-snc@tbs-sct.gc.ca" id="guides-contact-us-id" aria-label="{{ i18n "guides-contact-us" }}">
           {{ i18n "coaching-and-advice-contact-us" }}
         </a>
       </div>


### PR DESCRIPTION
# Summary | Résumé

Changed the email address on the Guides page to cds-snc@tbs-sct.gc.ca since the previous one kept bouncing.