### PR TITLE
Fixing typo on Coaching and advice English page

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -393,7 +393,7 @@ product-suite-tag:
 guides-tag:
   other: "guides-tag"
 coaching-and-advice-intro:
-  other: "As federal public servants ourselves, we know how complicated digital service delivery in government can be. Our team of digital practioners is here to help."        
+  other: "As federal public servants ourselves, we know how complicated digital service delivery in government can be. Our team of digital practitioners is here to help."        
 coaching-and-advice-checklist-title:
   other: "We can help empower your team to:"
 coaching-and-advice-checklist-item-one:


### PR DESCRIPTION
There's a small typo in the first sentence on the EN coaching and advice page. It currently reads: 
As federal public servants ourselves, we know how complicated digital service delivery in government can be. Our team of digital practioners is here to help. (changing it to should say "practitioners" instead). 