### PR TITLE
Security notice typo

### DIFF
--- a/content/en/legal/security-notice.html
+++ b/content/en/legal/security-notice.html
@@ -24,6 +24,7 @@ layout: page
               <li>articles.alpha.canada.ca</li>
               <li>forms-formulaires.alpha.canada.ca</li>
               <li>list-manager.alpha.canada.ca</li>
+              <li>resources.alpha.canada.ca/</li>
               <li>scan-files.alpha.canada.ca</li>
               <li>scan-websites.alpha.canada.ca</li>
             </ul>

--- a/content/en/legal/security-notice.html
+++ b/content/en/legal/security-notice.html
@@ -24,7 +24,7 @@ layout: page
               <li>articles.alpha.canada.ca</li>
               <li>forms-formulaires.alpha.canada.ca</li>
               <li>list-manager.alpha.canada.ca</li>
-              <li>resources.alpha.canada.ca/</li>
+              <li>resources.alpha.canada.ca</li>
               <li>scan-files.alpha.canada.ca</li>
               <li>scan-websites.alpha.canada.ca</li>
             </ul>

--- a/content/fr/blog/posts/lancement-d’un-service-alpha.md
+++ b/content/fr/blog/posts/lancement-d’un-service-alpha.md
@@ -14,7 +14,7 @@ image: https://de2an9clyit2x.cloudfront.net/get_updates_c19_phone_fr_963f308dbc.
 image-alt: >-
   Une personne en train de s’abonner au service «Obtenir les nouvelles sur la
   COVID-19» sur son téléphone mobile.
-translationKey: launch-of-the-canadian-digital-service
+translationKey: get-updates-blog-2
 thumb: https://de2an9clyit2x.cloudfront.net/small_get_updates_c19_phone_fr_963f308dbc.jpg
 ---
 *Marcel Saulnier et Jennifer Hollington sont tous deux sous-ministres adjoints à Santé Canada. M. Saulnier a supervisé la conception et le lancement du service de notification par courriel « [Obtenir les nouvelles sur la COVID-19](https://www.canada.ca/covid19nouvelles) » dans le cadre de sa participation au groupe de travail sur la COVID-19. L’équipe des communications de Mme Hollington a repris le service alors que celui-ci s’inscrit dans la fonction de communication de Santé Canada.*

--- a/content/fr/legal/security-notice.html
+++ b/content/fr/legal/security-notice.html
@@ -24,6 +24,7 @@ url: /transparence/avis-de-securite
               <li>articles.alpha.canada.ca</li>
               <li>forms-formulaires.alpha.canada.ca</li>
               <li>list-manager.alpha.canada.ca</li>
+              <li>ressources.alpha.canada.ca/fr/</li>
               <li>scan-files.alpha.canada.ca</li>
               <li>scan-websites.alpha.canada.ca</li>
             </ul>

--- a/content/fr/legal/security-notice.html
+++ b/content/fr/legal/security-notice.html
@@ -24,7 +24,7 @@ url: /transparence/avis-de-securite
               <li>articles.alpha.canada.ca</li>
               <li>forms-formulaires.alpha.canada.ca</li>
               <li>list-manager.alpha.canada.ca</li>
-              <li>ressources.alpha.canada.ca/fr</li>
+              <li>ressources.alpha.canada.ca</li>
               <li>scan-files.alpha.canada.ca</li>
               <li>scan-websites.alpha.canada.ca</li>
             </ul>

--- a/content/fr/legal/security-notice.html
+++ b/content/fr/legal/security-notice.html
@@ -24,7 +24,7 @@ url: /transparence/avis-de-securite
               <li>articles.alpha.canada.ca</li>
               <li>forms-formulaires.alpha.canada.ca</li>
               <li>list-manager.alpha.canada.ca</li>
-              <li>ressources.alpha.canada.ca/fr/</li>
+              <li>ressources.alpha.canada.ca/fr</li>
               <li>scan-files.alpha.canada.ca</li>
               <li>scan-websites.alpha.canada.ca</li>
             </ul>


### PR DESCRIPTION
Adding extra "s" to Learning Resources link on Security Notice page