### PR TITLE
Fixed small typo on Coaching and advice (English) page

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -418,7 +418,7 @@ coaching-and-advice-how-we-can-help-c1:
 coaching-and-advice-how-we-can-help-c2:
   other: " Facilitate exercises and workshops to help your team identify and solve problems"
 coaching-and-advice-how-we-can-help-c3:
-  other: " Connect you with peers who have tackled similiar problems" 
+  other: " Connect you with peers who have tackled similar problems" 
 coaching-and-advice-our-advice-title:
   other: "Some of the things we can advise on:"
 coaching-and-advice-our-advice-c1:


### PR DESCRIPTION
Changing "similiar" to "similar" under "How we can help" section