### PR TITLE
updated alias records

### DIFF
--- a/terragrunt/aws/cloudfront/route53.tf
+++ b/terragrunt/aws/cloudfront/route53.tf
@@ -1,13 +1,30 @@
-resource "aws_route53_record" "cds_website_A" {
-  for_each = aws_cloudfront_distribution.distribution
-  name     = each.key
-  zone_id  = each.value.hosted_zone_id
+resource "aws_route53_record" "cds_website_en_A" {
+  name     = local.name_en
+  zone_id  = local.hosted_zone_en
   type     = "A"
 
   alias {
-    name                   = each.value.domain_name
-    zone_id                = each.value.hosted_zone_id
+    name                   = aws_cloudfront_distribution.distribution[local.name_en].domain_name
+    zone_id                = aws_cloudfront_distribution.distribution[local.name_en].hosted_zone_id
     evaluate_target_health = false
   }
 }
 
+resource "aws_route53_record" "cds_website_fr_A" {
+  name     = local.name_fr
+  zone_id  = local.hosted_zone_fr
+  type     = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.distribution[local.name_fr].domain_name
+    zone_id                = aws_cloudfront_distribution.distribution[local.name_fr].hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+locals {
+    hosted_zone_en = var.hosted_zone_id_list[0]
+    hosted_zone_fr = var.hosted_zone_id_list[1]
+    name_en = var.website_domains[0]
+    name_fr = var.website_domains[1]
+}

--- a/terragrunt/aws/cloudfront/route53.tf
+++ b/terragrunt/aws/cloudfront/route53.tf
@@ -1,7 +1,7 @@
 resource "aws_route53_record" "cds_website_en_A" {
-  name     = local.name_en
-  zone_id  = local.hosted_zone_en
-  type     = "A"
+  name    = local.name_en
+  zone_id = local.hosted_zone_en
+  type    = "A"
 
   alias {
     name                   = aws_cloudfront_distribution.distribution[local.name_en].domain_name
@@ -11,9 +11,9 @@ resource "aws_route53_record" "cds_website_en_A" {
 }
 
 resource "aws_route53_record" "cds_website_fr_A" {
-  name     = local.name_fr
-  zone_id  = local.hosted_zone_fr
-  type     = "A"
+  name    = local.name_fr
+  zone_id = local.hosted_zone_fr
+  type    = "A"
 
   alias {
     name                   = aws_cloudfront_distribution.distribution[local.name_fr].domain_name
@@ -23,8 +23,8 @@ resource "aws_route53_record" "cds_website_fr_A" {
 }
 
 locals {
-    hosted_zone_en = var.hosted_zone_id_list[0]
-    hosted_zone_fr = var.hosted_zone_id_list[1]
-    name_en = var.website_domains[0]
-    name_fr = var.website_domains[1]
+  hosted_zone_en = var.hosted_zone_id_list[0]
+  hosted_zone_fr = var.hosted_zone_id_list[1]
+  name_en        = var.website_domains[0]
+  name_fr        = var.website_domains[1]
 }


### PR DESCRIPTION
# Summary | Résumé

Incorrect use of the hosted zone ID in the `"aws_route53_record" "cds_website_en_A"`