### PR TITLE
updated to buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim as build 
+FROM debian:buster-slim as build 
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install wget \


### PR DESCRIPTION
# Summary | Résumé

Updated Debian Image to `buster-slim` the previous `stretch-slim` is no archived