### PR TITLE
terragrunt/website-bucket-policy-update

### DIFF
--- a/terragrunt/aws/cloudfront/inputs.tf
+++ b/terragrunt/aws/cloudfront/inputs.tf
@@ -13,3 +13,8 @@ variable "hosted_zone_id_list" {
   description = "The hosted zone ID that holds our English and French DNS records"
   type        = list(string)
 }
+
+variable "s3_buckets" {
+  description = "EN and FR S3 Buckets"
+  type        = map(any)
+}

--- a/terragrunt/aws/cloudfront/s3.tf
+++ b/terragrunt/aws/cloudfront/s3.tf
@@ -3,3 +3,27 @@ module "log_bucket" {
   bucket_name       = "cds-website-waf-bucket-logs"
   billing_tag_value = var.billing_code
 }
+
+data "aws_iam_policy_document" "website_bucket_policy_doc" {
+  for_each = var.s3_buckets
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["${aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn}"]
+    }
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = [
+      "${each.value.s3_bucket_arn}/*"
+    ]
+  }
+
+}
+
+resource "aws_s3_bucket_policy" "website_bucket_policy" {
+  for_each = var.s3_buckets
+  bucket   = each.value.s3_bucket_id
+  policy   = data.aws_iam_policy_document.website_bucket_policy_doc[each.key].json
+}

--- a/terragrunt/env/production/cloudfront/terragrunt.hcl
+++ b/terragrunt/env/production/cloudfront/terragrunt.hcl
@@ -9,16 +9,17 @@ dependencies {
 dependency "s3" {
     config_path = "../s3"
     mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
-    mock_outputs_merge_strategy_with_state  = "shallow"
+    
     mock_outputs = {
         s3_bucket_regional_domain_name = []
+        s3_buckets = []
     }
 }
 
 dependency "hosted_zone" {
     config_path = "../hosted_zone"
     mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
-    mock_outputs_merge_strategy_with_state  = "shallow"
+    
     mock_outputs = {
         hosted_zone_id_en = ""
         hosted_zone_id_fr = ""
@@ -31,6 +32,7 @@ inputs = {
     hosted_zone_id_en = dependency.hosted_zone.outputs.hosted_zone_id_en
     hosted_zone_id_fr = dependency.hosted_zone.outputs.hosted_zone_id_fr
     hosted_zone_id_list = [dependency.hosted_zone.outputs.hosted_zone_id_en, dependency.hosted_zone.outputs.hosted_zone_id_fr]
+    s3_buckets = dependency.s3.outputs.s3_buckets
 }
 
 include {

--- a/terragrunt/env/production/cloudfront/terragrunt.hcl
+++ b/terragrunt/env/production/cloudfront/terragrunt.hcl
@@ -9,7 +9,7 @@ dependencies {
 dependency "s3" {
     config_path = "../s3"
     mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
-    
+    mock_outputs_merge_strategy_with_state  = "shallow"
     mock_outputs = {
         s3_bucket_regional_domain_name = []
         s3_buckets = []
@@ -19,7 +19,7 @@ dependency "s3" {
 dependency "hosted_zone" {
     config_path = "../hosted_zone"
     mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
-    
+    mock_outputs_merge_strategy_with_state  = "shallow"
     mock_outputs = {
         hosted_zone_id_en = ""
         hosted_zone_id_fr = ""


### PR DESCRIPTION
# Summary | Résumé

Added bucket policy to allow cloudfront to get content from the en and fr buckets