### PR TITLE
Removing automated lines from job posting template

### DIFF
--- a/layouts/section/job-posting.en.html
+++ b/layouts/section/job-posting.en.html
@@ -18,8 +18,7 @@
         </div>
         <div>
           <h2 class="h2-font-weight">Work anywhere in Canada</h2>
-          <p>CDS is a fully distributed team. This job can be performed from anywhere in Canada. In the future,
-            occasional travel to Ottawa may be required.</p>
+          <p>CDS is a fully distributed team. This job can be performed from anywhere in Canada.</p>
           <p>
             <a href="https://www.canada.ca/en/public-service-commission/services/assessment-accommodation-page.html"
               rel="external">Assessment

--- a/layouts/section/job-posting.fr.html
+++ b/layouts/section/job-posting.fr.html
@@ -18,8 +18,7 @@
           </div>
           <div>
             <h2 class="h2-font-weight">Travaillez de n’importe où au Canada</h2>
-            <p>Le SNC est une équipe entièrement décentralisée. Ce travail peut être effectué de n'importe où au Canada.
-              À l'avenir, des déplacements occasionnels à Ottawa pourraient être nécessaires.</p>
+            <p>Le SNC est une équipe entièrement décentralisée. Ce travail peut être effectué de n'importe où au Canada.</p>
             <p><a href="https://www.canada.ca/en/public-service-commission/services/assessment-accommodation-page.html"
                 rel="externe">Mesures
                 d’adaptation en matière d’évaluation<img src="/img/icons/assessment-accomodation.svg"

--- a/layouts/section/job-posting.fr.html
+++ b/layouts/section/job-posting.fr.html
@@ -26,7 +26,6 @@
 
             <p>Par mesure de précaution, toutes les entrevues dans un avenir proche seront menées par vidéo ou
               téléconférence.</p>
-
           </div>
 
         </div>


### PR DESCRIPTION
Removing the line "in the future, occasional travel to Ottawa may be required" (in English and French) to job posting template.
