### PR TITLE
Fix small typo on Coaching / advice page

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -426,7 +426,7 @@ coaching-and-advice-our-advice-title:
 coaching-and-advice-our-advice-c1:
   other: " Conducting user research"
 coaching-and-advice-our-advice-c2:
-  other: " Agile sotware development and ways of working" 
+  other: " Agile software development and ways of working" 
 coaching-and-advice-our-advice-c3:
   other: " Team compositions for delivery work"
 coaching-and-advice-our-advice-c4:


### PR DESCRIPTION
Change "sotware" to "software" under "Some of the things we can advise on" section